### PR TITLE
Pipeline uses wrong response builder for get and getSet

### DIFF
--- a/src/main/java/redis/clients/jedis/Pipeline.java
+++ b/src/main/java/redis/clients/jedis/Pipeline.java
@@ -154,9 +154,9 @@ public class Pipeline extends Queable {
         return getResponse(BuilderFactory.STRING);
     }
 
-    public Response<String> get(byte[] key) {
+    public Response<byte[]> get(byte[] key) {
         client.get(key);
-        return getResponse(BuilderFactory.STRING);
+        return getResponse(BuilderFactory.BYTE_ARRAY);
     }
 
     public Response<Boolean> getbit(String key, long offset) {
@@ -175,9 +175,9 @@ public class Pipeline extends Queable {
         return getResponse(BuilderFactory.STRING);
     }
 
-    public Response<String> getSet(byte[] key, byte[] value) {
+    public Response<byte[]> getSet(byte[] key, byte[] value) {
         client.getSet(key, value);
-        return getResponse(BuilderFactory.STRING);
+        return getResponse(BuilderFactory.BYTE_ARRAY);
     }
 
     public Response<Long> hdel(String key, String field) {


### PR DESCRIPTION
The byte[] versions of get and getSet are using the same response builder as String versions of these methods. I think these methods should use BuilderFactory.BYTE_ARRAY instead of BuilderFactory.String. 

Test are passing after this change (except the ones that are already broken in SharedJedisPipelineTest). I'm not adding new test cases for this change, as the change is trivial. 
