### PR TITLE
IO error may cause java.lang.ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/redis/clients/util/RedisInputStream.java
+++ b/src/main/java/redis/clients/util/RedisInputStream.java
@@ -106,7 +106,10 @@ public class RedisInputStream extends FilterInputStream {
     }
 
     private void fill() throws IOException {
-        limit = in.read(buf);
-        count = 0;
+        try {
+            limit = in.read(buf);
+        } finally {
+            count = 0;
+        }
     }
 }

--- a/src/main/java/redis/clients/util/RedisOutputStream.java
+++ b/src/main/java/redis/clients/util/RedisOutputStream.java
@@ -26,8 +26,11 @@ public final class RedisOutputStream extends FilterOutputStream {
 
     private void flushBuffer() throws IOException {
         if (count > 0) {
-            out.write(buf, 0, count);
-            count = 0;
+            try {
+                out.write(buf, 0, count);
+            } finally {
+                count = 0;
+            }
         }
     }
 
@@ -37,7 +40,7 @@ public final class RedisOutputStream extends FilterOutputStream {
             flushBuffer();
         }
     }
-    
+
     public void write(final byte[] b) throws IOException {
     	write(b, 0, b.length);
     }


### PR DESCRIPTION
Caused by: java.lang.ArrayIndexOutOfBoundsException: 8583
	at redis.clients.util.RedisOutputStream.write(RedisOutputStream.java:35)
	at redis.clients.jedis.Protocol.sendCommand(Protocol.java:34)
	at redis.clients.jedis.Protocol.sendCommand(Protocol.java:28)
	at redis.clients.jedis.Connection.sendCommand(Connection.java:85)
	at redis.clients.jedis.BinaryClient.ping(BinaryClient.java:67)
	at redis.clients.jedis.Jedis.ping(Jedis.java:32)