### PR TITLE
Add 'del' to ShardedJedisPipeline

### DIFF
--- a/src/main/java/redis/clients/jedis/ShardedJedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedisPipeline.java
@@ -39,6 +39,13 @@ public class ShardedJedisPipeline extends Queable {
         return getResponse(BuilderFactory.STRING);
     }
 
+    public Response<Long> del(String key) {
+        Client c = getClient(key);
+        c.del(key);
+        results.add(new FutureResult(c));
+        return getResponse(BuilderFactory.LONG);
+    }
+
     public Response<Boolean> exists(String key) {
         Client c = getClient(key);
         c.exists(key);

--- a/src/test/java/redis/clients/jedis/tests/ShardedJedisPipelineTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ShardedJedisPipelineTest.java
@@ -74,6 +74,8 @@ public class ShardedJedisPipelineTest {
 
         ShardedJedisPipeline p = jedis.pipelined();
         Response<String> string = p.get("string");
+        Response<Long> del = p.del("string");
+        Response<String> emptyString = p.get("string");
         Response<String> list = p.lpop("list");
         Response<String> hash = p.hget("hash", "foo");
         Response<Set<String>> zset = p.zrange("zset", 0, -1);
@@ -91,6 +93,8 @@ public class ShardedJedisPipelineTest {
         p.sync();
 
         assertEquals("foo", string.get());
+        assertEquals(Long.valueOf(1), del.get());
+        assertNull(emptyString.get());
         assertEquals("foo", list.get());
         assertEquals("bar", hash.get());
         assertEquals("foo", zset.get().iterator().next());


### PR DESCRIPTION
The sharded pipeline implementation doesn't currently have the 'del' operation.
