### PR TITLE
Mark inner classes static that don't reference parent class.

### DIFF
--- a/src/main/java/redis/clients/jedis/ShardedJedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedisPipeline.java
@@ -10,7 +10,7 @@ public abstract class ShardedJedisPipeline {
     private BinaryShardedJedis jedis;
     private List<FutureResult> results = new ArrayList<FutureResult>();
 
-    private class FutureResult {
+    private static class FutureResult {
         private Client client;
 
         public FutureResult(Client client) {

--- a/src/main/java/redis/clients/util/JedisByteHashMap.java
+++ b/src/main/java/redis/clients/util/JedisByteHashMap.java
@@ -88,7 +88,7 @@ public class JedisByteHashMap implements Map<byte[], byte[]>, Cloneable,
         return internalMap.values();
     }
 
-    private final class ByteArrayWrapper {
+    private static final class ByteArrayWrapper {
         private final byte[] data;
 
         public ByteArrayWrapper(byte[] data) {
@@ -110,7 +110,7 @@ public class JedisByteHashMap implements Map<byte[], byte[]>, Cloneable,
         }
     }
 
-    private final class JedisByteEntry implements Entry<byte[], byte[]> {
+    private static final class JedisByteEntry implements Entry<byte[], byte[]> {
         private byte[] value;
         private byte[] key;
 


### PR DESCRIPTION
This was discovered by running [findbugs](http://findbugs.sourceforge.net/) against the Jedis source.
