### PR TITLE
pipeline lrange return byte[]

### DIFF
--- a/src/main/java/redis/clients/jedis/Pipeline.java
+++ b/src/main/java/redis/clients/jedis/Pipeline.java
@@ -442,9 +442,9 @@ public class Pipeline extends Queable {
         return getResponse(BuilderFactory.STRING_LIST);
     }
 
-    public Response<List<String>> lrange(byte[] key, long start, long end) {
+    public Response<List<byte[]>> lrange(byte[] key, long start, long end) {
         client.lrange(key, start, end);
-        return getResponse(BuilderFactory.STRING_LIST);
+        return getResponse(BuilderFactory.BYTE_ARRAY_LIST);
     }
 
     public Response<Long> lrem(String key, long count, String value) {

--- a/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
@@ -69,6 +69,7 @@ public class PipeliningTest extends Assert {
         Response<Long> zcard = p.zcard("zset");
         p.lpush("list", "bar");
         Response<List<String>> lrange = p.lrange("list", 0, -1);
+        Response<List<byte[]>> lrangeBytes = p.lrange("list".getBytes(), 0, 1);
         Response<Map<String, String>> hgetAll = p.hgetAll("hash");
         p.sadd("set", "foo");
         Response<Set<String>> smembers = p.smembers("set");
@@ -85,6 +86,7 @@ public class PipeliningTest extends Assert {
         assertEquals(Double.valueOf(2), zincrby.get());
         assertEquals(Long.valueOf(1), zcard.get());
         assertEquals(1, lrange.get().size());
+        assertEquals(1, lrangeBytes.get().size());
         assertNotNull(hgetAll.get().get("foo"));
         assertEquals(1, smembers.get().size());
         assertEquals(1, zrangeWithScores.get().size());


### PR DESCRIPTION
When key is byte[] return Response<List<byte[]>> instead of Response<List<String>>
