### PR TITLE
Support for new 'set' API (redis 2.6.12+)

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -1,26 +1,22 @@
 package redis.clients.jedis;
 
-import static redis.clients.jedis.Protocol.toByteArray;
-import static redis.clients.jedis.Protocol.Command.*;
-import static redis.clients.jedis.Protocol.Keyword.ENCODING;
-import static redis.clients.jedis.Protocol.Keyword.IDLETIME;
-import static redis.clients.jedis.Protocol.Keyword.LEN;
-import static redis.clients.jedis.Protocol.Keyword.LIMIT;
-import static redis.clients.jedis.Protocol.Keyword.NO;
-import static redis.clients.jedis.Protocol.Keyword.ONE;
-import static redis.clients.jedis.Protocol.Keyword.REFCOUNT;
-import static redis.clients.jedis.Protocol.Keyword.RESET;
-import static redis.clients.jedis.Protocol.Keyword.STORE;
-import static redis.clients.jedis.Protocol.Keyword.WITHSCORES;
+import redis.clients.jedis.Protocol.Command;
+import redis.clients.jedis.Protocol.Keyword;
+import redis.clients.util.SafeEncoder;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import redis.clients.jedis.Protocol.Command;
-import redis.clients.jedis.Protocol.Keyword;
-import redis.clients.util.SafeEncoder;
+import static redis.clients.jedis.Protocol.Command.*;
+import static redis.clients.jedis.Protocol.Command.EXISTS;
+import static redis.clients.jedis.Protocol.Command.PSUBSCRIBE;
+import static redis.clients.jedis.Protocol.Command.PUNSUBSCRIBE;
+import static redis.clients.jedis.Protocol.Command.SUBSCRIBE;
+import static redis.clients.jedis.Protocol.Command.UNSUBSCRIBE;
+import static redis.clients.jedis.Protocol.Keyword.*;
+import static redis.clients.jedis.Protocol.toByteArray;
 
 public class BinaryClient extends Connection {
     public enum LIST_POSITION {
@@ -85,6 +81,11 @@ public class BinaryClient extends Connection {
     public void set(final byte[] key, final byte[] value) {
 	sendCommand(Command.SET, key, value);
     }
+
+    public void set(final byte[] key, final byte[] value, final byte[] nxxx, final byte[] expx, final long time) {
+        sendCommand(Command.SET, key, value, nxxx, expx, toByteArray(time));
+    }
+
 
     public void get(final byte[] key) {
 	sendCommand(Command.GET, key);

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -1,21 +1,15 @@
 package redis.clients.jedis;
 
-import static redis.clients.jedis.Protocol.toByteArray;
-
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import redis.clients.jedis.BinaryClient.LIST_POSITION;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.util.JedisByteHashMap;
 import redis.clients.util.SafeEncoder;
+
+import java.net.URI;
+import java.util.*;
+
+import static redis.clients.jedis.Protocol.toByteArray;
 
 public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKeyBinaryCommands, AdvancedBinaryJedisCommands, BinaryScriptingCommands {
     protected Client client = null;
@@ -76,6 +70,23 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 	checkIsInMulti();
 	client.set(key, value);
 	return client.getStatusCodeReply();
+    }
+
+    /**
+     * Set the string value as value of the key. The string can't be longer than
+     * 1073741824 bytes (1 GB).
+     * @param key
+     * @param value
+     * @param nxxx NX|XX, NX -- Only set the key if it does not already exist.
+     *                    XX -- Only set the key if it already exist.
+     * @param expx EX|PX, expire time units: EX = seconds; PX = milliseconds
+     * @param time expire time in the units of {@param #expx}
+     * @return Status code reply
+     */
+    public String set(final byte[] key, final byte[] value, final byte[] nxxx, final byte[] expx, final long time) {
+        checkIsInMulti();
+        client.set(key, value, nxxx, expx, time);
+        return client.getStatusCodeReply();
     }
 
     /**

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -1,12 +1,12 @@
 package redis.clients.jedis;
 
-import static redis.clients.jedis.Protocol.toByteArray;
+import redis.clients.util.SafeEncoder;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import redis.clients.util.SafeEncoder;
+import static redis.clients.jedis.Protocol.toByteArray;
 
 public class Client extends BinaryClient implements Commands {
     public Client(final String host) {
@@ -19,6 +19,10 @@ public class Client extends BinaryClient implements Commands {
 
     public void set(final String key, final String value) {
 	set(SafeEncoder.encode(key), SafeEncoder.encode(value));
+    }
+
+    public void set(final String key, final String value, final String nxxx, final String expx, final long time) {
+        set(SafeEncoder.encode(key), SafeEncoder.encode(value), SafeEncoder.encode(nxxx), SafeEncoder.encode(expx), time);
     }
 
     public void get(final String key) {

--- a/src/main/java/redis/clients/jedis/Commands.java
+++ b/src/main/java/redis/clients/jedis/Commands.java
@@ -1,12 +1,14 @@
 package redis.clients.jedis;
 
-import java.util.Map;
-
 import redis.clients.jedis.BinaryClient.LIST_POSITION;
+
+import java.util.Map;
 
 public interface Commands {
 
     public void set(final String key, final String value);
+
+    public void set(final String key, final String value, final String nxxx, final String expx, final long time);
 
     public void get(final String key);
 

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -1,18 +1,11 @@
 package redis.clients.jedis;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import redis.clients.jedis.BinaryClient.LIST_POSITION;
 import redis.clients.util.SafeEncoder;
 import redis.clients.util.Slowlog;
+
+import java.net.URI;
+import java.util.*;
 
 public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommands, AdvancedJedisCommands, ScriptingCommands {
     public Jedis(final String host) {
@@ -49,6 +42,23 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
 	checkIsInMulti();
 	client.set(key, value);
 	return client.getStatusCodeReply();
+    }
+
+    /**
+     * Set the string value as value of the key. The string can't be longer than
+     * 1073741824 bytes (1 GB).
+     * @param key
+     * @param value
+     * @param nxxx NX|XX, NX -- Only set the key if it does not already exist.
+     *                    XX -- Only set the key if it already exist.
+     * @param expx EX|PX, expire time units: EX = seconds; PX = milliseconds
+     * @param time expire time in the units of {@param #expx}
+     * @return Status code reply
+     */
+    public String set(final String key, final String value, final String nxxx, final String expx, final long time) {
+        checkIsInMulti();
+        client.set(key, value, nxxx, expx, time);
+        return client.getStatusCodeReply();
     }
 
     /**

--- a/src/main/java/redis/clients/jedis/JedisCommands.java
+++ b/src/main/java/redis/clients/jedis/JedisCommands.java
@@ -7,7 +7,8 @@ import java.util.Set;
 /**
  * Common interface for sharded and non-sharded Jedis
  */
-public interface JedisCommands {
+public interface
+        JedisCommands {
     String set(String key, String value);
 
     String get(String key);

--- a/src/test/java/redis/clients/jedis/tests/commands/JedisCommandTestBase.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/JedisCommandTestBase.java
@@ -1,18 +1,17 @@
 package redis.clients.jedis.tests.commands;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ComparisonFailure;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.tests.HostAndPortUtil;
+import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
+import redis.clients.jedis.tests.JedisTestBase;
+
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ComparisonFailure;
-
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.tests.HostAndPortUtil;
-import redis.clients.jedis.tests.JedisTestBase;
-import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
 
 public abstract class JedisCommandTestBase extends JedisTestBase {
     protected static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);


### PR DESCRIPTION
I have added support for the new "set" command (https://github.com/antirez/redis/blob/unstable/src/t_string.c) that has the following args:
SET key value [NX] [XX] [EX <seconds>] [PX <milliseconds>]

see further details http://redis.io/commands/set

Tell me if the IntelliJ import formatting changes are annoying/should be avoided.

Thanks !
