### PR TITLE
Make JedisByteHashMap entries Serializable

### DIFF
--- a/src/main/java/redis/clients/util/JedisByteHashMap.java
+++ b/src/main/java/redis/clients/util/JedisByteHashMap.java
@@ -88,8 +88,9 @@ public class JedisByteHashMap implements Map<byte[], byte[]>, Cloneable,
         return internalMap.values();
     }
 
-    private static final class ByteArrayWrapper {
-        private final byte[] data;
+    private static final class ByteArrayWrapper implements Serializable {
+		private static final long serialVersionUID = 1L;
+		private final byte[] data;
 
         public ByteArrayWrapper(byte[] data) {
             if (data == null) {

--- a/src/test/java/redis/clients/util/JedisByteHashMapTest.java
+++ b/src/test/java/redis/clients/util/JedisByteHashMapTest.java
@@ -1,0 +1,28 @@
+package redis.clients.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.junit.Test;
+
+public class JedisByteHashMapTest {
+	@Test
+	public void canSerializeEmptyJedisByteHashMap() throws Exception {
+		JedisByteHashMap map = new JedisByteHashMap();
+		serializeAndDeserialize(map);
+	}
+
+	private void serializeAndDeserialize(JedisByteHashMap map) throws IOException,
+			ClassNotFoundException {
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream);
+		objectOutputStream.writeObject(map);
+		ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+		ObjectInputStream objectInputStream = new ObjectInputStream(inputStream);
+		objectInputStream.readObject();
+	}
+	
+}

--- a/src/test/java/redis/clients/util/JedisByteHashMapTest.java
+++ b/src/test/java/redis/clients/util/JedisByteHashMapTest.java
@@ -14,6 +14,13 @@ public class JedisByteHashMapTest {
 		JedisByteHashMap map = new JedisByteHashMap();
 		serializeAndDeserialize(map);
 	}
+	
+	@Test
+	public void canSerializeJedisByteHashMapWithOneEntry() throws Exception {
+		JedisByteHashMap map = new JedisByteHashMap();
+		map.put(new byte[]{1}, new byte[]{1});
+		serializeAndDeserialize(map);
+	}
 
 	private void serializeAndDeserialize(JedisByteHashMap map) throws IOException,
 			ClassNotFoundException {


### PR DESCRIPTION
As far as I can see it makes no sense for the JedisByteHashMap to be Serializable if its entries are not?
(I hit this when attempting to use the output of Jedis.hgetAll(byte[]) in a wicket page, which has to be serializable)
