### PR TITLE
Fix Jedis.hvals(key) signature to use Collection instead of List to match JedisCommands interface

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
@@ -843,10 +844,10 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * @param key
      * @return All the fields values contained into a hash.
      */
-    public List<String> hvals(final String key) {
+    public Collection<String> hvals(final String key) {
         runChecks();
         client.hvals(key);
-        final List<String> lresult = client.getMultiBulkReply();
+        final Collection<String> lresult = client.getMultiBulkReply();
         return lresult;
     }
 

--- a/src/test/java/redis/clients/jedis/tests/commands/HashesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/HashesCommandsTest.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
@@ -245,7 +246,7 @@ public class HashesCommandsTest extends JedisCommandTestBase {
         hash.put("car", "bar");
         jedis.hmset("foo", hash);
 
-        List<String> vals = jedis.hvals("foo");
+        Collection<String> vals = jedis.hvals("foo");
         assertEquals(2, vals.size());
         assertTrue(vals.contains("bar"));
         assertTrue(vals.contains("car"));
@@ -256,11 +257,11 @@ public class HashesCommandsTest extends JedisCommandTestBase {
         bhash.put(bcar, bbar);
         jedis.hmset(bfoo, bhash);
 
-        List<byte[]> bvals = jedis.hvals(bfoo);
+        Collection<byte[]> bvals = jedis.hvals(bfoo);
 
         assertEquals(2, bvals.size());
-        assertTrue(arrayContains(bvals, bbar));
-        assertTrue(arrayContains(bvals, bcar));
+        assertTrue(collectionContains(bvals, bbar));
+        assertTrue(collectionContains(bvals, bcar));
     }
 
     @Test

--- a/src/test/java/redis/clients/jedis/tests/commands/JedisCommandTestBase.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/JedisCommandTestBase.java
@@ -5,6 +5,7 @@ import java.net.UnknownHostException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.Collection;
 
 import org.junit.After;
 import org.junit.Before;
@@ -62,18 +63,14 @@ public abstract class JedisCommandTestBase extends JedisTestBase {
     }
 
     protected boolean arrayContains(List<byte[]> array, byte[] expected) {
-        for (byte[] a : array) {
-            try {
-                assertArrayEquals(a, expected);
-                return true;
-            } catch (AssertionError e) {
-
-            }
-        }
-        return false;
+        return collectionContains(array, expected);
     }
 
     protected boolean setContains(Set<byte[]> set, byte[] expected) {
+        return collectionContains(set, expected);
+    }
+
+    protected boolean collectionContains(Collection<byte[]> set, byte[] expected) {
         for (byte[] a : set) {
             try {
                 assertArrayEquals(a, expected);


### PR DESCRIPTION
The JedisCommands interface was changed to use Collection instead of List on the JedisCommands interface for hvals(key), but the Jedis class wasn't updated to match.  This causes errors when compiling code (such as with Gedis where Jedis is used as a @Delegate).

The attached patch changes the signature to use Collection and fixes the tests that get broken by this (I also DRYed up one of the test helper classes in the process).
