### PR TITLE
Added persist() method to Transaction classes

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryTransaction.java
+++ b/src/main/java/redis/clients/jedis/BinaryTransaction.java
@@ -363,6 +363,10 @@ public class BinaryTransaction {
         client.sort(key, dstkey);
     }
 
+    public void persist(byte[] key) {
+        client.persist(key);
+    }
+
     public void setbit(byte[] key, long offset, byte[] value) {
         client.setbit(key, offset, value);
     }

--- a/src/main/java/redis/clients/jedis/Transaction.java
+++ b/src/main/java/redis/clients/jedis/Transaction.java
@@ -325,6 +325,10 @@ public class Transaction extends BinaryTransaction {
         client.sort(key, sortingParameters, dstkey);
     }
 
+    public void persist(String key) {
+        client.persist(key);
+    }
+
     public void setbit(String key, long offset, boolean value) {
         client.setbit(key, offset, value);
     }


### PR DESCRIPTION
The persist() method was missing from the Transaction classes, so I added it.
