### PR TITLE
Implemented persist method in sharded jedis

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
@@ -484,9 +484,4 @@ public class BinaryShardedJedis extends Sharded<Jedis, JedisShardInfo>
 	Jedis j = getShard(key);
 	return j.objectIdletime(key);
     }
-    
-    public Long persist(byte[] key) {
-    	Jedis j = getShard(key);
-    	return j.persist(key);
-    }
 }

--- a/src/main/java/redis/clients/jedis/ShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedis.java
@@ -483,9 +483,4 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands {
 	Jedis j = getShard(key);
 	return j.linsert(key, where, pivot, value);
     }
-    
-    public Long persist(String key) {
-    	Jedis j = getShard(key);
-        return j.persist(key);
-    }
 }


### PR DESCRIPTION
Persist command implementation was missing in sharded Jedis. Added persist command implementation in BinaryShardedJedis and ShardedJedis.
