### PR TITLE
Pipeline.hgetAll(byte[]) now returns Map<byte[],byte[]>

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -136,6 +136,24 @@ public class BuilderFactory {
         }
     };
 
+    public static final Builder<Map<byte[],byte[]>> BYTE_ARRAY_MAP = new Builder<Map<byte[],byte[]>>() {
+        @SuppressWarnings("unchecked")
+        public Map<byte[], byte[]> build(Object data) {
+            final List<byte[]> flatHash = (List<byte[]>) data;
+            final Map<byte[], byte[]> hash = new HashMap<byte[], byte[]>();
+            final Iterator<byte[]> iterator = flatHash.iterator();
+            while (iterator.hasNext()) {
+                hash.put(iterator.next(), iterator.next());
+            }
+
+            return hash;
+        }
+
+        public String toString() {
+            return "Map<byte[],byte[]>";
+        }
+    };
+
     public static final Builder<Set<byte[]>> BYTE_ARRAY_ZSET = new Builder<Set<byte[]>>() {
         @SuppressWarnings("unchecked")
         public Set<byte[]> build(Object data) {

--- a/src/main/java/redis/clients/jedis/Pipeline.java
+++ b/src/main/java/redis/clients/jedis/Pipeline.java
@@ -260,9 +260,9 @@ public class Pipeline extends Queable {
         return getResponse(BuilderFactory.STRING_MAP);
     }
 
-    public Response<Map<String, String>> hgetAll(byte[] key) {
+    public Response<Map<byte[], byte[]>> hgetAll(byte[] key) {
         client.hgetAll(key);
-        return getResponse(BuilderFactory.STRING_MAP);
+        return getResponse(BuilderFactory.BYTE_ARRAY_MAP);
     }
 
     public Response<Long> hincrBy(String key, String field, long value) {


### PR DESCRIPTION
Hi,
In the standard Jedis interface, methods that take byte arrays as a parameter usually return byte arrays.
This is the case in Jedis.hgetAll(byte[]) but not in Pipeline.hgetAll(byte[]) which I need in my project.
I fixed that in my commit.
I did not fix other methods, at least not for now.
Best regards,
Guillaume.
