### PR TITLE
JedisFactory selects database to the one in its configuration before the instance is borrowed from the pool

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -103,6 +103,17 @@ public class JedisPool extends Pool<Jedis> {
             
             return jedis;
         }
+        
+        @Override
+        public void activateObject(Object obj) throws Exception {
+            if (!(obj instanceof Jedis)) {
+        	throw new IllegalArgumentException("activated object is not a Jedis instance");
+            }
+            final Jedis jedis = (Jedis)obj;
+            if (jedis.getDB() != database) {
+        	jedis.select(database);
+            }
+        }
 
         public void destroyObject(final Object obj) throws Exception {
             if (obj instanceof Jedis) {

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
@@ -150,4 +150,23 @@ public class JedisPoolTest extends Assert {
 	assertEquals("PONG", jedis.ping());
 	assertEquals("bar", jedis.get("foo"));
     }
+    
+    @Test
+    public void selectDatabaseOnActivation() {
+        JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.host,
+                hnp.port, 2000, "foobared");
+        
+        Jedis jedis0 = pool.getResource();
+        assertEquals(0L, jedis0.getDB().longValue());
+        jedis0.select(1);
+        assertEquals(1L, jedis0.getDB().longValue());
+        pool.returnResource(jedis0);
+        
+        Jedis jedis1 = pool.getResource();
+        assertTrue("Jedis instance was not reused", jedis1 == jedis0);
+        assertEquals(0L, jedis1.getDB().longValue());
+        pool.returnResource(jedis1);
+        
+        pool.destroy();
+    }
 }


### PR DESCRIPTION
Right now Jedis instances are reused by the pool. If the Redis database is changed using the SELECT command and then returned to the pool, the next time it is borrowed from the pool again the database is not the one configured for the pool.

To fix this, [activateObject method](http://commons.apache.org/proper/commons-pool/api-1.5.7/org/apache/commons/pool/PoolableObjectFactory.html#activateObject%28java.lang.Object%29) is implemented in JedisFactory. It will reset the Redis database back to the one configured for the pool if the current database is different.
