### PR TITLE
 RedisInputStream#readLine can't decode multi-byte characters.

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/ProtocolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ProtocolTest.java
@@ -101,4 +101,11 @@ public class ProtocolTest extends JedisTestBase {
                 .read(new RedisInputStream(is));
         assertNull(response);
     }
+    
+    @Test
+    public void utf8StringReply() {
+        InputStream is = new ByteArrayInputStream("日本語(Japanese)".getBytes());
+        assertEquals("日本語(Japanese)", new RedisInputStream(is).readLine());
+    }
+
 }


### PR DESCRIPTION
Since RedisInputStream#readLine can't decode multi-byte characters, changing the way to decode from byte[] to string.