### PR TITLE
When writing a negative sign the write(char) method goes directly to the...

### DIFF
--- a/src/main/java/redis/clients/util/RedisOutputStream.java
+++ b/src/main/java/redis/clients/util/RedisOutputStream.java
@@ -187,7 +187,7 @@ public final class RedisOutputStream extends FilterOutputStream {
 
     public void writeIntCrLf(int value) throws IOException {
         if (value < 0) {
-            write('-');
+            write((byte)'-');
             value = -value;
         }
 


### PR DESCRIPTION
... output stream and by-passes the internal RedisOutputStream buffer causing random corruption of the output.  Casting the char to a byte ensures write(byte) is called which will properly buffer the output.
