### PR TITLE
Zadd Fixed:     It allows adding multiple members with the same score at the same time

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -393,6 +393,26 @@ public class BinaryClient extends Connection {
 
 	sendCommand(ZADD, argsArray);
     }
+    
+    
+    public void zaddBinaryFixed(final byte[] key, Map< byte[],Double> scoreMembers) {
+		ArrayList<byte[]> args = new ArrayList<byte[]>(
+				scoreMembers.size() * 2 + 1);
+
+		args.add(key);
+
+		for (Map.Entry<byte[],Double > entry : scoreMembers.entrySet()) {
+			args.add(toByteArray(entry.getValue()));
+			args.add(entry.getKey());
+			
+		}
+
+		byte[][] argsArray = new byte[args.size()][];
+		args.toArray(argsArray);
+
+		sendCommand(ZADD, argsArray);
+	}   
+    
 
     public void zrange(final byte[] key, final long start, final long end) {
 	sendCommand(ZRANGE, key, toByteArray(start), toByteArray(end));

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -719,6 +719,17 @@ public class Client extends BinaryClient implements Commands {
 
 	zaddBinary(SafeEncoder.encode(key), binaryScoreMembers);
     }
+    
+    public void zaddFixed(String key, Map<String, Double> scoreMembers) {
+		HashMap<byte[], Double> binaryScoreMembers = new HashMap<byte[], Double>();
+
+		for (Map.Entry<String, Double> entry : scoreMembers.entrySet()) {
+			binaryScoreMembers.put(SafeEncoder.encode(entry.getKey()),
+					entry.getValue());
+		}
+		zaddBinaryFixed(SafeEncoder.encode(key), binaryScoreMembers);
+	}
+
 
     public void objectRefcount(String key) {
 	objectRefcount(SafeEncoder.encode(key));

--- a/src/main/java/redis/clients/jedis/Commands.java
+++ b/src/main/java/redis/clients/jedis/Commands.java
@@ -144,6 +144,8 @@ public interface Commands {
     public void zadd(final String key, final double score, final String member);
 
     public void zadd(final String key, final Map<Double, String> scoreMembers);
+    
+    public void zaddFixed(final String key, final Map<String,Double > scoreMembers); 
 
     public void zrange(final String key, final long start, final long end);
 

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -1411,6 +1411,12 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
 	client.zadd(key, scoreMembers);
 	return client.getIntegerReply();
     }
+    
+    public Long zaddFixed(final String key, final Map<String, Double> scoreMembers) {
+    checkIsInMulti();
+    client.zaddFixed(key, scoreMembers);
+    return client.getIntegerReply();
+    }
 
     public Set<String> zrange(final String key, final long start, final long end) {
 	checkIsInMulti();

--- a/src/main/java/redis/clients/jedis/JedisCommands.java
+++ b/src/main/java/redis/clients/jedis/JedisCommands.java
@@ -116,6 +116,8 @@ public interface
     Long zadd(String key, double score, String member);
     
     Long zadd(String key, Map<Double, String> scoreMembers);
+    
+    Long zaddFixed(String key, Map<String,Double > scoreMembers); 
 
     Set<String> zrange(String key, long start, long end);
 

--- a/src/main/java/redis/clients/jedis/ShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedis.java
@@ -325,6 +325,12 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands {
 	Jedis j = getShard(key);
 	return j.zadd(key, score, member);
     }
+    
+    public Long zaddFixed(String key, Map<String, Double> scoreMembers) {
+    Jedis j = getShard(key);
+    return j.zaddFixed(key, scoreMembers);
+    } 
+
 
     public Long zadd(String key, Map<Double, String> scoreMembers) {
 	Jedis j = getShard(key);

--- a/src/test/java/redis/clients/jedis/tests/commands/ZaddCommandTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ZaddCommandTest.java
@@ -1,0 +1,95 @@
+package redis.clients.jedis.tests.commands;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import redis.clients.jedis.Jedis;
+
+public class ZaddCommandTest extends JedisCommandTestBase {
+final byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };
+final byte[] bbar = { 0x05, 0x06, 0x07, 0x08 };
+final byte[] bcar = { 0x09, 0x0A, 0x0B, 0x0C };
+final byte[] ba = { 0x0A };
+final byte[] bb = { 0x0B };
+final byte[] bc = { 0x0C };
+
+@Before
+@Override
+public void setUp() throws Exception {
+jedis = new Jedis(hnp.host, hnp.port, 500);
+jedis.connect();
+jedis.auth("foobared");
+jedis.configSet("timeout", "300");
+jedis.flushAll();
+}
+@After
+    public void tearDown() {
+
+        jedis.disconnect();
+    }
+
+@Test
+public void zadd() {
+long status = jedis.zadd("foo", 1d, "a");
+assertEquals(1, status);
+
+status = jedis.zadd("foo", 10d, "b");
+assertEquals(1, status);
+
+status = jedis.zadd("foo", 0.1d, "c");
+assertEquals(1, status);
+
+status = jedis.zadd("foo", 2d, "a");
+assertEquals(0, status);
+
+// Binary
+// long bstatus = jedis.zadd(bfoo, 1d, ba);
+// assertEquals(1, bstatus);
+//
+// bstatus = jedis.zadd(bfoo, 10d, bb);
+// assertEquals(1, bstatus);
+//
+// bstatus = jedis.zadd(bfoo, 0.1d, bc);
+// assertEquals(1, bstatus);
+//
+// bstatus = jedis.zadd(bfoo, 2d, ba);
+// assertEquals(0, bstatus);
+
+}
+
+/**
+* Test to prove that with the current Jedis interface is impossible to add two different
+* members with the same score in a single command. This is possible with Redis commands
+*/
+@Test
+public void zaddAll() {
+Map<Double,String> scoreMembers=new HashMap<Double, String>();
+scoreMembers.put(1D, "member_a");
+scoreMembers.put(1D, "member_b");
+        jedis.zadd("foo", scoreMembers);	
+        assertEquals(1, jedis.zcard("foo").longValue());
+        
+
+}
+
+/**
+* Test to prove that with the "fixed" Jedis interface is possible to add two different
+* members with the same score in a single command.
+*/
+@Test
+public void zaddAllFixed() {
+Map<String,Double> scoreMembers=new HashMap<String,Double >();
+scoreMembers.put("member_a",1D );
+scoreMembers.put("member_b",1D );
+        jedis.zaddFixed("foo", scoreMembers);	
+        assertEquals(2, jedis.zcard("foo").longValue());
+        
+
+}
+
+}
+


### PR DESCRIPTION
Hello,
as asked in the previous pull request from the branch zadd-map-fixed I've created a new commit without white spaces and pushed in the branch zadd-map-fixed-clean. Hope this can give you the possibility to evaluate this fix and introduce it in a future release of jedis. 
ZaddCommandTest explain the problem and explain the solution.
