### PR TITLE
Add ability to specify redis database number on pool config

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -8,30 +8,30 @@ import redis.clients.util.Pool;
 
 public class JedisPool extends Pool<Jedis> {
 
-    public JedisPool(final GenericObjectPool.Config poolConfig,
-            final String host) {
-        this(poolConfig, host, Protocol.DEFAULT_PORT, Protocol.DEFAULT_TIMEOUT,
-                null);
+    public JedisPool(final Config poolConfig, final String host) {
+        this(poolConfig, host, Protocol.DEFAULT_PORT, Protocol.DEFAULT_TIMEOUT, null, Protocol.DEFAULT_DATABASE);
     }
 
     public JedisPool(String host, int port) {
-        super(new Config(), new JedisFactory(host, port,
-                Protocol.DEFAULT_TIMEOUT, null));
+        this(new Config(), host, port, Protocol.DEFAULT_TIMEOUT, null, Protocol.DEFAULT_DATABASE);
     }
 
     public JedisPool(final Config poolConfig, final String host, int port,
             int timeout, final String password) {
-        super(poolConfig, new JedisFactory(host, port, timeout, password));
+        this(poolConfig, host, port, timeout, password, Protocol.DEFAULT_DATABASE);
     }
 
-    public JedisPool(final GenericObjectPool.Config poolConfig,
-            final String host, final int port) {
-        this(poolConfig, host, port, Protocol.DEFAULT_TIMEOUT, null);
+    public JedisPool(final Config poolConfig, final String host, final int port) {
+        this(poolConfig, host, port, Protocol.DEFAULT_TIMEOUT, null, Protocol.DEFAULT_DATABASE);
     }
 
-    public JedisPool(final GenericObjectPool.Config poolConfig,
-            final String host, final int port, final int timeout) {
-        this(poolConfig, host, port, timeout, null);
+    public JedisPool(final Config poolConfig, final String host, final int port, final int timeout) {
+        this(poolConfig, host, port, timeout, null, Protocol.DEFAULT_DATABASE);
+    }
+
+    public JedisPool(final Config poolConfig, final String host, int port, int timeout, final String password,
+                     final int database) {
+        super(poolConfig, new JedisFactory(host, port, timeout, password, database));
     }
 
     /**
@@ -42,14 +42,16 @@ public class JedisPool extends Pool<Jedis> {
         private final int port;
         private final int timeout;
         private final String password;
+        private final int database;
 
         public JedisFactory(final String host, final int port,
-                final int timeout, final String password) {
+                final int timeout, final String password, final int database) {
             super();
             this.host = host;
             this.port = port;
             this.timeout = timeout;
             this.password = password;
+            this.database = database;
         }
 
         public Object makeObject() throws Exception {
@@ -59,6 +61,10 @@ public class JedisPool extends Pool<Jedis> {
             if (null != this.password) {
                 jedis.auth(this.password);
             }
+            if( database != 0 ) {
+                jedis.select(database);
+            }
+            
             return jedis;
         }
 

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -14,6 +14,7 @@ public final class Protocol {
 
     public static final int DEFAULT_PORT = 6379;
     public static final int DEFAULT_TIMEOUT = 2000;
+    public static final int DEFAULT_DATABASE = 0;
 
     public static final String CHARSET = "UTF-8";
 

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
@@ -95,4 +95,22 @@ public class JedisPoolTest extends Assert {
         pool.returnResource(jedis);
         pool.destroy();
     }
+
+    @Test
+    public void nonDefaultDatabase() {
+        JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.host,
+                hnp.port, 2000, "foobared");
+        Jedis jedis0 = pool0.getResource();
+        jedis0.set("foo", "bar");
+        assertEquals( "bar", jedis0.get("foo") );
+        pool0.returnResource(jedis0);
+        pool0.destroy();
+
+        JedisPool pool1 = new JedisPool(new JedisPoolConfig(), hnp.host,
+                hnp.port, 2000, "foobared", 1);
+        Jedis jedis1 = pool1.getResource();
+        assertNull( jedis1.get("foo") );
+        pool1.returnResource(jedis0);
+        pool1.destroy();
+    }
 }


### PR DESCRIPTION
We would like to add the ability to specify the database number on the pool config. We have a number of integration/functional tests in different projects using redis and would like to keep them separate. Setting up a number of redis server instances on different ports would become unwieldy.

The changes add the ability to specify the database number for jedis pools with associated test. I did not add the ability to create a raw jedis connection with a database number because the current implementation of pool creates the jedis object first, then if a password exists it calls the auth command. However, if a password is required, then the select command on the jedis create would fail. I also did not change the shard constructor of jedis to use a database number (which actually does have the constructor of jedis call the auth command). 

I could clean up the implementation to always have the jedis constructor call auth if a password exists, then select the database if it is non-zero, and changing sharding info to contain a database config value. Let me know if you want me to make these bigger changes. 
