### PR TITLE
add FailSafe implementation

### DIFF
--- a/src/main/java/redis/clients/jedis/FailSafeJedisPool.java
+++ b/src/main/java/redis/clients/jedis/FailSafeJedisPool.java
@@ -1,0 +1,15 @@
+package redis.clients.jedis;
+
+import org.apache.commons.pool.impl.GenericObjectPool;
+
+import redis.clients.util.FailSafeJedisCluster;
+import redis.clients.util.FailSafeJedisFactory;
+import redis.clients.util.Pool;
+
+public class FailSafeJedisPool extends Pool<JedisFacade> {
+
+	public FailSafeJedisPool(final GenericObjectPool.Config poolConfig,
+			FailSafeJedisCluster cluster) {
+		super(poolConfig, new FailSafeJedisFactory(cluster));
+	}
+}

--- a/src/main/java/redis/clients/jedis/JedisFacade.java
+++ b/src/main/java/redis/clients/jedis/JedisFacade.java
@@ -1,0 +1,7 @@
+package redis.clients.jedis;
+
+public interface JedisFacade extends BasicCommands, BinaryJedisCommands,
+		MultiKeyBinaryCommands, AdvancedBinaryJedisCommands,
+		BinaryScriptingCommands, JedisCommands, MultiKeyCommands,
+		AdvancedJedisCommands, ScriptingCommands {
+}

--- a/src/main/java/redis/clients/jedis/JedisServerInfo.java
+++ b/src/main/java/redis/clients/jedis/JedisServerInfo.java
@@ -1,0 +1,76 @@
+package redis.clients.jedis;
+
+import java.net.URI;
+
+public class JedisServerInfo {
+	private int timeout;
+	private String host;
+	private int port;
+	private String password = null;
+
+	@Override
+	public String toString() {
+		return host + ":" + port;
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public JedisServerInfo(String host) {
+		URI uri = URI.create(host);
+		if (uri.getScheme() != null && uri.getScheme().equals("redis")) {
+			this.host = uri.getHost();
+			this.port = uri.getPort();
+			this.password = uri.getUserInfo().split(":", 2)[1];
+		} else {
+			this.host = host;
+			this.port = Protocol.DEFAULT_PORT;
+		}
+	}
+
+	public JedisServerInfo(String host, int port, String password, int timeout) {
+		this.host = host;
+		this.port = port;
+		this.password = password;
+		this.timeout = timeout;
+	}
+
+	public JedisServerInfo(String host, int port, String password) {
+		this(host, port, password, 2000);
+	}
+
+	public JedisServerInfo(String host, int port, int timeout) {
+		this(host, port, null, timeout);
+	}
+
+	public JedisServerInfo(String host, int port) {
+		this(host, port, null, 2000);
+	}
+
+	public JedisServerInfo(URI uri) {
+		this.host = uri.getHost();
+		this.port = uri.getPort();
+		this.password = uri.getUserInfo().split(":", 2)[1];
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String auth) {
+		this.password = auth;
+	}
+
+	public int getTimeout() {
+		return timeout;
+	}
+
+	public void setTimeout(int timeout) {
+		this.timeout = timeout;
+	}
+}

--- a/src/main/java/redis/clients/util/FailSafeInvocationHandler.java
+++ b/src/main/java/redis/clients/util/FailSafeInvocationHandler.java
@@ -1,0 +1,74 @@
+package redis.clients.util;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisServerInfo;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.exceptions.JedisException;
+
+public class FailSafeInvocationHandler implements InvocationHandler {
+	private final Map<JedisServerInfo, Jedis> resources = new HashMap<JedisServerInfo, Jedis>();
+	private final FailSafeJedisCluster cluster;
+
+	public FailSafeInvocationHandler(FailSafeJedisCluster cluster) {
+		this.cluster = cluster;
+		for (JedisServerInfo info : cluster.getMembers()) {
+			Jedis jedis = new Jedis(info.getHost(), info.getPort());
+			if (info.getPassword() != null)
+				jedis.auth(info.getPassword());
+			resources.put(info, jedis);
+		}
+	}
+
+	public Object invoke(Object proxy, Method method, Object[] args)
+			throws Throwable {
+		if (cluster.getMaster() == null)
+			throw new JedisException("No Master is found");
+
+		Jedis j = resources.get(cluster.getMaster());
+		try {
+			return method.invoke(j, args);
+		} catch (InvocationTargetException ex) {
+			if (ex.getCause() instanceof JedisConnectionException)
+				j = resources.get(cluster.electNewMaster());
+			else if (ex.getCause() instanceof JedisDataException
+					&& ex.getCause().getMessage().startsWith("READONLY"))
+				j = resources.get(cluster.electNewMaster());
+			else
+				throw ex.getCause();
+		}
+		return method.invoke(j, args);
+	}
+
+	public void destroyProxy() {
+		try {
+			for (Jedis j : resources.values()) {
+				j.quit();
+				j.disconnect();
+			}
+		} catch (Exception e) {
+		}
+	}
+
+	public boolean validateProxy() {
+		if (cluster.getMaster() == null)
+			return false;
+
+		Jedis j = resources.get(cluster.getMaster());
+
+		try {
+			if (j.ping().equals("PONG"))
+				return true;
+		} catch (Exception ex) {
+			return false;
+		}
+		return false;
+	}
+
+}

--- a/src/main/java/redis/clients/util/FailSafeInvocationHandler.java
+++ b/src/main/java/redis/clients/util/FailSafeInvocationHandler.java
@@ -55,20 +55,4 @@ public class FailSafeInvocationHandler implements InvocationHandler {
 		} catch (Exception e) {
 		}
 	}
