### PR TITLE
Add JedisPool constructor that takes only host string

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -14,9 +14,13 @@ public class JedisPool extends Pool<Jedis> {
                 null);
     }
 
-    public JedisPool(String host, int port) {
+    public JedisPool(final String host, final int port) {
         super(new Config(), new JedisFactory(host, port,
                 Protocol.DEFAULT_TIMEOUT, null));
+    }
+
+    public JedisPool(final String host) {
+        this(host, Protocol.DEFAULT_PORT);
     }
 
     public JedisPool(final Config poolConfig, final String host, int port,


### PR DESCRIPTION
This constructor type is available on the `Jedis` class and so I added it to `JedisPool` for consistency.
