### PR TITLE
multi get should return a map for easier usage of results

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -83,8 +83,12 @@ public class BuilderFactory {
             final Map<String, String> hash = new HashMap<String, String>();
             final Iterator<byte[]> iterator = flatHash.iterator();
             while (iterator.hasNext()) {
-                hash.put(SafeEncoder.encode(iterator.next()), SafeEncoder
-                        .encode(iterator.next()));
+                byte[] next = iterator.next();
+
+                if (next != null) {
+                    hash.put(SafeEncoder.encode(iterator.next()), SafeEncoder
+                            .encode(iterator.next()));
+                }
             }
 
             return hash;

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -1,12 +1,6 @@
 package redis.clients.jedis;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import redis.clients.jedis.BinaryClient.LIST_POSITION;
 
@@ -38,7 +32,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * 1073741824 bytes (1 GB).
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @param key
      * @param value
      * @return Status code reply
@@ -55,7 +49,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * error is returned because GET can only handle string values.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @param key
      * @return Bulk reply
      */
@@ -79,9 +73,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * Test if the specified key exists. The command returns "1" if the key
      * exists, otherwise "1" is returned. Note that even keys set with an empty
      * string as value will return "0".
-     * 
+     *
      * Time complexity: O(1)
-     * 
+     *
      * @param key
      * @return Boolean reply, true if the key exists, otherwise false
      */
@@ -94,9 +88,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
     /**
      * Remove the specified keys. If a given key does not exist no operation is
      * performed for this key. The command returns the number of keys removed.
-     * 
+     *
      * Time complexity: O(1)
-     * 
+     *
      * @param keys
      * @return Integer reply, specifically: an integer greater than 0 if one or
      *         more keys were removed 0 if none of the specified key existed
@@ -111,9 +105,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * Return the type of the value stored at key in form of a string. The type
      * can be one of "none", "string", "list", "set". "none" is returned if the
      * key does not exist.
-     * 
+     *
      * Time complexity: O(1)
-     * 
+     *
      * @param key
      * @return Status code reply, specifically: "none" if the key does not exist
      *         "string" if the key contains a String value "list" if the key
@@ -130,7 +124,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
     /**
      * Delete all the keys of the currently selected DB. This command never
      * fails.
-     * 
+     *
      * @return Status code reply
      */
 
@@ -167,7 +161,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <p>
      * Time complexity: O(n) (with n being the number of keys in the DB, and
      * assuming keys and pattern of limited length)
-     * 
+     *
      * @param pattern
      * @return Multi bulk reply
      */
@@ -182,7 +176,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * Return a randomly selected key from the currently selected DB.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @return Singe line reply, specifically the randomly selected key or an
      *         empty string is the database is empty
      */
@@ -198,7 +192,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * exists it is overwritten.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @param oldkey
      * @param newkey
      * @return Status code repy
@@ -214,7 +208,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * exists.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @param oldkey
      * @param newkey
      * @return Integer reply, specifically: 1 if the key was renamed 0 if the
@@ -228,7 +222,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
 
     /**
      * Return the number of keys in the currently selected database.
-     * 
+     *
      * @return Integer reply
      */
 
@@ -255,9 +249,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * PERSIST} command.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @see <ahref="http://code.google.com/p/redis/wiki/ExpireCommand">ExpireCommand</a>
-     * 
+     *
      * @param key
      * @param seconds
      * @return Integer reply, specifically: 1: the timeout was set. 0: the
@@ -291,9 +285,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * PERSIST} command.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @see <ahref="http://code.google.com/p/redis/wiki/ExpireCommand">ExpireCommand</a>
-     * 
+     *
      * @param key
      * @param unixTime
      * @return Integer reply, specifically: 1: the timeout was set. 0: the
