### PR TITLE
provide a reset() method to read all remaining data

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -34,6 +34,15 @@ public class Jedis extends BinaryJedis implements JedisCommands {
     }
 
     /**
+	 * Resets the client.
+	 * <p>
+	 * Reads all remaining responses from the input.
+	 */
+	public void reset() {
+		client.getAll();
+	}
+
+	/**
      * Set the string value as value of the key. The string can't be longer than
      * 1073741824 bytes (1 GB).
      * <p>


### PR DESCRIPTION
It would be useful to have a reset() method in Jedis client.

It could be called before returning a shared Jedis client to the pool, or borrowing it again.