-
-	public boolean validateProxy() {
-		if (cluster.getMaster() == null)
-			return false;
-
-		Jedis j = resources.get(cluster.getMaster());
-
-		try {
-			if (j.ping().equals("PONG"))
-				return true;
-		} catch (Exception ex) {
-			return false;
-		}
-		return false;
-	}
-
 }

--- a/src/main/java/redis/clients/util/FailSafeJedisCluster.java
+++ b/src/main/java/redis/clients/util/FailSafeJedisCluster.java
@@ -1,0 +1,88 @@
+package redis.clients.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import redis.clients.jedis.BasicCommands;
+import redis.clients.jedis.BinaryJedis;
+import redis.clients.jedis.JedisServerInfo;
+import redis.clients.jedis.exceptions.JedisException;
+
+public class FailSafeJedisCluster {
+
+	private Collection<JedisServerInfo> members = new ArrayList<JedisServerInfo>();
+	private Map<JedisServerInfo, BasicCommands> monitors = new HashMap<JedisServerInfo, BasicCommands>();
+	private JedisServerInfo elected = null;
+
+	public FailSafeJedisCluster(JedisServerInfo... vinfs) {
+		for (JedisServerInfo info : vinfs) {
+			this.members.add(info);
+			BinaryJedis jedis = new BinaryJedis(info.getHost(), info.getPort());
+			if (info.getPassword() != null)
+				jedis.auth(info.getPassword());
+			this.monitors.put(info, jedis);
+		}
+		electNewMaster();
+	}
+
+	public JedisServerInfo getMaster() {
+		return elected;
+	}
+
+	public Collection<JedisServerInfo> getMembers() {
+		return Collections.unmodifiableCollection(members);
+	}
+	
+	public BasicCommands getBasicCommands(JedisServerInfo info) {
+		return monitors.get(info);
+	}
+
+	public synchronized JedisServerInfo electNewMaster() {
+		if (this.elected == null || !eligible(this.elected)) {
+			this.elected = null;
+
+			for (JedisServerInfo m : this.members) {
+				if (eligible(m)) {
+					this.elected = m;
+					return this.elected;
+				}
+			}
+			throw new JedisException("No master is found");
+		}
+		return this.elected;
+	}
+	
+	public synchronized void resetMaster(JedisServerInfo newMaster){
+		if (monitors.get(newMaster) == null)
+			throw new JedisException(newMaster.toString() + " is not member of the cluster");
+		
+		for (JedisServerInfo m : this.members) {
+			BasicCommands jedis = monitors.get(m);
+			if (m == newMaster) {
+				jedis.slaveofNoOne();
+			} else {
+				jedis.slaveof(newMaster.getHost(), newMaster.getPort());
+			}
+		}
+		this.elected = newMaster;
+		
+	}
+
+	private boolean eligible(JedisServerInfo info) {
+		BasicCommands jedis = monitors.get(info);
+		try {
+			for (String line : jedis.info().split("\r\n")) {
+				String[] pair = line.split(":");
+				if (pair.length > 1 && pair[0].equals("role")
+						&& pair[1].equals("master"))
+					return true;
+			}
+		} catch (JedisException e) {
+		}
+		return false;
+	}
+
+}

