### PR TITLE
Connect.connect() does not honor timeout

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
 import java.util.ArrayList;
@@ -102,7 +103,8 @@ public class Connection {
     public void connect() {
         if (!isConnected()) {
             try {
-                socket = new Socket(host, port);
+                socket = new Socket();
+                socket.connect(new InetSocketAddress(host, port), timeout);
                 socket.setSoTimeout(timeout);
                 outputStream = new RedisOutputStream(socket.getOutputStream());
                 inputStream = new RedisInputStream(socket.getInputStream());


### PR DESCRIPTION
I changed the Connect.connect() method so that the initial connect operation honors the set timeout.
