### PR TITLE
Added JedisProxy

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisProxy.java
+++ b/src/main/java/redis/clients/jedis/JedisProxy.java
@@ -1,0 +1,63 @@
+package redis.clients.jedis;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeoutException;
+
+public class JedisProxy implements InvocationHandler {
+
+    private final JedisPool jedisPool;
+
+    public JedisProxy(JedisPool pool) {
+	this.jedisPool = pool;
+    }
+    
+    public static JedisCommands newInstance(JedisPool pool) {
+	return (JedisCommands) Proxy.newProxyInstance(
+	    Jedis.class.getClassLoader(),
+	    Jedis.class.getInterfaces(),
+	    new JedisProxy(pool));
+    }
+
+
+    @Override
+    public Object invoke(Object proxy, Method m, Object[] args) throws Throwable {
+	Object result;
+	Jedis jedis = obtainJedis();
+	try {
+	    result = m.invoke(jedis, args);
+	} catch (InvocationTargetException e) {
+	    throw e.getTargetException();
+	} catch (Exception e) {
+	    throw new JedisException("Unexpected proxy invocation exception: " + e.getMessage(), e);
+	} finally {
+	    returnJedis(jedis);
+	}
+	return result;
+    }
+
+    private Jedis obtainJedis() {
+	Jedis jedis;
+	try {
+	    jedis = jedisPool.getResource();
+	} catch (TimeoutException e) {
+	    throw new JedisException("Unable to get Jedis resource before timeout.", e);
+	}
+	return jedis;
+    }
+
+    private void returnJedis(Jedis jedis) {
+	try {
+	    if (jedis.isConnected()) {
+		jedis.ping();
+		jedisPool.returnResource(jedis);
+	    } else {
+		jedisPool.returnBrokenResource(jedis);
+	    }
+	} catch (JedisException e) {
+	    jedisPool.returnBrokenResource(jedis);
+	}
+    }
+}

--- a/src/test/java/redis/clients/jedis/tests/JedisProxyTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisProxyTest.java
@@ -1,0 +1,40 @@
+package redis.clients.jedis.tests;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import redis.clients.jedis.JedisCommands;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisProxy;
+import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
+
+public class JedisProxyTest {
+
+    private static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
+
+    private static JedisPool JEDIS_POOL;
+    private JedisCommands proxiedJedis;
+
+    @BeforeClass
+    public static void setupPool() {
+	JedisPool thePool = new JedisPool(hnp.host, hnp.port);
+	thePool.init();
+	JEDIS_POOL = thePool;
+    }
+
+    @Before
+    public void setup() {
+	this.proxiedJedis = JedisProxy.newInstance(JEDIS_POOL);
+    }
+
+    @Test
+    public void aJedisProxyInstanceCanSetAndGetAStringValue() {
+	String testString = "testvalue";
+	String testKey = "testkey";
+	proxiedJedis.set(testKey, testString);
+	assertTrue(testString.equals(proxiedJedis.get(testKey)));
+    }
+}


### PR DESCRIPTION
I added a JedisProxy that uses Java reflection proxies to delegate all requests to a fresh Jedis instance from a JedisPool. Feel free to clean this up as appropriate.

Example usage is 

```
private final JedisCommands jedis;

@Autowired
public RedisCacheRepository(JedisPool pool) {
Validate.notNull(pool, "A valid pool must be provided");
this.jedis = JedisProxy.newInstance(pool);
}
```
