### PR TITLE
pipeline get doesn't return byte[] 

### DIFF
--- a/src/main/java/redis/clients/jedis/Pipeline.java
+++ b/src/main/java/redis/clients/jedis/Pipeline.java
@@ -158,6 +158,11 @@ public class Pipeline extends Queable {
         client.get(key);
         return getResponse(BuilderFactory.STRING);
     }
+    
+    public Response<byte[]> getBytes(byte[] key) {
+        client.get(key);
+        return getResponse(BuilderFactory.BYTE_ARRAY);
+    }
 
     public Response<Boolean> getbit(String key, long offset) {
         client.getbit(key, offset);


### PR DESCRIPTION
pipeline is not supporting byte[] return as response, so added a method that return byte[] response, without changing the current get
