### PR TITLE
make pubsub threadsafe

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisPubSub.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisPubSub.java
@@ -19,7 +19,7 @@ public abstract class BinaryJedisPubSub {
     public abstract void onMessage(byte[] channel, byte[] message);
 
     public abstract void onPMessage(byte[] pattern, byte[] channel,
-            byte[] message);
+                                    byte[] message);
 
     public abstract void onSubscribe(byte[] channel, int subscribedChannels);
 
@@ -29,92 +29,100 @@ public abstract class BinaryJedisPubSub {
 
     public abstract void onPSubscribe(byte[] pattern, int subscribedChannels);
 
-    public void unsubscribe() {
+    synchronized public void unsubscribe() {
         client.unsubscribe();
         client.flush();
     }
 
-    public void unsubscribe(byte[]... channels) {
+    synchronized public void unsubscribe(byte[]... channels) {
         client.unsubscribe(channels);
         client.flush();
     }
 
-    public void subscribe(byte[]... channels) {
+    synchronized public void subscribe(byte[]... channels) {
         client.subscribe(channels);
         client.flush();
     }
 
-    public void psubscribe(byte[]... patterns) {
+    synchronized public void psubscribe(byte[]... patterns) {
         client.psubscribe(patterns);
         client.flush();
     }
 
-    public void punsubscribe() {
+    synchronized public void punsubscribe() {
         client.punsubscribe();
         client.flush();
     }
 
-    public void punsubscribe(byte[]... patterns) {
+    synchronized public void punsubscribe(byte[]... patterns) {
         client.punsubscribe(patterns);
         client.flush();
     }
 
-    public boolean isSubscribed() {
+    synchronized public boolean isSubscribed() {
         return subscribedChannels > 0;
     }
 
     public void proceedWithPatterns(Client client, byte[]... patterns) {
-        this.client = client;
-        client.psubscribe(patterns);
+        synchronized(this) {
+            this.client = client;
+            client.psubscribe(patterns);
+            client.flush();
+        }
         process(client);
     }
 
-    public void proceed(Client client, byte[]... channels) {
-        this.client = client;
-        client.subscribe(channels);
+    synchronized public void proceed(Client client, byte[]... channels) {
+        synchronized(this) {
+            this.client = client;
+            client.subscribe(channels);
+            client.flush();
+        }
         process(client);
     }
 
     private void process(Client client) {
         do {
-            List<Object> reply = client.getObjectMultiBulkReply();
-            final Object firstObj = reply.get(0);
-            if (!(firstObj instanceof byte[])) {
-                throw new JedisException("Unknown message type: " + firstObj);
-            }
-            final byte[] resp = (byte[]) firstObj;
-            if (Arrays.equals(SUBSCRIBE.raw, resp)) {
-                subscribedChannels = ((Long) reply.get(2)).intValue();
-                final byte[] bchannel = (byte[]) reply.get(1);
-                onSubscribe(bchannel, subscribedChannels);
-            } else if (Arrays.equals(UNSUBSCRIBE.raw, resp)) {
-                subscribedChannels = ((Long) reply.get(2)).intValue();
-                final byte[] bchannel = (byte[]) reply.get(1);
-                onUnsubscribe(bchannel, subscribedChannels);
-            } else if (Arrays.equals(MESSAGE.raw, resp)) {
-                final byte[] bchannel = (byte[]) reply.get(1);
-                final byte[] bmesg = (byte[]) reply.get(2);
-                onMessage(bchannel, bmesg);
-            } else if (Arrays.equals(PMESSAGE.raw, resp)) {
-                final byte[] bpattern = (byte[]) reply.get(1);
-                final byte[] bchannel = (byte[]) reply.get(2);
-                final byte[] bmesg = (byte[]) reply.get(3);
-                onPMessage(bpattern, bchannel, bmesg);
-            } else if (Arrays.equals(PSUBSCRIBE.raw, resp)) {
-                subscribedChannels = ((Long) reply.get(2)).intValue();
-                final byte[] bpattern = (byte[]) reply.get(1);
-                onPSubscribe(bpattern, subscribedChannels);
-            } else if (Arrays.equals(PUNSUBSCRIBE.raw, resp)) {
-                subscribedChannels = ((Long) reply.get(2)).intValue();
-                final byte[] bpattern = (byte[]) reply.get(1);
-                onPUnsubscribe(bpattern, subscribedChannels);
-            } else {
-                throw new JedisException("Unknown message type: " + firstObj);
+            List<Object> reply = client.rawGetObjectMultiBulkReply();
+            synchronized(this) {
+                final Object firstObj = reply.get(0);
+                if (!(firstObj instanceof byte[])) {
+                    throw new JedisException("Unknown message type: " + firstObj);
+                }
+                final byte[] resp = (byte[]) firstObj;
+                if (Arrays.equals(SUBSCRIBE.raw, resp)) {
+                    subscribedChannels = ((Long) reply.get(2)).intValue();
+                    final byte[] bchannel = (byte[]) reply.get(1);
+                    onSubscribe(bchannel, subscribedChannels);
+                } else if (Arrays.equals(UNSUBSCRIBE.raw, resp)) {
+                    subscribedChannels = ((Long) reply.get(2)).intValue();
+                    final byte[] bchannel = (byte[]) reply.get(1);
+                    onUnsubscribe(bchannel, subscribedChannels);
+                } else if (Arrays.equals(MESSAGE.raw, resp)) {
+                    final byte[] bchannel = (byte[]) reply.get(1);
+                    final byte[] bmesg = (byte[]) reply.get(2);
+                    onMessage(bchannel, bmesg);
+                } else if (Arrays.equals(PMESSAGE.raw, resp)) {
+                    final byte[] bpattern = (byte[]) reply.get(1);
+                    final byte[] bchannel = (byte[]) reply.get(2);
+                    final byte[] bmesg = (byte[]) reply.get(3);
+                    onPMessage(bpattern, bchannel, bmesg);
+                } else if (Arrays.equals(PSUBSCRIBE.raw, resp)) {
+                    subscribedChannels = ((Long) reply.get(2)).intValue();
+                    final byte[] bpattern = (byte[]) reply.get(1);
+                    onPSubscribe(bpattern, subscribedChannels);
+                } else if (Arrays.equals(PUNSUBSCRIBE.raw, resp)) {
+                    subscribedChannels = ((Long) reply.get(2)).intValue();
+                    final byte[] bpattern = (byte[]) reply.get(1);
+                    onPUnsubscribe(bpattern, subscribedChannels);
+                } else {
+                    throw new JedisException("Unknown message type: " + firstObj);
+                }
             }
         } while (isSubscribed());
     }
 
-    public int getSubscribedChannels() {
+    synchronized public int getSubscribedChannels() {
         return subscribedChannels;
     }
 }

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -47,6 +47,7 @@ public class Connection {
     public void rollbackTimeout() {
         try {
             socket.setSoTimeout(timeout);
+            pipelinedCommands = 0;
         } catch (SocketException ex) {
             throw new JedisException(ex);
         }
@@ -190,10 +191,14 @@ public class Connection {
     }
 
     @SuppressWarnings("unchecked")
+    public List<Object> rawGetObjectMultiBulkReply() {
+        return (List<Object>) protocol.read(inputStream);
+    }
+
     public List<Object> getObjectMultiBulkReply() {
         flush();
         pipelinedCommands--;
-        return (List<Object>) protocol.read(inputStream);
+        return rawGetObjectMultiBulkReply();
     }
 
     public List<Object> getAll() {


### PR DESCRIPTION
Calling subscribe/unsubscribe on a PubSub object from a foreign thread isn't threadsafe because callbacks may also be calling these functions.

This patch simply makes things that might write to redis synchronized while leaving the reader unsynchronized.

It also resets the pipeline count on exit from a subscribe loop since the number isn't used in the pubsub case.