### PR TITLE
Allow JedisPool to set a custom client name

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisFactory.java
@@ -11,15 +11,21 @@ class JedisFactory extends BasePoolableObjectFactory {
     private final int timeout;
     private final String password;
     private final int database;
+    private final String clientName;
 
     public JedisFactory(final String host, final int port,
-            final int timeout, final String password, final int database) {
+                final int timeout, final String password, final int database) {
+        this(host, port, timeout, password, database, null);
+    }
+    public JedisFactory(final String host, final int port,
+            final int timeout, final String password, final int database, final String clientName) {
         super();
         this.host = host;
         this.port = port;
         this.timeout = timeout;
         this.password = password;
         this.database = database;
+        this.clientName = clientName;
     }
 
     public Object makeObject() throws Exception {
@@ -32,10 +38,13 @@ class JedisFactory extends BasePoolableObjectFactory {
         if( database != 0 ) {
             jedis.select(database);
         }
-        
+        if ( clientName != null ) {
+            jedis.clientSetname(clientName);
+        }
+
         return jedis;
     }
-    
+
     @Override
     public void activateObject(Object obj) throws Exception {
 		if (obj instanceof Jedis) {

--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -10,11 +10,11 @@ import redis.clients.util.Pool;
 public class JedisPool extends Pool<Jedis> {
 
     public JedisPool(final Config poolConfig, final String host) {
-        this(poolConfig, host, Protocol.DEFAULT_PORT, Protocol.DEFAULT_TIMEOUT, null, Protocol.DEFAULT_DATABASE);
+        this(poolConfig, host, Protocol.DEFAULT_PORT, Protocol.DEFAULT_TIMEOUT, null, Protocol.DEFAULT_DATABASE, null);
     }
 
     public JedisPool(String host, int port) {
-        this(new Config(), host, port, Protocol.DEFAULT_TIMEOUT, null, Protocol.DEFAULT_DATABASE);
+        this(new Config(), host, port, Protocol.DEFAULT_TIMEOUT, null, Protocol.DEFAULT_DATABASE, null);
     }
 
     public JedisPool(final String host) {
@@ -25,11 +25,11 @@ public class JedisPool extends Pool<Jedis> {
 	    String password = uri.getUserInfo().split(":", 2)[1];
 	    int database = Integer.parseInt(uri.getPath().split("/", 2)[1]);
 	    this.internalPool = new GenericObjectPool(new JedisFactory(h, port,
-		    Protocol.DEFAULT_TIMEOUT, password, database), new Config());
+		    Protocol.DEFAULT_TIMEOUT, password, database, null), new Config());
 	} else {
 	    this.internalPool = new GenericObjectPool(new JedisFactory(host,
 		    Protocol.DEFAULT_PORT, Protocol.DEFAULT_TIMEOUT, null,
-		    Protocol.DEFAULT_DATABASE), new Config());
+		    Protocol.DEFAULT_DATABASE, null), new Config());
 	}
     }
 
@@ -39,33 +39,38 @@ public class JedisPool extends Pool<Jedis> {
 	String password = uri.getUserInfo().split(":", 2)[1];
 	int database = Integer.parseInt(uri.getPath().split("/", 2)[1]);
 	this.internalPool = new GenericObjectPool(new JedisFactory(h, port,
-		Protocol.DEFAULT_TIMEOUT, password, database), new Config());
+		Protocol.DEFAULT_TIMEOUT, password, database, null), new Config());
     }
-    
+
     public JedisPool(final Config poolConfig, final String host, int port,
             int timeout, final String password) {
-        this(poolConfig, host, port, timeout, password, Protocol.DEFAULT_DATABASE);
+        this(poolConfig, host, port, timeout, password, Protocol.DEFAULT_DATABASE, null);
     }
 
     public JedisPool(final Config poolConfig, final String host, final int port) {
-        this(poolConfig, host, port, Protocol.DEFAULT_TIMEOUT, null, Protocol.DEFAULT_DATABASE);
+        this(poolConfig, host, port, Protocol.DEFAULT_TIMEOUT, null, Protocol.DEFAULT_DATABASE, null);
     }
 
     public JedisPool(final Config poolConfig, final String host, final int port, final int timeout) {
-        this(poolConfig, host, port, timeout, null, Protocol.DEFAULT_DATABASE);
+        this(poolConfig, host, port, timeout, null, Protocol.DEFAULT_DATABASE, null);
     }
 
     public JedisPool(final Config poolConfig, final String host, int port, int timeout, final String password,
-                     final int database) {
-        super(poolConfig, new JedisFactory(host, port, timeout, password, database));
+                        final int database) {
+        this(poolConfig, host, port, timeout, password, database, null);
+    }
+
+    public JedisPool(final Config poolConfig, final String host, int port, int timeout, final String password,
+                     final int database, final String clientName) {
+        super(poolConfig, new JedisFactory(host, port, timeout, password, database, clientName));
     }
 
 
     public void returnBrokenResource(final BinaryJedis resource) {
     	returnBrokenResourceObject(resource);
     }
-    
+
     public void returnResource(final BinaryJedis resource) {
     	returnResourceObject(resource);
-    }   
+    }
 }

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
@@ -117,7 +117,7 @@ public class JedisPoolTest extends Assert {
         pool1.returnResource(jedis0);
         pool1.destroy();
     }
-    
+
     @Test
     public void returnBinary() {
         JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.host,
@@ -126,7 +126,7 @@ public class JedisPoolTest extends Assert {
         pool.returnResource(jedis);
         pool.destroy();
     }
-    
+
     @Test
     public void startWithUrlString() {
 	Jedis j = new Jedis("localhost", 6380);
@@ -138,7 +138,7 @@ public class JedisPoolTest extends Assert {
 	assertEquals("PONG", jedis.ping());
 	assertEquals("bar", jedis.get("foo"));
     }
-    
+
     @Test
     public void startWithUrl() throws URISyntaxException {
 	Jedis j = new Jedis("localhost", 6380);
@@ -149,5 +149,18 @@ public class JedisPoolTest extends Assert {
 	Jedis jedis = pool.getResource();
 	assertEquals("PONG", jedis.ping());
 	assertEquals("bar", jedis.get("foo"));
+    }
+
+    @Test
+    public void customClientName() {
+        JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.host,
+                        hnp.port, 2000, "foobared", 0, "my_shiny_client_name");
+
+        Jedis jedis = pool0.getResource();
+
+        assertEquals("my_shiny_client_name", jedis.clientGetname());
+
+        pool0.returnResource(jedis);
+        pool0.destroy();
     }
 }


### PR DESCRIPTION
First and foremost, please excuse the funky formatting.  I tried to match style as best I could, but the source mixes tabs and spaces, so kind of hard.

Moving on, this PR allows you to specify a client name when configuring a JedisPool.

You can see the new usage in the accompanying test.

I only set the client name when we first make the object, and not when we activate it since it seems like there is not a valid use case for a loanee of a client to set the client name directly just for that one usage (unlike .select() which does have use cases).

I also think it would be interesting at some point to expose JedisPool creation through a Builder object, since half of those classes (JedisPool, Pool, and JedisFactory) are constructor defs.

Thanks again for the great project, it's been rock solid for us!