--- a/src/main/java/redis/clients/util/FailSafeJedisFactory.java
+++ b/src/main/java/redis/clients/util/FailSafeJedisFactory.java
@@ -1,0 +1,52 @@
+package redis.clients.util;
+
+import java.lang.reflect.Proxy;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.pool.BasePoolableObjectFactory;
+
+import redis.clients.jedis.JedisFacade;
+
+public class FailSafeJedisFactory extends BasePoolableObjectFactory {
+	private final Map<Object, FailSafeInvocationHandler> resources;
+	private final FailSafeJedisCluster cluster;
+
+	public FailSafeJedisFactory(FailSafeJedisCluster cluster) {
+		this.cluster = cluster;
+		this.resources = new ConcurrentHashMap<Object, FailSafeInvocationHandler>();
+	}
+
+	public Object makeObject() throws Exception {
+		FailSafeInvocationHandler handler = new FailSafeInvocationHandler(
+				cluster);
+
+		Object proxy = Proxy.newProxyInstance(
+				JedisFacade.class.getClassLoader(),
+				new Class[] { JedisFacade.class }, handler);
+
+		resources.put(proxy, handler);
+
+		return proxy;
+	}
+
+	public void destroyObject(final Object obj) throws Exception {
+		if (obj != null) {
+			FailSafeInvocationHandler handler = resources.get(obj);
+			if (handler != null) {
+				handler.destroyProxy();
+				resources.remove(obj);
+			}
+		}
+	}
+
+	public boolean validateObject(final Object obj) {
+		if (obj != null) {
+			FailSafeInvocationHandler handler = resources.get(obj);
+			if (handler != null) {
+				return handler.validateProxy();
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/redis/clients/util/FailSafeJedisFactory.java
+++ b/src/main/java/redis/clients/util/FailSafeJedisFactory.java
@@ -1,20 +1,15 @@
 package redis.clients.util;
 
 import java.lang.reflect.Proxy;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.apache.commons.pool.BasePoolableObjectFactory;
 
 import redis.clients.jedis.JedisFacade;
 
 public class FailSafeJedisFactory extends BasePoolableObjectFactory {
-	private final Map<Object, FailSafeInvocationHandler> resources;
 	private final FailSafeJedisCluster cluster;
 
 	public FailSafeJedisFactory(FailSafeJedisCluster cluster) {
 		this.cluster = cluster;
-		this.resources = new ConcurrentHashMap<Object, FailSafeInvocationHandler>();
 	}
 
 	public Object makeObject() throws Exception {
@@ -25,27 +20,20 @@ public class FailSafeJedisFactory extends BasePoolableObjectFactory {
 				JedisFacade.class.getClassLoader(),
 				new Class[] { JedisFacade.class }, handler);
 
-		resources.put(proxy, handler);
-
 		return proxy;
 	}
 
 	public void destroyObject(final Object obj) throws Exception {
-		if (obj != null) {
-			FailSafeInvocationHandler handler = resources.get(obj);
-			if (handler != null) {
-				handler.destroyProxy();
-				resources.remove(obj);
-			}
-		}
+		FailSafeInvocationHandler handler = (FailSafeInvocationHandler) Proxy
+				.getInvocationHandler(obj);
+		handler.destroyProxy();
 	}
 
 	public boolean validateObject(final Object obj) {
-		if (obj != null) {
-			FailSafeInvocationHandler handler = resources.get(obj);
-			if (handler != null) {
-				return handler.validateProxy();
-			}
+		JedisFacade jedis = (JedisFacade) obj;
+		try {
+			return "OK".equals(jedis.set("foo", "bar"));
+		} catch (Exception ex) {
 		}
 		return false;
 	}

--- a/src/test/java/redis/clients/jedis/tests/FailSafeJedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/FailSafeJedisPoolTest.java
@@ -1,0 +1,96 @@
+package redis.clients.jedis.tests;
+
+import junit.framework.Assert;
+
+import org.apache.commons.pool.impl.GenericObjectPool.Config;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import redis.clients.jedis.FailSafeJedisPool;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisFacade;
+import redis.clients.jedis.JedisServerInfo;
+import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
+import redis.clients.util.FailSafeJedisCluster;
+
+public class FailSafeJedisPoolTest extends Assert {
+	private final HostAndPort hnp0 = HostAndPortUtil.getRedisServers().get(0);
+	private final HostAndPort hnp1 = HostAndPortUtil.getRedisServers().get(1);
+
+	private Jedis jedis0, jedis1;
+	private FailSafeJedisCluster cluster;
+
+	@Before
+	public void setUp() {
+		jedis0 = new Jedis(hnp0.host, hnp0.port);
+		jedis0.auth("foobared");
+		jedis1 = new Jedis(hnp1.host, hnp1.port);
+		jedis1.auth("foobared");
+
+		cluster = new FailSafeJedisCluster(new JedisServerInfo(hnp0.host,
+				hnp0.port, "foobared"), new JedisServerInfo(hnp1.host,
+				hnp1.port, "foobared"));
+	}
+
+	@After
+	public void tearDown() {
+		jedis0.slaveofNoOne();
+		jedis1.slaveofNoOne();
+
+		jedis0.disconnect();
+		jedis1.disconnect();
+	}
+
+	@Test
+	public void connectionFromPoolShouldWork() {
+		FailSafeJedisPool pool = new FailSafeJedisPool(new Config(), cluster);
+		JedisFacade jedis = pool.getResource();
+
+		jedis.set("foo", "bar");
+		assertEquals("bar", jedis.get("foo"));
+		pool.returnResource(jedis);
+		pool.destroy();
+	}
+
+	@Test
+	public void connectionIsReusedWhenReturned() {
+		Config config = new Config();
+		config.maxActive = 1;
+		FailSafeJedisPool pool = new FailSafeJedisPool(config, cluster);
+		JedisFacade jedisA, jedisB;
+		
+		jedisA = pool.getResource();
+		jedisA.set("foo", "0");
+		pool.returnResource(jedisA);
+
+		jedisB = pool.getResource();
+		jedisB.incr("foo");
+		pool.returnResource(jedisB);
+		
+		assertTrue(jedisA == jedisB);
+		pool.destroy();
+	}
+	
+	@Test
+	public void shouldWorkIfOneServerFails() {
+		Config config = new Config();
+		FailSafeJedisPool pool = new FailSafeJedisPool(config, cluster);		
+		JedisFacade jedis;
+		
+		jedis0.slaveof(hnp1.host, hnp1.port);
+		jedis = pool.getResource();
+		assertEquals("OK", jedis.set("foo", "0"));
+		pool.returnResource(jedis);
+		
+		jedis1.slaveof(hnp0.host, hnp0.port);
+		jedis0.slaveofNoOne();
+		
+		jedis = pool.getResource();
+		assertEquals("OK", jedis.set("foo", "1"));
+		pool.returnResource(jedis);
+
+		pool.destroy();	
+	}
+
+}

--- a/src/test/java/redis/clients/jedis/tests/FailSafeJedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/FailSafeJedisTest.java
@@ -1,0 +1,83 @@
+package redis.clients.jedis.tests;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisCommands;
+import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
+import redis.clients.util.FailSafeJedisCluster;
+import redis.clients.util.FailSafeJedisFactory;
+import redis.clients.jedis.JedisServerInfo;
+
+public class FailSafeJedisTest extends Assert {
+	private final HostAndPort hnp0 = HostAndPortUtil.getRedisServers().get(0);
+	private final HostAndPort hnp1 = HostAndPortUtil.getRedisServers().get(1);
+	
+	private Jedis jedis0, jedis1;
+	
+	@Before
+	public void setUp() {
+		jedis0 = new Jedis(hnp0.host, hnp0.port);
+		jedis0.auth("foobared");
+		jedis1 = new Jedis(hnp1.host, hnp1.port);
+		jedis1.auth("foobared");
+	}
+
+	@After
+	public void tearDown() {
+		jedis0.slaveofNoOne();
+		jedis1.slaveofNoOne();
+
+		jedis0.disconnect();
+		jedis1.disconnect();
+	}
+
+	@Test
+	public void masterInstanceIsElected() {
+		FailSafeJedisCluster cluster = new FailSafeJedisCluster(
+				new JedisServerInfo(hnp0.host, hnp0.port, "foobared"), 
+				new JedisServerInfo(hnp1.host, hnp1.port, "foobared"));
+
+		jedis0.slaveof(hnp1.host, hnp1.port);
+		cluster.electNewMaster();
+		assertEquals(hnp1.host, cluster.getMaster().getHost());
+
+		jedis1.slaveof(hnp0.host, hnp0.port);
+		jedis0.slaveofNoOne();
+		cluster.electNewMaster();
+		assertEquals(hnp0.host, cluster.getMaster().getHost());
+	}
+	
+	@Test
+	public void liveInstanceIsElected() {
+		FailSafeJedisCluster cluster = new FailSafeJedisCluster(
+				new JedisServerInfo(hnp0.host, hnp0.port, "foobared"), 
+				new JedisServerInfo("localhost", 9999, null));
+		assertEquals(hnp0.host, cluster.getMaster().getHost());
+	}
+	 
+	@Test
+	public void aCommandIsExecutedAgainstElectedMaster() throws Exception {
+		FailSafeJedisCluster cluster = new FailSafeJedisCluster(
+				new JedisServerInfo(hnp0.host, hnp0.port, "foobared"), 
+				new JedisServerInfo(hnp1.host, hnp1.port, "foobared"));
+
+		FailSafeJedisFactory factory = new FailSafeJedisFactory(cluster);
+		JedisCommands jedis = (JedisCommands) factory.makeObject();
+		
+		jedis0.slaveof(hnp1.host, hnp1.port);
+		
+		assertEquals("OK", jedis.set("foo", "foo"));
+		assertEquals(hnp1.host, cluster.getMaster().getHost());
+
+		jedis0.slaveofNoOne();
+		jedis1.slaveof(hnp0.host, hnp0.port);
+		assertEquals("OK", jedis.set("bar", "bar"));
+		assertEquals(hnp0.host, cluster.getMaster().getHost());
+		
+	}
+
+}


### PR DESCRIPTION
Hi

I have added a simple implementation of Fail Safe Jedis that can detect if Redis Master fails or has been changed and gracefully switch to the new Master (if there is any) in the context of Redis Master/Slave replication cluster.

We are using this code in one of our project, so if you feel  that it is useful for community please incorporate it into master branch. 

I had an intention to do some refactor to reduce a bit of duplication and rewrite sharding implementation to allow combine sharding with fail safe features but  don´t want to touch the original code base without knowing your opinion first.