### PR TITLE
Fix NPE in BuilderFactory for Double.

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -7,7 +7,8 @@ import java.util.*;
 public class BuilderFactory {
     public static final Builder<Double> DOUBLE = new Builder<Double>() {
         public Double build(Object data) {
-            return Double.valueOf(STRING.build(data));
+            String asString = STRING.build(data);
+            return asString == null ? null : Double.valueOf(asString);
         }
 
         public String toString() {


### PR DESCRIPTION
When pipelining a zscore we get a null pointer exception when the requested value isn't present in the set.  We should just get null.
