### PR TITLE
Exception thrown when trying to get a key with pipeline that does not exist

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -1,15 +1,8 @@
 package redis.clients.jedis;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import redis.clients.util.SafeEncoder;
+
+import java.util.*;
 
 public class BuilderFactory {
     public static final Builder<Double> DOUBLE = new Builder<Double>() {
@@ -52,7 +45,7 @@ public class BuilderFactory {
     };
     public static final Builder<String> STRING = new Builder<String>() {
         public String build(Object data) {
-            return SafeEncoder.encode((byte[]) data);
+            return data == null ? null : SafeEncoder.encode((byte[]) data);
         }
 
         public String toString() {

--- a/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
@@ -1,21 +1,17 @@
 package redis.clients.jedis.tests;
 
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.*;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
+
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.Pipeline;
-import redis.clients.jedis.PipelineBlock;
-import redis.clients.jedis.Response;
-import redis.clients.jedis.Tuple;
-import redis.clients.jedis.exceptions.JedisDataException;
-import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
+import java.util.UUID;
 
 public class PipeliningTest extends Assert {
     private static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
@@ -113,5 +109,13 @@ public class PipeliningTest extends Assert {
         pipelined.sync();
         assertEquals(0, p1.get().longValue());
         assertEquals(0, p2.get().longValue());
+    }
+
+    @Test
+    public void canRetrieveUnsetKey() {
+        Pipeline p = jedis.pipelined();
+        Response<String> shouldNotExist = p.get(UUID.randomUUID().toString());
+        p.sync();
+        assertNull(shouldNotExist.get());
     }
 }


### PR DESCRIPTION
It is trying to run SafeEncoder on the value it retrieves.  If it is null, this fails.