@@ -313,7 +307,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * that has an {@link #expire(String, int) EXPIRE} set. This introspection
      * capability allows a Redis client to check how many seconds a given key
      * will continue to be part of the dataset.
-     * 
+     *
      * @param key
      * @return Integer reply, returns the remaining time to live in seconds of a
      *         key that has an EXPIRE. If the Key does not exists or does not
@@ -328,7 +322,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
     /**
      * Select the DB with having the specified zero-based numeric index. For
      * default every new client connection is automatically selected to DB 0.
-     * 
+     *
      * @param index
      * @return Status code reply
      */
@@ -345,7 +339,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * successfully moved, and 0 if the target key was already there or if the
      * source key was not found at all, so it is possible to use MOVE as a
      * locking primitive.
-     * 
+     *
      * @param key
      * @param dbIndex
      * @return Integer reply, specifically: 1 if the key was moved 0 if the key
@@ -361,7 +355,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
     /**
      * Delete all the keys of all the existing databases, not just the currently
      * selected one. This command never fails.
-     * 
+     *
      * @return Status code reply
      */
 
@@ -377,7 +371,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * string can't be longer than 1073741824 bytes (1 GB).
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @param key
      * @param value
      * @return Bulk reply
@@ -394,7 +388,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * of the specified key, but the operation never fails.
      * <p>
      * Time complexity: O(1) for every key
-     * 
+     *
      * @param keys
      * @return Multi bulk reply
      */
@@ -405,12 +399,42 @@ public class Jedis extends BinaryJedis implements JedisCommands {
     }
 
     /**
+     * Get the values of all the specified keys. If one or more keys dont exist
+     * or is not of type String, a 'nil' value is returned instead of the value
+     * of the specified key, but the operation never fails. This method returns
+     * a map instead of a list.
+     * <p/>
+     * Time complexity: O(1) for every key
+     *
+     * @param keys
+     * @return Multi bulk reply
+     */
+    public Map<String, String> mgetMap(final String... keys) {
+        checkIsInMulti();
+        client.mget(keys);
+
+        Map<String, String> mapret = new LinkedHashMap<String, String>();
+        List<String> redisret = client.getMultiBulkReply();
+
+        int index = 0;
+        for(String item: redisret) {
+            if(item != null) {
+                mapret.put(keys[index], item);
+            }
+
+            index++;
+        }
+
+        return mapret;
+    }
+
+    /**
      * SETNX works exactly like {@link #set(String, String) SET} with the only
      * difference that if the key already exists no operation is performed.
      * SETNX actually means "SET if Not eXists".
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @param key
      * @param value
      * @return Integer reply, specifically: 1 if the key was set 0 if the key
@@ -428,7 +452,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * The operation is atomic.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @param key
      * @param seconds
      * @param value
@@ -454,9 +478,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * if the keys A and B are modified, another client talking to Redis can
      * either see the changes to both A and B at once, or no modification at
      * all.
-     * 
+     *
      * @see #msetnx(String...)
-     * 
+     *
      * @param keysvalues
      * @return Status code reply Basically +OK as MSET can't fail
      */
@@ -480,9 +504,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * if the keys A and B are modified, another client talking to Redis can
      * either see the changes to both A and B at once, or no modification at
      * all.
-     * 
+     *
      * @see #mset(String...)
-     * 
+     *
      * @param keysvalues
      * @return Integer reply, specifically: 1 if the all the keys were set 0 if
      *         no key was set (at least one key already existed)
@@ -505,11 +529,11 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * string.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @see #incr(String)
      * @see #decr(String)
      * @see #incrBy(String, int)
-     * 
+     *
      * @param key
      * @param integer
      * @return Integer reply, this commands will reply with the new value of key
@@ -534,11 +558,11 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * string.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @see #incr(String)
      * @see #incrBy(String, int)
      * @see #decrBy(String, int)
-     * 
+     *
      * @param key
      * @return Integer reply, this commands will reply with the new value of key
      *         after the increment.
@@ -561,11 +585,11 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * string.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @see #incr(String)
      * @see #decr(String)
      * @see #decrBy(String, int)
-     * 
+     *
      * @param key
      * @param integer
      * @return Integer reply, this commands will reply with the new value of key
@@ -590,11 +614,11 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * string.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @see #incrBy(String, int)
      * @see #decr(String)
      * @see #decrBy(String, int)
-     * 
+     *
      * @param key
      * @return Integer reply, this commands will reply with the new value of key
      *         after the increment.
@@ -615,7 +639,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * appended value is small and the already present value is of any size,
      * since the dynamic string library used by Redis will double the free space
      * available on every reallocation.
-     * 
+     *
      * @param key
      * @param value
      * @return Integer reply, specifically the total length of the string after
@@ -639,7 +663,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * Time complexity: O(start+n) (with start being the start index and n the
      * total length of the requested range). Note that the lookup part of this
      * command is O(1) so for small strings this is actually an O(1) command.
-     * 
+     *
      * @param key
      * @param start
      * @param end
@@ -652,13 +676,13 @@ public class Jedis extends BinaryJedis implements JedisCommands {
     }
 
     /**
-     * 
+     *
      * Set the specified hash field to the specified value.
      * <p>
      * If key does not exist, a new key holding a hash is created.
      * <p>
      * <b>Time complexity:</b> O(1)
-     * 
+     *
      * @param key
      * @param field
      * @param value
@@ -680,7 +704,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * value is returned.
      * <p>
      * <b>Time complexity:</b> O(1)
-     * 
+     *
      * @param key
      * @param field
      * @return Bulk reply
@@ -692,10 +716,10 @@ public class Jedis extends BinaryJedis implements JedisCommands {
     }
 
     /**
-     * 
+     *
      * Set the specified hash field to the specified value if the field not
      * exists. <b>Time complexity:</b> O(1)
-     * 
+     *
      * @param key
      * @param field
      * @param value
@@ -715,7 +739,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * If key does not exist, a new key holding a hash is created.
      * <p>
      * <b>Time complexity:</b> O(N) (with N being the number of fields)
-     * 
+     *
      * @param key
      * @param hash
      * @return Return OK or Exception if hash is empty
@@ -733,7 +757,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * Non existing keys are considered like empty hashes.
      * <p>
      * <b>Time complexity:</b> O(N) (with N being the number of fields)
-     * 
+     *
      * @param key
      * @param fields
      * @return Multi Bulk Reply specifically a list of all the values associated
@@ -756,7 +780,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * integers.
      * <p>
      * <b>Time complexity:</b> O(1)
-     * 
+     *
      * @param key
      * @param field
      * @param value
@@ -771,9 +795,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
 
     /**
      * Test for existence of a specified field in a hash.
-     * 
+     *
      * <b>Time complexity:</b> O(1)
-     * 
+     *
      * @param key
      * @param field
      * @return Return 1 if the hash stored at key contains the specified field.
@@ -789,7 +813,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * Remove the specified field from an hash stored at key.
      * <p>
      * <b>Time complexity:</b> O(1)
-     * 
+     *
      * @param key
      * @param field
      * @return If the field was present in the hash it is deleted and 1 is
@@ -805,7 +829,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * Return the number of items in a hash.
      * <p>
      * <b>Time complexity:</b> O(1)
-     * 
+     *
      * @param key
      * @return The number of entries (fields) contained in the hash stored at
      *         key. If the specified key does not exist, 0 is returned assuming
@@ -821,7 +845,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * Return all the fields in a hash.
      * <p>
      * <b>Time complexity:</b> O(N), where N is the total number of entries
-     * 
+     *
      * @param key
      * @return All the fields names contained into a hash.
      */
@@ -836,7 +860,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * Return all the values in a hash.
      * <p>
      * <b>Time complexity:</b> O(N), where N is the total number of entries
-     * 
+     *
      * @param key
      * @return All the fields values contained into a hash.
      */
@@ -851,7 +875,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * Return all the fields and associated values in a hash.
      * <p>
      * <b>Time complexity:</b> O(N), where N is the total number of entries
-     * 
+     *
      * @param key
      * @return All the fields and values contained into a hash.
      */
@@ -869,9 +893,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * is returned.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @see Jedis#lpush(String, String)
-     * 
+     *
      * @param key
      * @param string
      * @return Integer reply, specifically, the number of elements inside the
@@ -890,9 +914,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * is returned.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @see Jedis#rpush(String, String)
-     * 
+     *
      * @param key
      * @param string
      * @return Integer reply, specifically, the number of elements inside the
@@ -910,7 +934,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * If the value stored at key is not a list an error is returned.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @param key
      * @return The length of the list.
      */
@@ -951,7 +975,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <p>
      * Time complexity: O(start+n) (with n being the length of the range and
      * start being the start offset)
-     * 
+     *
      * @param key
      * @param start
      * @param end
@@ -992,7 +1016,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * one element is removed from the tail of the list.
      * <p>
      * Time complexity: O(n) (with n being len of list - len of range)
-     * 
+     *
      * @param key
      * @param start
      * @param end
@@ -1017,7 +1041,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * first or the last element of the list is O(1).
      * <p>
      * Time complexity: O(n) (with n being the length of the list)
-     * 
+     *
      * @param key
      * @param index
      * @return Bulk reply, specifically the requested element
@@ -1041,9 +1065,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <p>
      * O(N) (with N being the length of the list), setting the first or last
      * elements of the list is O(1).
-     * 
+     *
      * @see #lindex(String, int)
-     * 
+     *
      * @param key
      * @param index
      * @param value
@@ -1067,7 +1091,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * against non existing keys will always return 0.
      * <p>
      * Time complexity: O(N) (with N being the length of the list)
-     * 
+     *
      * @param key
      * @param count
      * @param value
@@ -1087,9 +1111,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <p>
      * If the key does not exist or the list is already empty the special value
      * 'nil' is returned.
-     * 
+     *
      * @see #rpop(String)
-     * 
+     *
      * @param key
      * @return Bulk reply
      */
@@ -1106,9 +1130,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <p>
      * If the key does not exist or the list is already empty the special value
      * 'nil' is returned.
-     * 
+     *
      * @see #lpop(String)
-     * 
+     *
      * @param key
      * @return Bulk reply
      */
@@ -1131,7 +1155,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * first element of the list, so it's a "list rotation" command.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @param srckey
      * @param dstkey
      * @return Bulk reply
@@ -1149,7 +1173,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * the key exists but does not hold a set value an error is returned.
      * <p>
      * Time complexity O(1)
-     * 
+     *
      * @param key
      * @param member
      * @return Integer reply, specifically: 1 if the new element was added 0 if
@@ -1166,7 +1190,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * just syntax glue for {@link #sinter(String...) SINTER}.
      * <p>
      * Time complexity O(N)
-     * 
+     *
      * @param key
      * @return Multi bulk reply
      */
@@ -1183,7 +1207,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * hold a set value an error is returned.
      * <p>
      * Time complexity O(1)
-     * 
+     *
      * @param key
      * @param member
      * @return Integer reply, specifically: 1 if the new element was removed 0
@@ -1203,7 +1227,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * returned element is not removed from the Set.
      * <p>
      * Time complexity O(1)
-     * 
+     *
      * @param key
      * @return Bulk reply
      */
@@ -1228,7 +1252,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * value.
      * <p>
      * Time complexity O(1)
-     * 
+     *
      * @param srckey
      * @param dstkey
      * @param member
@@ -1246,7 +1270,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
     /**
      * Return the set cardinality (number of elements). If the key does not
      * exist 0 is returned, like for empty sets.
-     * 
+     *
      * @param key
      * @return Integer reply, specifically: the cardinality (number of elements)
      *         of the set as an integer.
@@ -1262,7 +1286,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * returned.
      * <p>
      * Time complexity O(1)
-     * 
+     *
      * @param key
      * @param member
      * @return Integer reply, specifically: 1 if the element is a member of the
@@ -1290,7 +1314,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <p>
      * Time complexity O(N*M) worst case where N is the cardinality of the
      * smallest set and M the number of sets
-     * 
+     *
      * @param keys
      * @return Multi bulk reply, specifically the list of common elements.
      */
@@ -1307,7 +1331,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <p>
      * Time complexity O(N*M) worst case where N is the cardinality of the
      * smallest set and M the number of sets
-     * 
+     *
      * @param dstkey
      * @param keys
      * @return Status code reply
@@ -1330,7 +1354,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <p>
      * Time complexity O(N) where N is the total number of elements in all the
      * provided sets
-     * 
+     *
      * @param keys
      * @return Multi bulk reply, specifically the list of common elements.
      */
@@ -1348,7 +1372,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <p>
      * Time complexity O(N) where N is the total number of elements in all the
      * provided sets
-     * 
+     *
      * @param dstkey
      * @param keys
      * @return Status code reply
@@ -1364,20 +1388,20 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * key2, ..., keyN
      * <p>
      * <b>Example:</b>
-     * 
+     *
      * <pre>
      * key1 = [x, a, b, c]
      * key2 = [c]
      * key3 = [a, d]
      * SDIFF key1,key2,key3 => [x, b]
      * </pre>
-     * 
+     *
      * Non existing keys are considered like empty sets.
      * <p>
      * <b>Time complexity:</b>
      * <p>
      * O(N) with N being the total number of elements of all the sets
-     * 
+     *
      * @param keys
      * @return Return the members of a set resulting from the difference between
      *         the first set provided and all the successive sets.
@@ -1392,7 +1416,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
     /**
      * This command works exactly like {@link #sdiff(String...) SDIFF} but
      * instead of being returned the resulting set is stored in dstkey.
-     * 
+     *
      * @param dstkey
      * @param keys
      * @return Status code reply
@@ -1411,7 +1435,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * (removed) from the Set.
      * <p>
      * Time complexity O(1)
-     * 
+     *
      * @param key
      * @return Bulk reply
      */
@@ -1434,7 +1458,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <p>
      * Time complexity O(log(N)) with N being the number of elements in the
      * sorted set
-     * 
+     *
      * @param key
      * @param score
      * @param member
@@ -1462,9 +1486,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <p>
      * Time complexity O(log(N)) with N being the number of elements in the
      * sorted set
-     * 
-     * 
-     * 
+     *
+     *
+     *
      * @param key
      * @param member
      * @return Integer reply, specifically: 1 if the new element was removed 0
@@ -1494,7 +1518,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <p>
      * Time complexity O(log(N)) with N being the number of elements in the
      * sorted set
-     * 
+     *
      * @param key
      * @param score
      * @param member
@@ -1519,9 +1543,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <b>Time complexity:</b>
      * <p>
      * O(log(N))
-     * 
+     *
      * @see #zrevrank(String, String)
-     * 
+     *
      * @param key
      * @param member
      * @return Integer reply or a nil bulk reply, specifically: the rank of the
@@ -1545,9 +1569,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <b>Time complexity:</b>
      * <p>
      * O(log(N))
-     * 
+     *
      * @see #zrank(String, String)
-     * 
+     *
      * @param key
      * @param member
      * @return Integer reply or a nil bulk reply, specifically: the rank of the
@@ -1589,7 +1613,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * not exist 0 is returned, like for empty sorted sets.
      * <p>
      * Time complexity O(1)
-     * 
+     *
      * @param key
      * @return the cardinality (number of elements) of the set as an integer.
      */
@@ -1605,7 +1629,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * not exist at all, a special 'nil' value is returned.
      * <p>
      * <b>Time complexity:</b> O(1)
-     * 
+     *
      * @param key
      * @param member
      * @return the score
@@ -1628,12 +1652,12 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * Sort the elements contained in the List, Set, or Sorted Set value at key.
      * By default sorting is numeric with elements being compared as double
      * precision floating point numbers. This is the simplest form of SORT.
-     * 
+     *
      * @see #sort(String, String)
      * @see #sort(String, SortingParams)
      * @see #sort(String, SortingParams, String)
-     * 
-     * 
+     *
+     *
      * @param key
      * @return Assuming the Set/List at key contains a list of numbers, the
      *         return value will be the list of numbers ordered from the
@@ -1651,72 +1675,72 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <b>examples:</b>
      * <p>
      * Given are the following sets and key/values:
-     * 
+     *
      * <pre>
      * x = [1, 2, 3]
      * y = [a, b, c]
-     * 
+     *
      * k1 = z
      * k2 = y
      * k3 = x
-     * 
+     *
      * w1 = 9
      * w2 = 8
      * w3 = 7
      * </pre>
-     * 
+     *
      * Sort Order:
-     * 
+     *
      * <pre>
      * sort(x) or sort(x, sp.asc())
      * -> [1, 2, 3]
-     * 
+     *
      * sort(x, sp.desc())
      * -> [3, 2, 1]
-     * 
+     *
      * sort(y)
      * -> [c, a, b]
-     * 
+     *
      * sort(y, sp.alpha())
      * -> [a, b, c]
-     * 
+     *
      * sort(y, sp.alpha().desc())
      * -> [c, a, b]
      * </pre>
-     * 
+     *
      * Limit (e.g. for Pagination):
-     * 
+     *
      * <pre>
      * sort(x, sp.limit(0, 2))
      * -> [1, 2]
-     * 
+     *
      * sort(y, sp.alpha().desc().limit(1, 2))
      * -> [b, a]
      * </pre>
-     * 
+     *
      * Sorting by external keys:
-     * 
+     *
      * <pre>
      * sort(x, sb.by(w*))
      * -> [3, 2, 1]
-     * 
+     *
      * sort(x, sb.by(w*).desc())
      * -> [1, 2, 3]
      * </pre>
-     * 
+     *
      * Getting external keys:
-     * 
+     *
      * <pre>
      * sort(x, sp.by(w*).get(k*))
      * -> [x, y, z]
-     * 
+     *
      * sort(x, sp.by(w*).get(#).get(k*))
      * -> [3, x, 2, y, 1, z]
      * </pre>
-     * 
+     *
      * @see #sort(String)
      * @see #sort(String, SortingParams, String)
-     * 
+     *
      * @param key
      * @param sortingParameters
      * @return a list of sorted elements.
@@ -1787,9 +1811,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * MULTI/EXEC the time will flow at infinite speed :)
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @see #brpop(int, String...)
-     * 
+     *
      * @param timeout
      * @param keys
      * @return BLPOP returns a two-elements array via a multi bulk reply in
@@ -1818,11 +1842,11 @@ public class Jedis extends BinaryJedis implements JedisCommands {
     /**
      * Sort a Set or a List accordingly to the specified parameters and store
      * the result at dstkey.
-     * 
+     *
      * @see #sort(String, SortingParams)
      * @see #sort(String)
      * @see #sort(String, String)
-     * 
+     *
      * @param key
      * @param sortingParameters
      * @param dstkey
@@ -1842,11 +1866,11 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * and store the result at dstkey. By default sorting is numeric with
      * elements being compared as double precision floating point numbers. This
      * is the simplest form of SORT.
-     * 
+     *
      * @see #sort(String)
      * @see #sort(String, SortingParams)
      * @see #sort(String, SortingParams, String)
-     * 
+     *
      * @param key
      * @param dstkey
      * @return The number of elements of the list at dstkey.
@@ -1916,9 +1940,9 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * MULTI/EXEC the time will flow at infinite speed :)
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @see #blpop(int, String...)
-     * 
+     *
      * @param timeout
      * @param keys
      * @return BLPOP returns a two-elements array via a multi bulk reply in
@@ -1956,7 +1980,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * is possible to try a lot of passwords in parallel in very short time, so
      * make sure to generate a strong and very long password so that this attack
      * is infeasible.
-     * 
+     *
      * @param password
      * @return Status code reply
      */
@@ -2038,14 +2062,14 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * M the number of elements returned by the command, so if M is constant
      * (for instance you always ask for the first ten elements with LIMIT) you
      * can consider it O(log(N))
-     * 
+     *
      * @see #zrangeByScore(String, double, double)
      * @see #zrangeByScore(String, double, double, int, int)
      * @see #zrangeByScoreWithScores(String, double, double)
      * @see #zrangeByScoreWithScores(String, String, String)
      * @see #zrangeByScoreWithScores(String, double, double, int, int)
      * @see #zcount(String, double, double)
-     * 
+     *
      * @param key
      * @param min
      * @param max
@@ -2109,13 +2133,13 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * M the number of elements returned by the command, so if M is constant
      * (for instance you always ask for the first ten elements with LIMIT) you
      * can consider it O(log(N))
-     * 
+     *
      * @see #zrangeByScore(String, double, double)
      * @see #zrangeByScore(String, double, double, int, int)
      * @see #zrangeByScoreWithScores(String, double, double)
      * @see #zrangeByScoreWithScores(String, double, double, int, int)
      * @see #zcount(String, double, double)
-     * 
+     *
      * @param key
      * @param min
      * @param max
@@ -2172,13 +2196,13 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * M the number of elements returned by the command, so if M is constant
      * (for instance you always ask for the first ten elements with LIMIT) you
      * can consider it O(log(N))
-     * 
+     *
      * @see #zrangeByScore(String, double, double)
      * @see #zrangeByScore(String, double, double, int, int)
      * @see #zrangeByScoreWithScores(String, double, double)
      * @see #zrangeByScoreWithScores(String, double, double, int, int)
      * @see #zcount(String, double, double)
-     * 
+     *
      * @param key
      * @param min
      * @param max
@@ -2236,13 +2260,13 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * M the number of elements returned by the command, so if M is constant
      * (for instance you always ask for the first ten elements with LIMIT) you
      * can consider it O(log(N))
-     * 
+     *
      * @see #zrangeByScore(String, double, double)
      * @see #zrangeByScore(String, double, double, int, int)
      * @see #zrangeByScoreWithScores(String, double, double)
      * @see #zrangeByScoreWithScores(String, double, double, int, int)
      * @see #zcount(String, double, double)
-     * 
+     *
      * @param key
      * @param min
      * @param max
@@ -2320,7 +2344,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <b>Time complexity:</b> O(log(N))+O(M) with N being the number of
      * elements in the sorted set and M the number of elements removed by the
      * operation
-     * 
+     *
      */
     public Long zremrangeByRank(final String key, final int start, final int end) {
         checkIsInMulti();
@@ -2336,7 +2360,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <p>
      * O(log(N))+O(M) with N being the number of elements in the sorted set and
      * M the number of elements removed by the operation
-     * 
+     *
      * @param key
      * @param start
      * @param end
@@ -2376,12 +2400,12 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <b>Time complexity:</b> O(N) + O(M log(M)) with N being the sum of the
      * sizes of the input sorted sets, and M being the number of elements in the
      * resulting sorted set
-     * 
+     *
      * @see #zunionstore(String, String...)
      * @see #zunionstore(String, ZParams, String...)
      * @see #zinterstore(String, String...)
      * @see #zinterstore(String, ZParams, String...)
-     * 
+     *
      * @param dstkey
      * @param sets
      * @return Integer reply, specifically the number of elements in the sorted
@@ -2420,12 +2444,12 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <b>Time complexity:</b> O(N) + O(M log(M)) with N being the sum of the
      * sizes of the input sorted sets, and M being the number of elements in the
      * resulting sorted set
-     * 
+     *
      * @see #zunionstore(String, String...)
      * @see #zunionstore(String, ZParams, String...)
      * @see #zinterstore(String, String...)
      * @see #zinterstore(String, ZParams, String...)
-     * 
+     *
      * @param dstkey
      * @param sets
      * @param params
@@ -2466,12 +2490,12 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <b>Time complexity:</b> O(N) + O(M log(M)) with N being the sum of the
      * sizes of the input sorted sets, and M being the number of elements in the
      * resulting sorted set
-     * 
+     *
      * @see #zunionstore(String, String...)
      * @see #zunionstore(String, ZParams, String...)
      * @see #zinterstore(String, String...)
      * @see #zinterstore(String, ZParams, String...)
-     * 
+     *
      * @param dstkey
      * @param sets
      * @return Integer reply, specifically the number of elements in the sorted
@@ -2510,12 +2534,12 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * <b>Time complexity:</b> O(N) + O(M log(M)) with N being the sum of the
      * sizes of the input sorted sets, and M being the number of elements in the
      * resulting sorted set
-     * 
+     *
      * @see #zunionstore(String, String...)
      * @see #zunionstore(String, ZParams, String...)
      * @see #zinterstore(String, String...)
      * @see #zinterstore(String, ZParams, String...)
-     * 
+     *
      * @param dstkey
      * @param sets
      * @param params
@@ -2544,7 +2568,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
      * a normal key.
      * <p>
      * Time complexity: O(1)
-     * 
+     *
      * @param key
      * @return Integer reply, specifically: 1: the key is now persist. 0: the
      *         key is not persist (only happens when key not set).
@@ -2573,7 +2597,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
     /**
      * Pop a value from a list, push it to another list and return it; or block
      * until one is available
-     * 
+     *
      * @param source
      * @param destination
      * @param timeout
@@ -2589,7 +2613,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
 
     /**
      * Sets or clears the bit at offset in the string value stored at key
-     * 
+     *
      * @param key
      * @param offset
      * @param value
@@ -2602,7 +2626,7 @@ public class Jedis extends BinaryJedis implements JedisCommands {
 
     /**
      * Returns the bit value at offset in the string value stored at key
-     * 
+     *
      * @param key
      * @param offset
      * @return

--- a/src/test/java/redis/clients/jedis/tests/commands/StringValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/StringValuesCommandsTest.java
@@ -2,6 +2,7 @@ package redis.clients.jedis.tests.commands;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -53,6 +54,33 @@ public class StringValuesCommandsTest extends JedisCommandTestBase {
         values = jedis.mget("foo", "bar");
 
         assertEquals(expected, values);
+    }
+
+    @Test
+    public void mgetMap() {
+        Map<String, String> values = jedis.mgetMap("foo", "bar");
+
+
+        assertTrue(values.isEmpty());
+
+        jedis.set("foo", "bar");
+
+        values = jedis.mgetMap("foo", "bar");
+
+        assertTrue(values.size() == 1);
+        assertTrue(values.containsKey("foo"));
+        assertEquals(values.get("foo"),"bar");
+
+        jedis.set("bar", "foo");
+
+
+        values = jedis.mgetMap("foo", "bar");
+
+        assertTrue(values.size() == 2);
+        assertTrue(values.containsKey("foo"));
+        assertEquals(values.get("foo"),"bar");
+        assertTrue(values.containsKey("bar"));
+        assertEquals(values.get("bar"),"foo");
     }
 
     @Test


### PR DESCRIPTION
When a list is returned from a multiget request you move to the client the burden of checking what keys were returned and which did not. I just copied the multiget method an added a new one called multigetMap which returns a map instead of a list.

Thanks!