### PR TITLE
Update src/main/java/redis/clients/util/RedisOutputStream.java

### DIFF
--- a/src/main/java/redis/clients/util/RedisOutputStream.java
+++ b/src/main/java/redis/clients/util/RedisOutputStream.java
@@ -26,8 +26,15 @@ public final class RedisOutputStream extends FilterOutputStream {
 
     private void flushBuffer() throws IOException {
         if (count > 0) {
-            out.write(buf, 0, count);
-            count = 0;
+              //this add try finally,because when out.write(buf, 0, count); throw error,the count=0 is not exec;
+           	  // it's cause java.lang.ClassCastException: java.util.ArrayList cannot be cast to java.lang.Long 
+           	  //at redis.clients.jedis.Connection.getIntegerReply(Connection.java:161) 
+           	  //at redis.clients.jedis.Jedis.del(Jedis.java:108) 
+           	  try{
+           		  out.write(buf, 0, count);
+           	  }finally{
+           		  count = 0;
+           	  }
         }
     }
 


### PR DESCRIPTION
flushBuffer() this add try finally,because when out.write(buf, 0, count); throw error,the count=0 is not exec; ?it's cause java.lang.ClassCastException: java.util.ArrayList cannot be cast to java.lang.Long? ?at redis.clients.jedis.Connection.getIntegerReply(Connection.java:161)? ?at redis.clients.jedis.Jedis.del(Jedis.java:108)?  在这个方法里，应该加入try finally，因为当out.write(buf, 0, count); 这句抛出异常时，会造成 count=0;这一行 不能正常执行，就行造成部分剩余的错误命令在下次的请求中，会再次发送，将会造成java.lang.ClassCastException异常