### PR TITLE
issue 118 - One pool per redis instance

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -25,6 +25,9 @@ public class Connection implements Closeable {
     private int pipelinedCommands = 0;
     private int timeout = Protocol.DEFAULT_TIMEOUT;
 
+    // caching DNS lookups
+    private InetSocketAddress endpoint;
+    
     public Socket getSocket() {
 	return socket;
     }
@@ -105,6 +108,7 @@ public class Connection implements Closeable {
 
     public void setHost(final String host) {
 	this.host = host;
+        this.endpoint = null;
     }
 
     public int getPort() {
@@ -113,6 +117,7 @@ public class Connection implements Closeable {
 
     public void setPort(final int port) {
 	this.port = port;
+        this.endpoint = null;
     }
 
     public Connection() {
@@ -133,8 +138,11 @@ public class Connection implements Closeable {
 					     // the underlying socket is closed
 					     // immediately
 		// <-@wjw_add
+        if (endpoint == null) {
+            endpoint = new InetSocketAddress(host, port);
+        }
 
-		socket.connect(new InetSocketAddress(host, port), timeout);
+		socket.connect(endpoint, timeout);
 		socket.setSoTimeout(timeout);
 		outputStream = new RedisOutputStream(socket.getOutputStream());
 		inputStream = new RedisInputStream(socket.getInputStream());

--- a/src/main/java/redis/clients/jedis/HostAndPort.java
+++ b/src/main/java/redis/clients/jedis/HostAndPort.java
@@ -27,12 +27,21 @@ public class HostAndPort {
 	    String thisHost = convertHost(host);
 	    String hpHost = convertHost(hp.host);
 	    return port == hp.port && thisHost.equals(hpHost);
-
+	
 	}
-
-	return false;
+	
+    return false;
     }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((host == null) ? 0 : convertHost(host).hashCode());
+        result = prime * result + port;
+        return result;
+    }
+	
     @Override
     public String toString() {
 	return host + ":" + port;

--- a/src/main/java/redis/clients/jedis/JedisShardInfo.java
+++ b/src/main/java/redis/clients/jedis/JedisShardInfo.java
@@ -3,7 +3,6 @@ package redis.clients.jedis;
 import java.net.URI;
 
 import redis.clients.util.ShardInfo;
-import redis.clients.util.Sharded;
 
 public class JedisShardInfo extends ShardInfo<Jedis> {
     public String toString() {
@@ -25,7 +24,7 @@ public class JedisShardInfo extends ShardInfo<Jedis> {
     }
 
     public JedisShardInfo(String host) {
-	super(Sharded.DEFAULT_WEIGHT);
+	super(DEFAULT_WEIGHT);
 	URI uri = URI.create(host);
 	if (uri.getScheme() != null && uri.getScheme().equals("redis")) {
 	    this.host = uri.getHost();
@@ -50,23 +49,27 @@ public class JedisShardInfo extends ShardInfo<Jedis> {
     }
 
     public JedisShardInfo(String host, int port, int timeout) {
-	this(host, port, timeout, Sharded.DEFAULT_WEIGHT);
+	this(host, port, timeout, DEFAULT_WEIGHT);
     }
 
     public JedisShardInfo(String host, int port, int timeout, String name) {
-	this(host, port, timeout, Sharded.DEFAULT_WEIGHT);
-	this.name = name;
+	this(host, port, timeout, DEFAULT_WEIGHT, name);
     }
 
     public JedisShardInfo(String host, int port, int timeout, int weight) {
-	super(weight);
-	this.host = host;
-	this.port = port;
-	this.timeout = timeout;
+        this(host, port, timeout, weight, null);
+    }
+
+    public JedisShardInfo(String host, int port, int timeout, int weight, String name) {
+    super(weight);
+    this.host = host;
+    this.port = port;
+    this.timeout = timeout;
+    this.name = name;
     }
 
     public JedisShardInfo(URI uri) {
-	super(Sharded.DEFAULT_WEIGHT);
+	super(DEFAULT_WEIGHT);
 	this.host = uri.getHost();
 	this.port = uri.getPort();
 	this.password = uri.getUserInfo().split(":", 2)[1];

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -174,7 +174,7 @@ public final class Protocol {
     private static List<Object> processMultiBulkReply(final RedisInputStream is) {
 	int num = Integer.parseInt(is.readLine());
 	if (num == -1) {
-	    return null;
+	    return new ArrayList<Object>();
 	}
 	List<Object> ret = new ArrayList<Object>(num);
 	for (int i = 0; i < num; i++) {

--- a/src/main/java/redis/clients/jedis/shard/JedisPoolShardInfo.java
+++ b/src/main/java/redis/clients/jedis/shard/JedisPoolShardInfo.java
@@ -1,0 +1,73 @@
+package redis.clients.jedis.shard;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisShardInfo;
+import redis.clients.util.ShardInfo;
+
+public class JedisPoolShardInfo extends ShardInfo<JedisPool>{
+
+  private final JedisShardInfo shardInfo;
+  private final GenericObjectPoolConfig poolConfig;
+  private int database;
+  
+  public JedisPoolShardInfo(JedisShardInfo shardInfo, int database, GenericObjectPoolConfig poolConfig){
+    super(shardInfo.getWeight());
+    
+    this.shardInfo = shardInfo;
+    this.database = database;
+    this.poolConfig = poolConfig;
+  }
+  
+  public JedisShardInfo getShardInfo() {
+    return shardInfo;
+  }
+
+  public GenericObjectPoolConfig getPoolConfig() {
+    return poolConfig;
+  }
+  
+  public String getHost() {
+    return shardInfo.getHost();
+  }
+
+  public int getPort() {
+    return shardInfo.getPort();
+  }
+
+  @Override
+  public String getName() {
+      return shardInfo.getName();
+  }
+  
+  @Override
+  protected JedisPool createResource() {
+    return new JedisPool(poolConfig, shardInfo.getHost(), shardInfo.getPort(), shardInfo.getTimeout(),
+                    shardInfo.getPassword(), database);
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + shardInfo.hashCode();
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    JedisPoolShardInfo other = (JedisPoolShardInfo) obj;
+    if (shardInfo != other.shardInfo) {
+      return false;
+    }
+    return true;
+  }
+  
+}

--- a/src/main/java/redis/clients/jedis/shard/ShardedPool.java
+++ b/src/main/java/redis/clients/jedis/shard/ShardedPool.java
@@ -1,0 +1,119 @@
+package redis.clients.jedis.shard;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+import redis.clients.jedis.Client;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisShardInfo;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.util.Hashing;
+import redis.clients.util.Sharded;
+
+public class ShardedPool extends Sharded<JedisPool, JedisPoolShardInfo> {
+
+  private Map<HostAndPort,JedisPoolShardInfo> shardInfoLookup = new HashMap<HostAndPort, JedisPoolShardInfo>();
+  
+  public ShardedPool(GenericObjectPoolConfig poolConfig, List<JedisShardInfo> shards, int database) {
+    super(createPooledShards(poolConfig, shards, database));
+    initLookup();
+  }
+
+  public ShardedPool(GenericObjectPoolConfig poolConfig, List<JedisShardInfo> shards, int database, Hashing algo) {
+    super(createPooledShards(poolConfig, shards, database), algo);
+    initLookup();
+  }
+
+  public ShardedPool(GenericObjectPoolConfig poolConfig, List<JedisShardInfo> shards, int database, Pattern tagPattern) {
+    super(createPooledShards(poolConfig, shards, database), tagPattern);
+    initLookup();
+  }
+
+  public ShardedPool(GenericObjectPoolConfig poolConfig, List<JedisShardInfo> shards, int database, Hashing algo, Pattern tagPattern) {
+    super(createPooledShards(poolConfig, shards, database), algo, tagPattern);
+    initLookup();
+  }
+
+  private static List<JedisPoolShardInfo> createPooledShards(GenericObjectPoolConfig poolConfig,  List<JedisShardInfo> shards, int database) {
+    List<JedisPoolShardInfo> pooledShards = new ArrayList<JedisPoolShardInfo>(shards.size()); 
+    for(JedisShardInfo shardInfo : shards){
+      pooledShards.add(new JedisPoolShardInfo(shardInfo, database, poolConfig));
+    }
+    return pooledShards;
+  }
+
+  private void initLookup() {
+    for (JedisPoolShardInfo shardInfo : getAllShardInfo()) {
+      shardInfoLookup.put(new HostAndPort(shardInfo.getHost(), shardInfo.getPort()), shardInfo);
+    }
+  }
+
+  public Jedis getResource(String key) {
+    try {
+      JedisPool pool = getShard(key);
+      return pool.getResource();
+    } catch (Exception e) {
+      throw new JedisConnectionException("Could not get a resource from the pool", e);
+    }
+  }
+
+  public Jedis getResource(byte[] key) {
+    try {
+      JedisPool pool = getShard(key);
+      return pool.getResource();
+    } catch (Exception e) {
+      throw new JedisConnectionException("Could not get a resource from the pool", e);
+    }
+  }
+
+  public void returnResource(final Jedis resource) {
+    try {
+      JedisPool pool = findPool(resource);
+      pool.returnResource(resource);
+    } catch (Exception e) {
+      throw new JedisException("Could not return the resource to the pool", e);
+    }
+  }
+
+  public void returnBrokenResource(final Jedis resource) {
+    try {
+      JedisPool pool = findPool(resource);
+      pool.returnBrokenResource(resource);
+    } catch (Exception e) {
+      throw new JedisException("Could not return the resource to the pool", e);
+    }
+  }
+
+  protected JedisPool findPool(Jedis resource) {
+    Client client = resource.getClient();
+    JedisPoolShardInfo shardInfo = shardInfoLookup.get(new HostAndPort(client.getHost(), client.getPort()));
+    if (shardInfo == null) {
+      throw new JedisException("Could not find pool. ");
+    }
+    return getShard(shardInfo);
+  }
+
+  public void destroy() {
+    Exception lastException = null;
+    for (JedisPool pool : this.getAllShards()) {
+      try {
+        pool.destroy();
+      } catch (Exception e) {
+        lastException = e;
+      }
+    }
+
+    if (lastException != null) {
+      throw new JedisException("Could not destroy some pools", lastException);
+    }
+  }
+
+}

--- a/src/main/java/redis/clients/util/KetamaHash.java
+++ b/src/main/java/redis/clients/util/KetamaHash.java
@@ -1,0 +1,50 @@
+package redis.clients.util;
+
+import java.util.List;
+import java.util.TreeMap;
+
+public class KetamaHash extends MD5Hash {
+
+    @Override
+    protected String createContinuumId(ShardInfo<?> shardInfo, int shardPosition, int repetition) {
+        return shardInfo.getName() + "-" + repetition;
+    }
+
+    /**
+     * ketama - a consistent hashing algo
+     * libketama compatible implementation
+     * http://www.last.fm/user/RJ/journal/2007/04/10/rz_libketama_-_a_consistent_hashing_algo_for_memcache_clients
+     * 
+     * Notice the difference with {@link #createContinuum(List)}. 
+     * The repetition is calculated differently. Evenly weighted shards are for ketama max 40 and not 160
+     */
+    protected <S extends ShardInfo<?>> TreeMap<Long, S> createContinuum(List<S> shards) {
+        TreeMap<Long, S> nodes = new TreeMap<Long, S>();
+
+        int totalWeight = 0;
+        for (S shardInfo : shards) {
+            totalWeight += shardInfo.getWeight() <= 0 ? ShardInfo.DEFAULT_WEIGHT : shardInfo.getWeight();
+        }
+        
+        for (int i = 0; i != shards.size(); ++i) {
+            final S shardInfo = shards.get(i);
+            int weight = shardInfo.getWeight() <= 0 ? ShardInfo.DEFAULT_WEIGHT : shardInfo.getWeight();
+            double factor = Math.floor(((double) (40 * shards.size() * weight)) / (double) totalWeight);
+        
+            for (int repetition = 0; repetition < factor; repetition++) {
+                String continuumid = createContinuumId(shardInfo, i, repetition);
+                byte[] d = hashBytes(SafeEncoder.encode(continuumid));
+                // MD% returns 16 bytes. Create 4 continuum points out of these bytes
+                for (int h = 0; h < 4; h++) {
+                    Long k = ((long) (d[3 + h * 4] & 0xFF) << 24)
+                     | ((long) (d[2 + h * 4] & 0xFF) << 16)
+                     | ((long) (d[1 + h * 4] & 0xFF) << 8)
+                     | ((long) (d[0 + h * 4] & 0xFF));
+                    nodes.put(k, shardInfo);
+                }
+            }
+        }
+        return nodes;
+    }
+
+}

--- a/src/main/java/redis/clients/util/MD5Hash.java
+++ b/src/main/java/redis/clients/util/MD5Hash.java
@@ -1,0 +1,38 @@
+package redis.clients.util;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class MD5Hash extends Hashing {
+
+    public ThreadLocal<MessageDigest> md5Holder = new ThreadLocal<MessageDigest>();
+
+    public long hash(String key) {
+        return hash(SafeEncoder.encode(key));
+    }
+
+    public long hash(byte[] key) {
+        byte[] bKey = hashBytes(key);
+        long res = ((long) (bKey[3] & 0xFF) << 24)
+                | ((long) (bKey[2] & 0xFF) << 16)
+                | ((long) (bKey[1] & 0xFF) << 8) | (long) (bKey[0] & 0xFF);
+        return res;
+    }
+
+    protected byte[] hashBytes(byte[] key) {
+        try {
+            if (md5Holder.get() == null) {
+                md5Holder.set(MessageDigest.getInstance("MD5"));
+            }
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("++++ no md5 algorythm found");
+        }
+        MessageDigest md5 = md5Holder.get();
+
+        md5.reset();
+        md5.update(key);
+        byte[] bKey = md5.digest();
+        return bKey;
+    }
+
+}

--- a/src/main/java/redis/clients/util/MurmurHash.java
+++ b/src/main/java/redis/clients/util/MurmurHash.java
@@ -29,7 +29,7 @@ import java.nio.ByteOrder;
  * Andrzej Bialecki (ab at getopt org).
  * </p>
  */
-public class MurmurHash implements Hashing {
+public class MurmurHash extends Hashing {
     /**
      * Hashes bytes in an array.
      * 

--- a/src/main/java/redis/clients/util/ShardInfo.java
+++ b/src/main/java/redis/clients/util/ShardInfo.java
@@ -1,6 +1,8 @@
 package redis.clients.util;
 
 public abstract class ShardInfo<T> {
+    public static final int DEFAULT_WEIGHT = 1;
+
     private int weight;
 
     public ShardInfo() {


### PR DESCRIPTION
There is already a pull request for the same issue, but to me that implementation could have been simpler. That implementation introduced even more dependecies from the none sharding code (BinaryJedis and Jedis) to the shardinfo implementation. In my opinion. these classes should not know anything about sharding.To return the Jedis instance to the correct pool I decided to use the host and port from the shardinfo and jedis client. 