### PR TITLE
Execute several TransactionBlock in a unique transaction

### DIFF
--- a/src/main/java/redis/clients/jedis/Queable.java
+++ b/src/main/java/redis/clients/jedis/Queable.java
@@ -4,7 +4,7 @@ import java.util.LinkedList;
 import java.util.Queue;
 
 public class Queable {
-    private Queue<Response<?>> pipelinedResponses = new LinkedList<Response<?>>();
+    protected Queue<Response<?>> pipelinedResponses = new LinkedList<Response<?>>();
 
     protected void clean() {
         pipelinedResponses.clear();

--- a/src/main/java/redis/clients/jedis/TransactionBlockList.java
+++ b/src/main/java/redis/clients/jedis/TransactionBlockList.java
@@ -1,0 +1,36 @@
+package redis.clients.jedis;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import redis.clients.jedis.exceptions.JedisException;
+
+public class TransactionBlockList extends TransactionBlock
+{
+    private List<TransactionBlock> transactionBlocks = new ArrayList<TransactionBlock>();
+
+    public TransactionBlockList(final Client client)
+    {
+        super(client);
+    }
+
+    public TransactionBlockList()
+    {
+    }
+
+    public void add(final TransactionBlock transactionBlock)
+    {
+        if (transactionBlock != null) {
+            transactionBlocks.add(transactionBlock);
+        }
+    }
+
+    @Override
+    public void execute() throws JedisException {
+        for (TransactionBlock transactionBlock : transactionBlocks) {
+            transactionBlock.setClient(client);
+            transactionBlock.execute();
+            pipelinedResponses.addAll(transactionBlock.pipelinedResponses);
+        }
+    }
+}


### PR DESCRIPTION
TransactionBlockList allows the execution of several TransactionBlock in the same Transaction

``` java
TransactionBlock transactionBlockA = new TransactionBlock() {
    @Override
    public void execute() throws JedisException {
        set("A", UUID.randomUUID().toString());
    }
};

TransactionBlock transactionBlockB = new TransactionBlock() {
    @Override
    public void execute() throws JedisException
    {
        set("B", UUID.randomUUID().toString());
        set("C", UUID.randomUUID().toString());
    }
};

TransactionBlockList transactionBlockList = new TransactionBlockList();
transactionBlockList.add(transactionBlockA);
transactionBlockList.add(transactionBlockB);

Jedis redis = new Jedis("localhost");
List<Object> results = redis.multi(transactionBlockList);
redis.disconnect();
```

It is useful, for example, if you have abstracted all the persistence operations of an object in a DAO where all modification methods returns a TransactionBlock and you want to execute several calls in a unique transaction.
