### PR TITLE
Parse infinity when returned by redis

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -4,6 +4,7 @@ import redis.clients.jedis.BinaryClient.LIST_POSITION;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.util.JedisByteHashMap;
+import redis.clients.util.Parser;
 import redis.clients.util.SafeEncoder;
 
 import java.net.URI;
@@ -1565,7 +1566,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 	checkIsInMulti();
 	client.zincrby(key, score, member);
 	String newscore = client.getBulkReply();
-	return Double.valueOf(newscore);
+	return Parser.parseRedisDouble(newscore);
     }
 
     /**
@@ -2417,8 +2418,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 	Set<Tuple> set = new LinkedHashSet<Tuple>();
 	Iterator<byte[]> iterator = membersWithScores.iterator();
 	while (iterator.hasNext()) {
-	    set.add(new Tuple(iterator.next(), Double.valueOf(SafeEncoder
-		    .encode(iterator.next()))));
+	    set.add(new Tuple(iterator.next(), BuilderFactory.DOUBLE.build(iterator.next())));
 	}
 	return set;
     }

--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -8,7 +8,15 @@ public class BuilderFactory {
     public static final Builder<Double> DOUBLE = new Builder<Double>() {
         public Double build(Object data) {
             String asString = STRING.build(data);
-            return asString == null ? null : Double.valueOf(asString);
+            if (asString == null) {
+                return null;
+            } else if (asString.equals("+inf") || asString.equals("inf")) {
+                return Double.POSITIVE_INFINITY;
+            } else if (asString.equals("-inf")) {
+                return Double.NEGATIVE_INFINITY;
+            } else {
+                return Double.valueOf(asString);
+            }
         }
 
         public String toString() {
@@ -211,8 +219,7 @@ public class BuilderFactory {
             final Set<Tuple> result = new LinkedHashSet<Tuple>(l.size());
             Iterator<byte[]> iterator = l.iterator();
             while (iterator.hasNext()) {
-                result.add(new Tuple(SafeEncoder.encode(iterator.next()),
-                        Double.valueOf(SafeEncoder.encode(iterator.next()))));
+                result.add(new Tuple(SafeEncoder.encode(iterator.next()), DOUBLE.build(iterator.next())));
             }
             return result;
         }
@@ -233,8 +240,7 @@ public class BuilderFactory {
             final Set<Tuple> result = new LinkedHashSet<Tuple>(l.size());
             Iterator<byte[]> iterator = l.iterator();
             while (iterator.hasNext()) {
-                result.add(new Tuple(iterator.next(), Double
-                        .valueOf(SafeEncoder.encode(iterator.next()))));
+                result.add(new Tuple(iterator.next(), DOUBLE.build(iterator.next())));
             }
 
             return result;

--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -1,22 +1,16 @@
 package redis.clients.jedis;
 
+import redis.clients.util.Parser;
 import redis.clients.util.SafeEncoder;
 
 import java.util.*;
 
 public class BuilderFactory {
+
     public static final Builder<Double> DOUBLE = new Builder<Double>() {
         public Double build(Object data) {
             String asString = STRING.build(data);
-            if (asString == null) {
-                return null;
-            } else if (asString.equals("+inf") || asString.equals("inf")) {
-                return Double.POSITIVE_INFINITY;
-            } else if (asString.equals("-inf")) {
-                return Double.NEGATIVE_INFINITY;
-            } else {
-                return Double.valueOf(asString);
-            }
+            return asString == null ? null : Parser.parseRedisDouble(asString);
         }
 
         public String toString() {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis;
 
 import redis.clients.jedis.BinaryClient.LIST_POSITION;
+import redis.clients.util.Parser;
 import redis.clients.util.SafeEncoder;
 import redis.clients.util.Slowlog;
 
@@ -1469,7 +1470,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
 	checkIsInMulti();
 	client.zincrby(key, score, member);
 	String newscore = client.getBulkReply();
-	return Double.valueOf(newscore);
+	return Parser.parseRedisDouble(newscore);
     }
 
     /**
@@ -2252,7 +2253,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
 	Set<Tuple> set = new LinkedHashSet<Tuple>();
 	Iterator<String> iterator = membersWithScores.iterator();
 	while (iterator.hasNext()) {
-	    set.add(new Tuple(iterator.next(), Double.valueOf(iterator.next())));
+	    set.add(new Tuple(iterator.next(), Parser.parseRedisDouble(iterator.next())));
 	}
 	return set;
     }

--- a/src/main/java/redis/clients/util/Parser.java
+++ b/src/main/java/redis/clients/util/Parser.java
@@ -1,0 +1,19 @@
+package redis.clients.util;
+
+public class Parser {
+    /**
+     * Returns a double parsed from a redis string representation of a double. Handles parsing +inf and -inf as
+     * POSITIVE_INFINITY and NEGATIVE_INFINITY respectively, which Double.valueOf doesn't handle.
+     *
+     * @throws NumberFormatException if the string isn't parsable as a double
+     */
+    public static Double parseRedisDouble(String redisDouble) {
+        if (redisDouble.equals("+inf") || redisDouble.equals("inf")) {
+            return Double.POSITIVE_INFINITY;
+        } else if (redisDouble.equals("-inf")) {
+            return Double.NEGATIVE_INFINITY;
+        } else {
+            return Double.valueOf(redisDouble);
+        }
+    }
+}

--- a/src/test/java/redis/clients/jedis/tests/BuilderFactoryTest.java
+++ b/src/test/java/redis/clients/jedis/tests/BuilderFactoryTest.java
@@ -11,4 +11,14 @@ public class BuilderFactoryTest extends Assert {
         Double build = BuilderFactory.DOUBLE.build("1.0".getBytes());
         assertEquals(new Double(1.0), build);
     }
