### PR TITLE
Proper sort (with STORE) implementation for multi

### DIFF
--- a/src/main/java/redis/clients/jedis/MultiKeyBinaryRedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/MultiKeyBinaryRedisPipeline.java
@@ -39,9 +39,9 @@ public interface MultiKeyBinaryRedisPipeline {
 
     Response<Long> smove(byte[] srckey, byte[] dstkey, byte[] member);
 
-    Response<List<byte[]>> sort(byte[] key, SortingParams sortingParameters, byte[] dstkey);
+    Response<Long> sort(byte[] key, SortingParams sortingParameters, byte[] dstkey);
 
-    Response<List<byte[]>> sort(byte[] key, byte[] dstkey);
+    Response<Long> sort(byte[] key, byte[] dstkey);
 
     Response<Set<byte[]>> sunion(byte[]... keys);
 

--- a/src/main/java/redis/clients/jedis/MultiKeyCommandsPipeline.java
+++ b/src/main/java/redis/clients/jedis/MultiKeyCommandsPipeline.java
@@ -39,9 +39,9 @@ public interface MultiKeyCommandsPipeline {
 
     Response<Long> smove(String srckey, String dstkey, String member);
 
-    Response<List<String>> sort(String key, SortingParams sortingParameters, String dstkey);
+    Response<Long> sort(String key, SortingParams sortingParameters, String dstkey);
 
-    Response<List<String>> sort(String key, String dstkey);
+    Response<Long> sort(String key, String dstkey);
 
     Response<Set<String>> sunion(String... keys);
 

--- a/src/main/java/redis/clients/jedis/MultiKeyPipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiKeyPipelineBase.java
@@ -160,26 +160,26 @@ abstract class MultiKeyPipelineBase extends PipelineBase implements
         return getResponse(BuilderFactory.LONG);
     }
 
-    public Response<List<String>> sort(String key,
+    public Response<Long> sort(String key,
                                        SortingParams sortingParameters, String dstkey) {
         client.sort(key, sortingParameters, dstkey);
-        return getResponse(BuilderFactory.STRING_LIST);
+        return getResponse(BuilderFactory.LONG);
     }
 
-    public Response<List<byte[]>> sort(byte[] key,
+    public Response<Long> sort(byte[] key,
                                        SortingParams sortingParameters, byte[] dstkey) {
         client.sort(key, sortingParameters, dstkey);
-        return getResponse(BuilderFactory.BYTE_ARRAY_LIST);
+        return getResponse(BuilderFactory.LONG);
     }
 
-    public Response<List<String>> sort(String key, String dstkey) {
+    public Response<Long> sort(String key, String dstkey) {
         client.sort(key, dstkey);
-        return getResponse(BuilderFactory.STRING_LIST);
+        return getResponse(BuilderFactory.LONG);
     }
 
-    public Response<List<byte[]>> sort(byte[] key, byte[] dstkey) {
+    public Response<Long> sort(byte[] key, byte[] dstkey) {
         client.sort(key, dstkey);
-        return getResponse(BuilderFactory.BYTE_ARRAY_LIST);
+        return getResponse(BuilderFactory.LONG);
     }
 
     public Response<Set<String>> sunion(String... keys) {

--- a/src/test/java/redis/clients/jedis/tests/commands/TransactionCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/TransactionCommandsTest.java
@@ -242,7 +242,7 @@ public class TransactionCommandsTest extends JedisCommandTestBase {
         string.get();
         t.exec();
     }
-    
+
     @Test
     public void transactionResponseWithError() {
     	Transaction t = jedis.multi();
@@ -259,7 +259,7 @@ public class TransactionCommandsTest extends JedisCommandTestBase {
         }
         assertEquals(r.get(), "bar");
     }
-    
+
     @Test
     public void execGetResponse() {
         Transaction t = jedis.multi();
@@ -277,7 +277,7 @@ public class TransactionCommandsTest extends JedisCommandTestBase {
         }
         assertEquals("bar", lr.get(2).get());
     }
-    
+
     @Test
     public void select() {
         jedis.select(1);
@@ -286,13 +286,27 @@ public class TransactionCommandsTest extends JedisCommandTestBase {
         Transaction t = jedis.multi();
         t.select(0);
         t.set("bar", "foo");
-        
+
         Jedis jedis2 = createJedis();
         jedis2.select(1);
         jedis2.set("foo", "bar2");
-        
+
         List<Object> results = t.exec();
-        
+
         assertNull(results);
     }
+
+    @Test
+    public void sort(){
+      jedis.sadd("foo", "2", "1", "3");
+
+      Transaction t = jedis.multi();
+      t.sort("foo", "bar");
+      t.lrange("bar", 0, 3);
+
+      List<Object> results = t.exec();
+
+      assertEquals(Arrays.asList("1", "2", "3"), results.get(1));
+    }
+
 }

--- a/src/test/java/redis/clients/jedis/tests/commands/TransactionCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/TransactionCommandsTest.java
@@ -305,7 +305,6 @@ public class TransactionCommandsTest extends JedisCommandTestBase {
       t.lrange("bar", 0, 3);
 
       List<Object> results = t.exec();
-
       assertEquals(Arrays.asList("1", "2", "3"), results.get(1));
     }
 


### PR DESCRIPTION
Currently sort with a dstkey inside a multi() transaction raises an exception (java.lang.ClassCastException: java.lang.Long cannot be cast to java.util.List) as redis returns a Long as the response, but jedis is expecting it to return a Set of Strings. Updated this to work correctly - first commit adds a failing test showing the problem, second commit makes that test pass.  



