### PR TITLE
Broken sharded test fix

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/ShardedJedisPipelineTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ShardedJedisPipelineTest.java
@@ -13,7 +13,7 @@ import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
-public class SharedJedisPipelineTest {
+public class ShardedJedisPipelineTest {
     private static HostAndPortUtil.HostAndPort redis1 = HostAndPortUtil.getRedisServers()
             .get(0);
     private static HostAndPortUtil.HostAndPort redis2 = HostAndPortUtil.getRedisServers()


### PR DESCRIPTION
SharedJedisPipelineTest is broken : it doesn't do any authent, so it can't be played along other tests (aka mvn test always fails).

This pull request fix this ...
