### PR TITLE
HashSet instead of LinkedHashSet

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -182,7 +182,7 @@ public class BinaryJedis implements BinaryJedisCommands {
     public Set<byte[]> keys(final byte[] pattern) {
         checkIsInMulti();
         client.keys(pattern);
-        final HashSet<byte[]> keySet = new LinkedHashSet<byte[]>(client
+        final HashSet<byte[]> keySet = new HashSet<byte[]>(client
                 .getBinaryMultiBulkReply());
         return keySet;
     }
@@ -835,7 +835,7 @@ public class BinaryJedis implements BinaryJedisCommands {
         checkIsInMulti();
         client.hkeys(key);
         final List<byte[]> lresult = client.getBinaryMultiBulkReply();
-        return new LinkedHashSet<byte[]>(lresult);
+        return new HashSet<byte[]>(lresult);
     }
 
     /**
@@ -1186,7 +1186,7 @@ public class BinaryJedis implements BinaryJedisCommands {
         checkIsInMulti();
         client.smembers(key);
         final List<byte[]> members = client.getBinaryMultiBulkReply();
-        return new LinkedHashSet<byte[]>(members);
+        return new HashSet<byte[]>(members);
     }
 
     /**
@@ -1310,7 +1310,7 @@ public class BinaryJedis implements BinaryJedisCommands {
         checkIsInMulti();
         client.sinter(keys);
         final List<byte[]> members = client.getBinaryMultiBulkReply();
-        return new LinkedHashSet<byte[]>(members);
+        return new HashSet<byte[]>(members);
     }
 
     /**
@@ -1350,7 +1350,7 @@ public class BinaryJedis implements BinaryJedisCommands {
         checkIsInMulti();
         client.sunion(keys);
         final List<byte[]> members = client.getBinaryMultiBulkReply();
-        return new LinkedHashSet<byte[]>(members);
+        return new HashSet<byte[]>(members);
     }
 
     /**
@@ -1398,7 +1398,7 @@ public class BinaryJedis implements BinaryJedisCommands {
         checkIsInMulti();
         client.sdiff(keys);
         final List<byte[]> members = client.getBinaryMultiBulkReply();
-        return new LinkedHashSet<byte[]>(members);
+        return new HashSet<byte[]>(members);
     }
 
     /**

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -1182,7 +1182,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
         runChecks();
         client.smembers(key);
         final List<String> members = client.getMultiBulkReply();
-        return new LinkedHashSet<String>(members);
+        return new HashSet<String>(members);
     }
 
     /**
@@ -1306,7 +1306,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
         runChecks();
         client.sinter(keys);
         final List<String> members = client.getMultiBulkReply();
-        return new LinkedHashSet<String>(members);
+        return new HashSet<String>(members);
     }
 
     /**
@@ -1346,7 +1346,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
         runChecks();
         client.sunion(keys);
         final List<String> members = client.getMultiBulkReply();
-        return new LinkedHashSet<String>(members);
+        return new HashSet<String>(members);
     }
 
     /**
@@ -1394,7 +1394,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
         runChecks();
         client.sdiff(keys);
         final List<String> members = client.getMultiBulkReply();
-        return new LinkedHashSet<String>(members);
+        return new HashSet<String>(members);
     }
 
     /**


### PR DESCRIPTION
HashSet instead of LinkedHashSet for replies that are inherently unordered.

Cheers,
Pieter
