### PR TITLE
Fix sentinel test by making redis2 instance slave of redis1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ daemonize yes
 port 6380
 requirepass foobared
 pidfile /tmp/redis2.pid
+slaveof 127.0.0.1 6379
 endef
 
 


### PR DESCRIPTION
All tests pased against latest redis master.

Redis server v=2.9.9 sha=b237de33:0 malloc=jemalloc-3.2.0 bits=64 build=9847765dc0700d77
