### PR TITLE
Set socket keepalive during subscribe operations

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -34,6 +34,7 @@ public class Connection {
 
     public void setTimeoutInfinite() {
         try {
+            socket.setKeepAlive(true);
             socket.setSoTimeout(0);
         } catch (SocketException ex) {
             throw new JedisException(ex);
@@ -43,6 +44,7 @@ public class Connection {
     public void rollbackTimeout() {
         try {
             socket.setSoTimeout(timeout);
+            socket.setKeepAlive(false);
         } catch (SocketException ex) {
             throw new JedisException(ex);
         }


### PR DESCRIPTION
The subscribe and psubscribe operations call setTimeoutInfinite() since they never return on their own. If the Redis server goes away without closing the connection, the connection can hang indefinitely. Turning on keep-alive will allow the connection to eventually timeout and attempt reconnection.

Note that keepalive must also be enabled on your server, see the Linux HOWTOs on how to do this.