+
+    @Test
+    public void buildInfinities() {
+        Double build = BuilderFactory.DOUBLE.build("-inf".getBytes());
+        assertEquals(new Double(Double.NEGATIVE_INFINITY), build);
+        build = BuilderFactory.DOUBLE.build("inf".getBytes());
+        assertEquals(new Double(Double.POSITIVE_INFINITY), build);
+        build = BuilderFactory.DOUBLE.build("+inf".getBytes());
+        assertEquals(new Double(Double.POSITIVE_INFINITY), build);
+    }
 }

--- a/src/test/java/redis/clients/jedis/tests/commands/SortedSetCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/SortedSetCommandsTest.java
@@ -16,6 +16,8 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
     final byte[] ba = { 0x0A };
     final byte[] bb = { 0x0B };
     final byte[] bc = { 0x0C };
+    final byte[] bd = { 0x0D };
+    final byte[] be = { 0x0E };
 
     @Test
     public void zadd() {
@@ -26,6 +28,9 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
         assertEquals(1, status);
 
         status = jedis.zadd("foo", 0.1d, "c");
+        assertEquals(1, status);
+
+        status = jedis.zadd("foo", Double.NEGATIVE_INFINITY, "d");
         assertEquals(1, status);
 
         status = jedis.zadd("foo", 2d, "a");
@@ -39,6 +44,9 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
         assertEquals(1, bstatus);
 
         bstatus = jedis.zadd(bfoo, 0.1d, bc);
+        assertEquals(1, bstatus);
+
+        bstatus = jedis.zadd(bfoo, Double.NEGATIVE_INFINITY, bd);
         assertEquals(1, bstatus);
 
         bstatus = jedis.zadd(bfoo, 2d, ba);
@@ -169,6 +177,11 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
         assertEquals(3d, score, 0);
         assertEquals(expected, jedis.zrange("foo", 0, 100));
 
+
+        jedis.zadd("foo", Double.POSITIVE_INFINITY, "p");
+        score = jedis.zincrby("foo", 2d, "p");
+        assertEquals(Double.POSITIVE_INFINITY, score, 0);
+
         // Binary
         jedis.zadd(bfoo, 1d, ba);
         jedis.zadd(bfoo, 2d, bb);
@@ -181,6 +194,10 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
 
         assertEquals(3d, bscore, 0);
         assertEquals(bexpected, jedis.zrange(bfoo, 0, 100));
+
+        jedis.zadd(bfoo, Double.NEGATIVE_INFINITY, bc);
+        bscore = jedis.zincrby(bfoo, 2d, bc);
+        assertEquals(Double.NEGATIVE_INFINITY, bscore, 0);
 
     }
 
@@ -239,16 +256,20 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
         jedis.zadd("foo", 1d, "a");
         jedis.zadd("foo", 10d, "b");
         jedis.zadd("foo", 0.1d, "c");
+        jedis.zadd("foo", Double.NEGATIVE_INFINITY, "n");
+        jedis.zadd("foo", Double.POSITIVE_INFINITY, "p");
         jedis.zadd("foo", 2d, "a");
 
         Set<Tuple> expected = new LinkedHashSet<Tuple>();
         expected.add(new Tuple("c", 0.1d));
         expected.add(new Tuple("a", 2d));
+        expected.add(new Tuple("n", Double.NEGATIVE_INFINITY));
 
-        Set<Tuple> range = jedis.zrangeWithScores("foo", 0, 1);
+        Set<Tuple> range = jedis.zrangeWithScores("foo", 0, 2);
         assertEquals(expected, range);
 
         expected.add(new Tuple("b", 10d));
+        expected.add(new Tuple("p", Double.POSITIVE_INFINITY));
         range = jedis.zrangeWithScores("foo", 0, 100);
         assertEquals(expected, range);
 
@@ -256,16 +277,20 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
         jedis.zadd(bfoo, 1d, ba);
         jedis.zadd(bfoo, 10d, bb);
         jedis.zadd(bfoo, 0.1d, bc);
+        jedis.zadd(bfoo, Double.NEGATIVE_INFINITY, bd);
+        jedis.zadd(bfoo, Double.POSITIVE_INFINITY, be);
         jedis.zadd(bfoo, 2d, ba);
 
         Set<Tuple> bexpected = new LinkedHashSet<Tuple>();
         bexpected.add(new Tuple(bc, 0.1d));
         bexpected.add(new Tuple(ba, 2d));
+        bexpected.add(new Tuple(bd, Double.NEGATIVE_INFINITY));
 
-        Set<Tuple> brange = jedis.zrangeWithScores(bfoo, 0, 1);
+        Set<Tuple> brange = jedis.zrangeWithScores(bfoo, 0, 2);
         assertEquals(bexpected, brange);
 
         bexpected.add(new Tuple(bb, 10d));
+        bexpected.add(new Tuple(be, Double.POSITIVE_INFINITY));
         brange = jedis.zrangeWithScores(bfoo, 0, 100);
         assertEquals(bexpected, brange);
 
@@ -305,7 +330,6 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
         bexpected.add(new Tuple(bc, 0.1d));
         brange = jedis.zrevrangeWithScores(bfoo, 0, 100);
         assertEquals(bexpected, brange);
-
     }
 
     @Test


### PR DESCRIPTION
Redis returns positive infinity as +inf or inf and negative infinity as -inf. Java's Double.valueOf expects +Infinity or -Infinity, so it chokes on those strings. This replaces all usages of Double.valueOf with a method that checks for redis-style infinity before handing off to Double.valueOf.
