### PR TITLE
Speed up Sentinel related unit tests (wait for real redis/sentinel status)

### DIFF
--- a/src/main/java/redis/clients/jedis/HostAndPort.java
+++ b/src/main/java/redis/clients/jedis/HostAndPort.java
@@ -1,0 +1,39 @@
+package redis.clients.jedis;
+
+public class HostAndPort {
+	private String host;
+	private int port;
+	
+	public HostAndPort(String host, int port) {
+		this.host = host;
+		this.port = port;
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+	    if (obj instanceof HostAndPort) {
+			HostAndPort hp = (HostAndPort) obj;
+			
+			// localhost and 127.0.0.1 is same
+			return port == hp.port && 
+				(host.equals(hp.host) || 
+						(host.equals("localhost") && hp.host.equals("127.0.0.1")) || 
+						(host.equals("127.0.0.1") && hp.host.equals("localhost")) );
+	    }
+	    
+	    return false;
+	}
+
+	@Override
+	public String toString() {
+	    return host + ":" + port;
+	}
+}

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -81,25 +81,6 @@ public class JedisSentinelPool extends Pool<Jedis> {
 	returnResourceObject(resource);
     }
 
-    private class HostAndPort {
-	String host;
-	int port;
-
-	@Override
-	public boolean equals(Object obj) {
-	    if (obj instanceof HostAndPort) {
-		HostAndPort hp = (HostAndPort) obj;
-		return port == hp.port && host.equals(hp.host);
-	    }
-	    return false;
-	}
-
-	@Override
-	public String toString() {
-	    return host + ":" + port;
-	}
-    }
-
     private volatile HostAndPort currentHostMaster;
 
     public void destroy() {
@@ -118,7 +99,7 @@ public class JedisSentinelPool extends Pool<Jedis> {
 	if (!master.equals(currentHostMaster)) {
 	    currentHostMaster = master;
 	    log.info("Created JedisPool to master at " + master);
-	    initPool(poolConfig, new JedisFactory(master.host, master.port,
+	    initPool(poolConfig, new JedisFactory(master.getHost(), master.getPort(),
 		    timeout, password, database));
 	}
     }
@@ -141,7 +122,7 @@ public class JedisSentinelPool extends Pool<Jedis> {
 		log.fine("Connecting to Sentinel " + hap);
 
 		try {
-		    Jedis jedis = new Jedis(hap.host, hap.port);
+		    Jedis jedis = new Jedis(hap.getHost(), hap.getPort());
 
 		    if (master == null) {
 			master = toHostAndPort(jedis
@@ -172,7 +153,7 @@ public class JedisSentinelPool extends Pool<Jedis> {
 	    final HostAndPort hap = toHostAndPort(Arrays.asList(sentinel
 		    .split(":")));
 	    MasterListener masterListener = new MasterListener(masterName,
-		    hap.host, hap.port);
+		    hap.getHost(), hap.getPort());
 	    masterListeners.add(masterListener);
 	    masterListener.start();
 	}
@@ -181,10 +162,10 @@ public class JedisSentinelPool extends Pool<Jedis> {
     }
 
     private HostAndPort toHostAndPort(List<String> getMasterAddrByNameResult) {
-	final HostAndPort hap = new HostAndPort();
-	hap.host = getMasterAddrByNameResult.get(0);
-	hap.port = Integer.parseInt(getMasterAddrByNameResult.get(1));
-	return hap;
+    	String host = getMasterAddrByNameResult.get(0);
+    	int port = Integer.parseInt(getMasterAddrByNameResult.get(1));
+    	
+    	return new HostAndPort(host, port);
     }
 
     protected class JedisPubSubAdapter extends JedisPubSub {

--- a/src/test/java/redis/clients/jedis/tests/HostAndPortUtil.java
+++ b/src/test/java/redis/clients/jedis/tests/HostAndPortUtil.java
@@ -3,52 +3,37 @@ package redis.clients.jedis.tests;
 import java.util.ArrayList;
 import java.util.List;
 
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Protocol;
 
 public class HostAndPortUtil {
-    private static List<HostAndPort> redisHostAndPortList = new ArrayList<HostAndPortUtil.HostAndPort>();
-    private static List<HostAndPort> sentinelHostAndPortList = new ArrayList<HostAndPortUtil.HostAndPort>();
+    private static List<HostAndPort> redisHostAndPortList = new ArrayList<HostAndPort>();
+    private static List<HostAndPort> sentinelHostAndPortList = new ArrayList<HostAndPort>();
 
     static {
     	
-        HostAndPort defaulthnp1 = new HostAndPort();
-        defaulthnp1.host = "localhost";
-        defaulthnp1.port = Protocol.DEFAULT_PORT;        
+        HostAndPort defaulthnp1 = new HostAndPort("localhost", Protocol.DEFAULT_PORT);
         redisHostAndPortList.add(defaulthnp1);
 
-        HostAndPort defaulthnp2 = new HostAndPort();
-        defaulthnp2.host = "localhost";
-        defaulthnp2.port = Protocol.DEFAULT_PORT + 1;
+        HostAndPort defaulthnp2 = new HostAndPort("localhost", Protocol.DEFAULT_PORT + 1);
         redisHostAndPortList.add(defaulthnp2);
         
-        HostAndPort defaulthnp3 = new HostAndPort();
-        defaulthnp3.host = "localhost";
-        defaulthnp3.port = Protocol.DEFAULT_PORT + 2;
+        HostAndPort defaulthnp3 = new HostAndPort("localhost", Protocol.DEFAULT_PORT + 2);
         redisHostAndPortList.add(defaulthnp3);
         
-        HostAndPort defaulthnp4 = new HostAndPort();
-        defaulthnp4.host = "localhost";
-        defaulthnp4.port = Protocol.DEFAULT_PORT + 3;
+        HostAndPort defaulthnp4 = new HostAndPort("localhost", Protocol.DEFAULT_PORT + 3);
         redisHostAndPortList.add(defaulthnp4);
         
-        HostAndPort defaulthnp5 = new HostAndPort();
-        defaulthnp5.host = "localhost";
-        defaulthnp5.port = Protocol.DEFAULT_PORT + 4;
+        HostAndPort defaulthnp5 = new HostAndPort("localhost", Protocol.DEFAULT_PORT + 4);
         redisHostAndPortList.add(defaulthnp5);
         
-        HostAndPort defaulthnp6 = new HostAndPort();
-        defaulthnp6.host = "localhost";
-        defaulthnp6.port = Protocol.DEFAULT_SENTINEL_PORT;
+        HostAndPort defaulthnp6 = new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT);
         sentinelHostAndPortList.add(defaulthnp6);
         
-        HostAndPort defaulthnp7 = new HostAndPort();
-        defaulthnp7.host = "localhost";
-        defaulthnp7.port = Protocol.DEFAULT_SENTINEL_PORT + 1;
+        HostAndPort defaulthnp7 = new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 1);
         sentinelHostAndPortList.add(defaulthnp7);
         
-        HostAndPort defaulthnp8 = new HostAndPort();
-        defaulthnp8.host = "localhost";
-        defaulthnp8.port = Protocol.DEFAULT_SENTINEL_PORT + 2;
+        HostAndPort defaulthnp8 = new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 2);
         sentinelHostAndPortList.add(defaulthnp8);
 
         String envRedisHosts = System.getProperty("redis-hosts");
@@ -66,24 +51,22 @@ public class HostAndPortUtil {
             
             if (null != hostDefs && 2 <= hostDefs.length) {
             	
-            	List<HostAndPort> envHostsAndPorts = new ArrayList<HostAndPortUtil.HostAndPort>(hostDefs.length);
+            	List<HostAndPort> envHostsAndPorts = new ArrayList<HostAndPort>(hostDefs.length);
                 
                 for (String hostDef : hostDefs) {
                                     	
                 	String[] hostAndPort = hostDef.split(":");
                 	
                     if (null != hostAndPort && 2 == hostAndPort.length) {
+                    	String host = hostAndPort[0];
+                    	int port = Protocol.DEFAULT_PORT;
                     	
-                        HostAndPort hnp = new HostAndPort();
-                        hnp.host = hostAndPort[0];
-                        
-                        try {
-                            hnp.port = Integer.parseInt(hostAndPort[1]);
+                    	try {
+                            port = Integer.parseInt(hostAndPort[1]);
                         } catch (final NumberFormatException nfe) {
-                            hnp.port = Protocol.DEFAULT_PORT;
-                        }                                                
-                        
-                        envHostsAndPorts.add(hnp);
+                        }
+                    	
+                        envHostsAndPorts.add(new HostAndPort(host, port));
                     }
                 }
                                 
@@ -102,13 +85,4 @@ public class HostAndPortUtil {
         return sentinelHostAndPortList;
     }
 
-    public static class HostAndPort {
-        public String host;
-        public int port;
-        
-        @Override
-        public String toString() {
-        	return host + ":" + port;
-        }
-    }
 }

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
@@ -9,19 +9,19 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import redis.clients.jedis.BinaryJedis;
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.exceptions.JedisConnectionException;
-import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
 
 public class JedisPoolTest extends Assert {
     private static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
 
     @Test
     public void checkConnections() {
-        JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.host,
-                hnp.port, 2000);
+        JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), 
+        		hnp.getPort(), 2000);
         Jedis jedis = pool.getResource();
         jedis.auth("foobared");
         jedis.set("foo", "bar");
@@ -32,8 +32,8 @@ public class JedisPoolTest extends Assert {
 
     @Test
     public void checkConnectionWithDefaultPort() {
-        JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.host,
-                hnp.port);
+        JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), 
+        		hnp.getPort());
         Jedis jedis = pool.getResource();
         jedis.auth("foobared");
         jedis.set("foo", "bar");
@@ -44,8 +44,8 @@ public class JedisPoolTest extends Assert {
 
     @Test
     public void checkJedisIsReusedWhenReturned() {
-        JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.host,
-                hnp.port);
+    	JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), 
+        		hnp.getPort());
         Jedis jedis = pool.getResource();
         jedis.auth("foobared");
         jedis.set("foo", "0");
@@ -60,8 +60,8 @@ public class JedisPoolTest extends Assert {
 
     @Test
     public void checkPoolRepairedWhenJedisIsBroken() {
-        JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.host,
-                hnp.port);
+    	JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), 
+        		hnp.getPort());
         Jedis jedis = pool.getResource();
         jedis.auth("foobared");
         jedis.quit();
@@ -79,7 +79,7 @@ public class JedisPoolTest extends Assert {
         Config config = new Config();
         config.maxActive = 1;
         config.whenExhaustedAction = GenericObjectPool.WHEN_EXHAUSTED_FAIL;
-        JedisPool pool = new JedisPool(config, hnp.host, hnp.port);
+        JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort());
         Jedis jedis = pool.getResource();
         jedis.auth("foobared");
         jedis.set("foo", "0");
@@ -93,7 +93,8 @@ public class JedisPoolTest extends Assert {
     public void securePool() {
         JedisPoolConfig config = new JedisPoolConfig();
         config.setTestOnBorrow(true);
-        JedisPool pool = new JedisPool(config, hnp.host, hnp.port, 2000, "foobared");
+        JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 
+        		2000, "foobared");
         Jedis jedis = pool.getResource();
         jedis.set("foo", "bar");
         pool.returnResource(jedis);
@@ -102,16 +103,16 @@ public class JedisPoolTest extends Assert {
 
     @Test
     public void nonDefaultDatabase() {
-        JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.host,
-                hnp.port, 2000, "foobared");
+        JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), 
+        		hnp.getPort(), 2000, "foobared");
         Jedis jedis0 = pool0.getResource();
         jedis0.set("foo", "bar");
         assertEquals( "bar", jedis0.get("foo") );
         pool0.returnResource(jedis0);
         pool0.destroy();
 
-        JedisPool pool1 = new JedisPool(new JedisPoolConfig(), hnp.host,
-                hnp.port, 2000, "foobared", 1);
+        JedisPool pool1 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), 
+        		hnp.getPort(), 2000, "foobared", 1);
         Jedis jedis1 = pool1.getResource();
         assertNull( jedis1.get("foo") );
         pool1.returnResource(jedis0);
@@ -120,8 +121,8 @@ public class JedisPoolTest extends Assert {
 
     @Test
     public void returnBinary() {
-        JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.host,
-                hnp.port, 2000);
+        JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), 
+        		hnp.getPort(), 2000);
         BinaryJedis jedis = pool.getResource();
         pool.returnResource(jedis);
         pool.destroy();
@@ -153,7 +154,8 @@ public class JedisPoolTest extends Assert {
 
 	@Test
 	public void selectDatabaseOnActivation() {
-		JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.host, hnp.port, 2000, "foobared");
+		JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), 
+				hnp.getPort(), 2000, "foobared");
 
 		Jedis jedis0 = pool.getResource();
 		assertEquals(0L, jedis0.getDB().longValue());
@@ -173,8 +175,8 @@ public class JedisPoolTest extends Assert {
 
     @Test
     public void customClientName() {
-        JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.host,
-                        hnp.port, 2000, "foobared", 0, "my_shiny_client_name");
+        JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), 
+        		hnp.getPort(), 2000, "foobared", 0, "my_shiny_client_name");
 
         Jedis jedis = pool0.getResource();
 

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
@@ -1,6 +1,8 @@
 package redis.clients.jedis.tests;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.pool.impl.GenericObjectPool.Config;
@@ -8,91 +10,121 @@ import org.junit.Before;
 import org.junit.Test;
 
 import redis.clients.jedis.DebugParams;
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisSentinelPool;
-import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
+import redis.clients.jedis.tests.utils.JedisSentinelTestUtil;
 
 public class JedisSentinelPoolTest extends JedisTestBase {
+	private static final String MASTER_NAME = "mymaster";
 
-    protected static HostAndPort master = HostAndPortUtil.getRedisServers()
-	    .get(2);
-    protected static HostAndPort slave1 = HostAndPortUtil.getRedisServers()
-	    .get(3);
-    protected static HostAndPort slave2 = HostAndPortUtil.getRedisServers()
-    	.get(4);
-    protected static HostAndPort sentinel1 = HostAndPortUtil
-	    .getSentinelServers().get(1);
-    protected static HostAndPort sentinel2 = HostAndPortUtil
-	    .getSentinelServers().get(2);
+	protected static HostAndPort master = HostAndPortUtil.getRedisServers()
+			.get(2);
+	protected static HostAndPort slave1 = HostAndPortUtil.getRedisServers()
+			.get(3);
+	protected static HostAndPort slave2 = HostAndPortUtil.getRedisServers()
+			.get(4);
+	protected static HostAndPort sentinel1 = HostAndPortUtil
+			.getSentinelServers().get(1);
+	protected static HostAndPort sentinel2 = HostAndPortUtil
+			.getSentinelServers().get(2);
 
-    protected static Jedis masterJedis;
-    protected static Jedis slaveJedis1;
-    protected static Jedis slaveJedis2;
-    
-    protected static int slaveCount = 0;
+	protected static Jedis masterJedis;
+	protected static Jedis slaveJedis1;
+	protected static Jedis slaveJedis2;
+	protected static Jedis sentinelJedis1;
+	protected static Jedis sentinelJedis2;
 
-    protected Set<String> sentinels = new HashSet<String>();
+	protected Set<String> sentinels = new HashSet<String>();
 
-    @Before
-    public void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 
-	// set up master and slaves
-	masterJedis = new Jedis(master.host, master.port);
-	masterJedis.auth("foobared");
-	masterJedis.slaveofNoOne();
+		// set up master and slaves
+		masterJedis = new Jedis(master.getHost(), master.getPort());
+		masterJedis.auth("foobared");
+		masterJedis.slaveofNoOne();
 
-	slaveJedis1 = new Jedis(slave1.host, slave1.port);
-	slaveJedis1.auth("foobared");
-	slaveJedis1.slaveof(master.host, master.port);
-	slaveCount++;
-	
-	slaveJedis2 = new Jedis(slave2.host, slave2.port);
-	slaveJedis2.auth("foobared");
-	slaveJedis2.slaveof(master.host, master.port);
-	slaveCount++;
+		slaveJedis1 = new Jedis(slave1.getHost(), slave1.getPort());
+		slaveJedis1.auth("foobared");
+		slaveJedis1.slaveof(master.getHost(), master.getPort());
 
-	sentinels.add(sentinel1.toString());
-	sentinels.add(sentinel2.toString());
+		slaveJedis2 = new Jedis(slave2.getHost(), slave2.getPort());
+		slaveJedis2.auth("foobared");
+		slaveJedis2.slaveof(master.getHost(), master.getPort());
 
-	// FIXME: The following allows the master/slave relationship to
-	// be established, and let sentinels know about this relationship. 
-	// We can do this more elegantly.
-	Thread.sleep(10000);
-    }
+		sentinels.add(sentinel1.toString());
+		sentinels.add(sentinel2.toString());
 
-    @Test
-    public void ensureSafeTwiceFailover() throws InterruptedException {
-    	JedisSentinelPool pool = new JedisSentinelPool("mymaster", sentinels,
-    			new Config(), 1000, "foobared", 2);
-    		
-    	// perform failover
-    	doSegFaultMaster(pool);
-    	
-    	// perform failover once again
-    	doSegFaultMaster(pool);
-    	
-    	// you can test failover as much as possible
-    	// but you need to prepare additional slave per failover
-    }
-    
-    private void doSegFaultMaster(JedisSentinelPool pool) throws InterruptedException {
-    	// jedis connection should be master
-    	Jedis jedis = pool.getResource();
-    	assertEquals("PONG", jedis.ping());
+		List<HostAndPort> slaves = new ArrayList<HostAndPort>();
+		slaves.add(slave1);
+		slaves.add(slave2);
 
-    	try {
-    		jedis.debug(DebugParams.SEGFAULT());
-    	} catch (Exception e) {
-    	}
+		JedisSentinelTestUtil.waitForSentinelRecognizeRedisReplication(sentinel1, 
+				MASTER_NAME, master, slaves);
+		JedisSentinelTestUtil.waitForSentinelRecognizeRedisReplication(sentinel2, 
+				MASTER_NAME, master, slaves);
+		
+		// No need to wait for sentinels to recognize each other
+	}	
 
-    	// wait for the sentinel to promote a master
-    	// FIXME: we can query the sentinel and sleep
-    	// right until the master is promoted
-    	Thread.sleep(35000);
+	@Test
+	public void ensureSafeTwiceFailover() throws InterruptedException {
+		JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels,
+				new Config(), 1000, "foobared", 2);
 
-    	jedis = pool.getResource();
-    	assertEquals("PONG", jedis.ping());
-    	assertEquals("foobared", jedis.configGet("requirepass").get(1));
-    	assertEquals(2, jedis.getDB().intValue());
-    }
+		// perform failover
+		doSegFaultMaster(pool);
+
+		// perform failover once again
+		doSegFaultMaster(pool);
+
+		// you can test failover as much as possible
+		// but you need to prepare additional slave per failover
+	}
+
+	private void doSegFaultMaster(JedisSentinelPool pool) throws InterruptedException {
+		HostAndPort oldMaster = pool.getCurrentHostMaster();
+
+		// jedis connection should be master
+		Jedis jedis = pool.getResource();
+		assertEquals("PONG", jedis.ping());
+
+		try {
+			jedis.debug(DebugParams.SEGFAULT());
+		} catch (Exception e) {
+		}
+
+		waitForFailover(pool, oldMaster);
+
+		jedis = pool.getResource();
+		assertEquals("PONG", jedis.ping());
+		assertEquals("foobared", jedis.configGet("requirepass").get(1));
+		assertEquals(2, jedis.getDB().intValue());
+	}
+
+	private void waitForFailover(JedisSentinelPool pool, HostAndPort oldMaster) throws InterruptedException {
+		HostAndPort newMaster = JedisSentinelTestUtil.waitForNewPromotedMaster(sentinel1, 
+				MASTER_NAME, oldMaster);
+		JedisSentinelTestUtil.waitForNewPromotedMaster(sentinel2, MASTER_NAME, oldMaster);
+		JedisSentinelTestUtil.waitForSentinelsRecognizeEachOthers();
+		waitForJedisSentinelPoolRecognizeNewMaster(pool, newMaster);
+	}
+
+	private void waitForJedisSentinelPoolRecognizeNewMaster(JedisSentinelPool pool,
+			HostAndPort newMaster) throws InterruptedException {
+
+		while (true) {
+			String host = pool.getCurrentHostMaster().getHost();
+			int port = pool.getCurrentHostMaster().getPort();
+
+			if (host.equals(newMaster.getHost()) && port == newMaster.getPort())
+				break;
+
+			System.out.println("JedisSentinelPool's master is not yet changed, sleep...");
+
+			Thread.sleep(1000);
+		}
+	}
+
 }

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelTest.java
@@ -1,9 +1,6 @@
 package redis.clients.jedis.tests;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
-
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -11,59 +8,81 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.tests.utils.JedisSentinelTestUtil;
 
-public class JedisSentinelTest {
-    private static final String MASTER_NAME = "mymaster";
+public class JedisSentinelTest extends JedisTestBase {
+	private static final String MASTER_NAME = "mymaster";
 
-    @Before
-    public void setup() throws InterruptedException {
-	Jedis j = new Jedis("localhost", 6380);
-	j.auth("foobared");
-	j.configSet("masterauth", "foobared");
-	j.slaveof("localhost", 6379);
-	// TODO: The sleep is to give time to the slave to synchronize with the
-	// master and also let know the sentinels about this new topology. We
-	// should find a better way to do this.
-	Thread.sleep(10000);
-    }
+	protected static HostAndPort master = HostAndPortUtil.getRedisServers()
+			.get(0);
+	protected static HostAndPort slave = HostAndPortUtil.getRedisServers()
+			.get(1);
+	protected static HostAndPort sentinel = HostAndPortUtil
+			.getSentinelServers().get(0);
 
-    @After
-    public void clear() {
-	Jedis j = new Jedis("localhost", 6380);
-	j.auth("foobared");
-	j.slaveofNoOne();
-    }
+	protected static Jedis masterJedis;
+	protected static Jedis slaveJedis;
+	protected static Jedis sentinelJedis;
 
-    @Test
-    public void sentinel() {
-	Jedis j = new Jedis("localhost", 26379);
-	List<Map<String, String>> masters = j.sentinelMasters();
-	final String masterName = masters.get(0).get("name");
+	@Before
+	public void setup() throws InterruptedException {
+		masterJedis = new Jedis(master.getHost(), master.getPort());
 
-	assertEquals(MASTER_NAME, masterName);
+		slaveJedis = new Jedis(slave.getHost(), slave.getPort());
+		slaveJedis.auth("foobared");
+		slaveJedis.configSet("masterauth", "foobared");
+		slaveJedis.slaveof(master.getHost(), master.getPort());
 
-	List<String> masterHostAndPort = j
-		.sentinelGetMasterAddrByName(masterName);
-	assertEquals("127.0.0.1", masterHostAndPort.get(0));
-	assertEquals("6379", masterHostAndPort.get(1));
+		List<HostAndPort> slaves = new ArrayList<HostAndPort>();
+		slaves.add(slave);
 
-	List<Map<String, String>> slaves = j.sentinelSlaves(masterName);
-	assertTrue(slaves.size() > 0);
-	assertEquals("6379", slaves.get(0).get("master-port"));
+		JedisSentinelTestUtil.waitForSentinelRecognizeRedisReplication(sentinel,
+				MASTER_NAME, master, slaves);
+		
+		// No need to wait for sentinels to recognize each other
+	}
 
-	List<? extends Object> isMasterDownByAddr = j
-		.sentinelIsMasterDownByAddr("127.0.0.1", 6379);
-	assertEquals(Long.valueOf(0), (Long) isMasterDownByAddr.get(0));
-	assertFalse("?".equals(isMasterDownByAddr.get(1)));
+	@After
+	public void clear() throws InterruptedException {
+		Jedis j = new Jedis("localhost", 6380);
+		j.auth("foobared");
+		j.slaveofNoOne();
 
-	isMasterDownByAddr = j.sentinelIsMasterDownByAddr("127.0.0.1", 1);
-	assertEquals(Long.valueOf(0), (Long) isMasterDownByAddr.get(0));
-	assertTrue("?".equals(isMasterDownByAddr.get(1)));
+		JedisSentinelTestUtil.waitForSentinelRecognizeRedisReplication(sentinel,
+				MASTER_NAME, master, new ArrayList<HostAndPort>());
+	}
 
-	// DO NOT RE-RUN TEST TOO FAST, RESET TAKES SOME TIME TO... RESET
-	assertEquals(Long.valueOf(1), j.sentinelReset(masterName));
-	assertEquals(Long.valueOf(0), j.sentinelReset("woof" + masterName));
+	@Test
+	public void sentinel() {
+		Jedis j = new Jedis("localhost", 26379);
+		List<Map<String, String>> masters = j.sentinelMasters();
+		final String masterName = masters.get(0).get("name");
 
-    }
+		assertEquals(MASTER_NAME, masterName);
+
+		List<String> masterHostAndPort = j
+				.sentinelGetMasterAddrByName(masterName);
+		assertEquals("127.0.0.1", masterHostAndPort.get(0));
+		assertEquals("6379", masterHostAndPort.get(1));
+
+		List<Map<String, String>> slaves = j.sentinelSlaves(masterName);
+		assertTrue(slaves.size() > 0);
+		assertEquals("6379", slaves.get(0).get("master-port"));
+
+		List<? extends Object> isMasterDownByAddr = j
+				.sentinelIsMasterDownByAddr("127.0.0.1", 6379);
+		assertEquals(Long.valueOf(0), (Long) isMasterDownByAddr.get(0));
+		assertFalse("?".equals(isMasterDownByAddr.get(1)));
+
+		isMasterDownByAddr = j.sentinelIsMasterDownByAddr("127.0.0.1", 1);
+		assertEquals(Long.valueOf(0), (Long) isMasterDownByAddr.get(0));
+		assertTrue("?".equals(isMasterDownByAddr.get(1)));
+
+		// DO NOT RE-RUN TEST TOO FAST, RESET TAKES SOME TIME TO... RESET
+		assertEquals(Long.valueOf(1), j.sentinelReset(masterName));
+		assertEquals(Long.valueOf(0), j.sentinelReset("woof" + masterName));
+
+	}
 }

--- a/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
@@ -1,14 +1,24 @@
 package redis.clients.jedis.tests;
 
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.*;
-import redis.clients.jedis.exceptions.JedisDataException;
-import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
 
-import java.io.UnsupportedEncodingException;
-import java.util.*;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.PipelineBlock;
+import redis.clients.jedis.Response;
+import redis.clients.jedis.Tuple;
+import redis.clients.jedis.exceptions.JedisDataException;
 
 public class PipeliningTest extends Assert {
     private static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
@@ -17,7 +27,7 @@ public class PipeliningTest extends Assert {
 
     @Before
     public void setUp() throws Exception {
-        jedis = new Jedis(hnp.host, hnp.port, 500);
+        jedis = new Jedis(hnp.getHost(), hnp.getPort(), 500);
         jedis.connect();
         jedis.auth("foobared");
         jedis.flushAll();

--- a/src/test/java/redis/clients/jedis/tests/ShardedJedisPipelineTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ShardedJedisPipelineTest.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.Response;
@@ -24,26 +25,26 @@ import redis.clients.jedis.Tuple;
 import redis.clients.jedis.exceptions.JedisDataException;
 
 public class ShardedJedisPipelineTest {
-    private static HostAndPortUtil.HostAndPort redis1 = HostAndPortUtil
+    private static HostAndPort redis1 = HostAndPortUtil
             .getRedisServers().get(0);
-    private static HostAndPortUtil.HostAndPort redis2 = HostAndPortUtil
+    private static HostAndPort redis2 = HostAndPortUtil
             .getRedisServers().get(1);
 
     private ShardedJedis jedis;
 
     @Before
     public void setUp() throws Exception {
-        Jedis jedis = new Jedis(redis1.host, redis1.port);
+        Jedis jedis = new Jedis(redis1.getHost(), redis1.getPort());
         jedis.auth("foobared");
         jedis.flushAll();
         jedis.disconnect();
-        jedis = new Jedis(redis2.host, redis2.port);
+        jedis = new Jedis(redis2.getHost(), redis2.getPort());
         jedis.auth("foobared");
         jedis.flushAll();
         jedis.disconnect();
 
-        JedisShardInfo shardInfo1 = new JedisShardInfo(redis1.host, redis1.port);
-        JedisShardInfo shardInfo2 = new JedisShardInfo(redis2.host, redis2.port);
+        JedisShardInfo shardInfo1 = new JedisShardInfo(redis1.getHost(), redis1.getPort());
+        JedisShardInfo shardInfo2 = new JedisShardInfo(redis2.getHost(), redis2.getPort());
         shardInfo1.setPassword("foobared");
         shardInfo2.setPassword("foobared");
         List<JedisShardInfo> shards = new ArrayList<JedisShardInfo>();

--- a/src/test/java/redis/clients/jedis/tests/ShardedJedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ShardedJedisPoolTest.java
@@ -11,12 +11,12 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.ShardedJedis;
 import redis.clients.jedis.ShardedJedisPool;
 import redis.clients.jedis.exceptions.JedisConnectionException;
-import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
 
 public class ShardedJedisPoolTest extends Assert {
     private static HostAndPort redis1 = HostAndPortUtil.getRedisServers()
@@ -29,8 +29,8 @@ public class ShardedJedisPoolTest extends Assert {
     @Before
     public void startUp() {
         shards = new ArrayList<JedisShardInfo>();
-        shards.add(new JedisShardInfo(redis1.host, redis1.port));
-        shards.add(new JedisShardInfo(redis2.host, redis2.port));
+        shards.add(new JedisShardInfo(redis1.getHost(), redis1.getPort()));
+        shards.add(new JedisShardInfo(redis2.getHost(), redis2.getPort()));
         shards.get(0).setPassword("foobared");
         shards.get(1).setPassword("foobared");
         Jedis j = new Jedis(shards.get(0));

--- a/src/test/java/redis/clients/jedis/tests/ShardedJedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ShardedJedisTest.java
@@ -6,12 +6,12 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.ShardedJedis;
 import redis.clients.jedis.ShardedJedisPipeline;
-import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
 import redis.clients.util.Hashing;
 import redis.clients.util.SafeEncoder;
 import redis.clients.util.Sharded;
@@ -41,8 +41,8 @@ public class ShardedJedisTest extends Assert {
     @Test
     public void checkSharding() {
         List<JedisShardInfo> shards = new ArrayList<JedisShardInfo>();
-        shards.add(new JedisShardInfo(redis1.host, redis1.port));
-        shards.add(new JedisShardInfo(redis2.host, redis2.port));
+        shards.add(new JedisShardInfo(redis1.getHost(), redis1.getPort()));
+        shards.add(new JedisShardInfo(redis2.getHost(), redis2.getPort()));
         ShardedJedis jedis = new ShardedJedis(shards);
         List<String> keys = getKeysDifferentShard(jedis);
         JedisShardInfo s1 = jedis.getShardInfo(keys.get(0));
@@ -53,10 +53,10 @@ public class ShardedJedisTest extends Assert {
     @Test
     public void trySharding() {
         List<JedisShardInfo> shards = new ArrayList<JedisShardInfo>();
-        JedisShardInfo si = new JedisShardInfo(redis1.host, redis1.port);
+        JedisShardInfo si = new JedisShardInfo(redis1.getHost(), redis1.getPort());
         si.setPassword("foobared");
         shards.add(si);
-        si = new JedisShardInfo(redis2.host, redis2.port);
+        si = new JedisShardInfo(redis2.getHost(), redis2.getPort());
         si.setPassword("foobared");
         shards.add(si);
         ShardedJedis jedis = new ShardedJedis(shards);
@@ -80,10 +80,10 @@ public class ShardedJedisTest extends Assert {
     @Test
     public void tryShardingWithMurmure() {
         List<JedisShardInfo> shards = new ArrayList<JedisShardInfo>();
-        JedisShardInfo si = new JedisShardInfo(redis1.host, redis1.port);
+        JedisShardInfo si = new JedisShardInfo(redis1.getHost(), redis1.getPort());
         si.setPassword("foobared");
         shards.add(si);
-        si = new JedisShardInfo(redis2.host, redis2.port);
+        si = new JedisShardInfo(redis2.getHost(), redis2.getPort());
         si.setPassword("foobared");
         shards.add(si);
         ShardedJedis jedis = new ShardedJedis(shards, Hashing.MURMUR_HASH);
@@ -107,8 +107,8 @@ public class ShardedJedisTest extends Assert {
     @Test
     public void checkKeyTags() {
         List<JedisShardInfo> shards = new ArrayList<JedisShardInfo>();
-        shards.add(new JedisShardInfo(redis1.host, redis1.port));
-        shards.add(new JedisShardInfo(redis2.host, redis2.port));
+        shards.add(new JedisShardInfo(redis1.getHost(), redis1.getPort()));
+        shards.add(new JedisShardInfo(redis2.getHost(), redis2.getPort()));
         ShardedJedis jedis = new ShardedJedis(shards,
                 ShardedJedis.DEFAULT_KEY_TAG_PATTERN);
 
@@ -143,8 +143,8 @@ public class ShardedJedisTest extends Assert {
     @Test
     public void shardedPipeline() {
         List<JedisShardInfo> shards = new ArrayList<JedisShardInfo>();
-        shards.add(new JedisShardInfo(redis1.host, redis1.port));
-        shards.add(new JedisShardInfo(redis2.host, redis2.port));
+        shards.add(new JedisShardInfo(redis1.getHost(), redis1.getPort()));
+        shards.add(new JedisShardInfo(redis2.getHost(), redis2.getPort()));
         shards.get(0).setPassword("foobared");
         shards.get(1).setPassword("foobared");
         ShardedJedis jedis = new ShardedJedis(shards);

--- a/src/test/java/redis/clients/jedis/tests/benchmark/GetSetBenchmark.java
+++ b/src/test/java/redis/clients/jedis/tests/benchmark/GetSetBenchmark.java
@@ -4,9 +4,9 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Calendar;
 
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.tests.HostAndPortUtil;
-import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
 
 public class GetSetBenchmark {
 	private static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
@@ -14,7 +14,7 @@ public class GetSetBenchmark {
 
     public static void main(String[] args) throws UnknownHostException,
 	    IOException {
-	Jedis jedis = new Jedis(hnp.host, hnp.port);
+	Jedis jedis = new Jedis(hnp.getHost(), hnp.getPort());
 	jedis.connect();
 	jedis.auth("foobared");
 	jedis.flushAll();

--- a/src/test/java/redis/clients/jedis/tests/benchmark/HashingBenchmark.java
+++ b/src/test/java/redis/clients/jedis/tests/benchmark/HashingBenchmark.java
@@ -7,11 +7,11 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.List;
 
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.ShardedJedis;
 import redis.clients.jedis.tests.HostAndPortUtil;
-import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
 
 public class HashingBenchmark {
     private static HostAndPort hnp1 = HostAndPortUtil.getRedisServers().get(0);
@@ -21,10 +21,10 @@ public class HashingBenchmark {
     public static void main(String[] args) throws UnknownHostException,
             IOException {
         List<JedisShardInfo> shards = new ArrayList<JedisShardInfo>();
-        JedisShardInfo shard = new JedisShardInfo(hnp1.host, hnp1.port);
+        JedisShardInfo shard = new JedisShardInfo(hnp1.getHost(), hnp1.getPort());
         shard.setPassword("foobared");
         shards.add(shard);
-        shard = new JedisShardInfo(hnp2.host, hnp2.port);
+        shard = new JedisShardInfo(hnp2.getHost(), hnp2.getPort());
         shard.setPassword("foobared");
         shards.add(shard);
         ShardedJedis jedis = new ShardedJedis(shards);

--- a/src/test/java/redis/clients/jedis/tests/benchmark/PipelinedGetSetBenchmark.java
+++ b/src/test/java/redis/clients/jedis/tests/benchmark/PipelinedGetSetBenchmark.java
@@ -4,10 +4,10 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Calendar;
 
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.tests.HostAndPortUtil;
-import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
 
 public class PipelinedGetSetBenchmark {
     private static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
@@ -15,7 +15,7 @@ public class PipelinedGetSetBenchmark {
 
     public static void main(String[] args) throws UnknownHostException,
             IOException {
-        Jedis jedis = new Jedis(hnp.host, hnp.port);
+        Jedis jedis = new Jedis(hnp.getHost(), hnp.getPort());
         jedis.connect();
         jedis.auth("foobared");
         jedis.flushAll();

--- a/src/test/java/redis/clients/jedis/tests/benchmark/PoolBenchmark.java
+++ b/src/test/java/redis/clients/jedis/tests/benchmark/PoolBenchmark.java
@@ -6,17 +6,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.pool.impl.GenericObjectPool.Config;
 
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.tests.HostAndPortUtil;
-import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
 
 public class PoolBenchmark {
     private static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
     private static final int TOTAL_OPERATIONS = 100000;
 
     public static void main(String[] args) throws Exception {
-        Jedis j = new Jedis(hnp.host, hnp.port);
+        Jedis j = new Jedis(hnp.getHost(), hnp.getPort());
         j.connect();
         j.auth("foobared");
         j.flushAll();
@@ -30,7 +30,7 @@ public class PoolBenchmark {
     }
 
     private static void withPool() throws Exception {
-        final JedisPool pool = new JedisPool(new Config(), hnp.host, hnp.port,
+        final JedisPool pool = new JedisPool(new Config(), hnp.getHost(), hnp.getPort(),
                 2000, "foobared");
         List<Thread> tds = new ArrayList<Thread>();
 

--- a/src/test/java/redis/clients/jedis/tests/commands/ConnectionHandlingCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ConnectionHandlingCommandsTest.java
@@ -3,8 +3,8 @@ package redis.clients.jedis.tests.commands;
 import org.junit.Test;
 
 import redis.clients.jedis.BinaryJedis;
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.tests.HostAndPortUtil;
-import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
 
 public class ConnectionHandlingCommandsTest extends JedisCommandTestBase {
     protected static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
@@ -16,7 +16,7 @@ public class ConnectionHandlingCommandsTest extends JedisCommandTestBase {
 
     @Test
     public void binary_quit() {
-        BinaryJedis bj = new BinaryJedis(hnp.host);
+        BinaryJedis bj = new BinaryJedis(hnp.getHost());
         assertEquals("OK", bj.quit());
     }
 }

--- a/src/test/java/redis/clients/jedis/tests/commands/JedisCommandTestBase.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/JedisCommandTestBase.java
@@ -1,17 +1,18 @@
 package redis.clients.jedis.tests.commands;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ComparisonFailure;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.tests.HostAndPortUtil;
-import redis.clients.jedis.tests.HostAndPortUtil.HostAndPort;
-import redis.clients.jedis.tests.JedisTestBase;
-
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ComparisonFailure;
+
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.tests.HostAndPortUtil;
+import redis.clients.jedis.tests.JedisTestBase;
 
 public abstract class JedisCommandTestBase extends JedisTestBase {
     protected static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
@@ -24,7 +25,7 @@ public abstract class JedisCommandTestBase extends JedisTestBase {
 
     @Before
     public void setUp() throws Exception {
-        jedis = new Jedis(hnp.host, hnp.port, 500);
+        jedis = new Jedis(hnp.getHost(), hnp.getPort(), 500);
         jedis.connect();
         jedis.auth("foobared");
         jedis.configSet("timeout", "300");
@@ -37,7 +38,7 @@ public abstract class JedisCommandTestBase extends JedisTestBase {
     }
 
     protected Jedis createJedis() {
-        Jedis j = new Jedis(hnp.host, hnp.port);
+        Jedis j = new Jedis(hnp.getHost(), hnp.getPort());
         j.connect();
         j.auth("foobared");
         j.flushAll();

--- a/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
@@ -475,7 +475,7 @@ public class PublishSubscribeCommandsTest extends JedisCommandTestBase {
     @Test @Ignore
     public void subscribeWithoutConnecting() {
         try {
-            Jedis jedis = new Jedis(hnp.host, hnp.port);
+            Jedis jedis = new Jedis(hnp.getHost(), hnp.getPort());
             jedis.subscribe(new JedisPubSub() {
                 public void onMessage(String channel, String message) {
                 }

--- a/src/test/java/redis/clients/jedis/tests/commands/TransactionCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/TransactionCommandsTest.java
@@ -32,7 +32,7 @@ public class TransactionCommandsTest extends JedisCommandTestBase {
     public void setUp() throws Exception {
         super.setUp();
 
-        nj = new Jedis(hnp.host, hnp.port, 500);
+        nj = new Jedis(hnp.getHost(), hnp.getPort(), 500);
         nj.connect();
         nj.auth("foobared");
         nj.flushAll();

--- a/src/test/java/redis/clients/jedis/tests/utils/JedisSentinelTestUtil.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/JedisSentinelTestUtil.java
@@ -1,0 +1,113 @@
+package redis.clients.jedis.tests.utils;
+
+import java.util.List;
+import java.util.Map;
+
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+
+public class JedisSentinelTestUtil {
+
+	public static void waitForSentinelRecognizeRedisReplication(HostAndPort sentinel, 
+			String masterName, HostAndPort master, List<HostAndPort> slaves) throws InterruptedException {
+		Jedis sentinelJedis = new Jedis(sentinel.getHost(), sentinel.getPort());
+
+		while (true) {
+			Thread.sleep(1000);
+
+			if (!isMasterRecognized(sentinelJedis, masterName, master)) {
+				System.out.println("Master not recognized by Sentinel " + 
+						sentinel.getHost() + ":" + sentinel.getPort() + ", sleep...");
+				continue;
+			}
+
+			if (!isSlavesRecognized(sentinelJedis, masterName, slaves)) {
+				System.out.println("Slaves not recognized by Sentinel " + 
+						sentinel.getHost() + ":" + sentinel.getPort() + ", sleep...");
+				continue;
+			}
+
+			// all recognized
+			break;
+		}
+
+	}
+
+	public static HostAndPort waitForNewPromotedMaster(HostAndPort sentinel, String masterName, HostAndPort oldMaster) throws InterruptedException {
+		Jedis sentinelJedis = new Jedis(sentinel.getHost(), sentinel.getPort());
+
+		HostAndPort newMaster = null;
+		while (true) {
+			Thread.sleep(1000);
+
+			List<String> sentinelMasterInfos = sentinelJedis.sentinelGetMasterAddrByName(masterName);
+			if (sentinelMasterInfos == null)
+				continue;
+
+			newMaster = new HostAndPort(sentinelMasterInfos.get(0), 
+					Integer.parseInt(sentinelMasterInfos.get(1)) );
+
+			if (!newMaster.equals(oldMaster))
+				break;
+
+			System.out.println("Sentinel's master is not yet changed, sleep...");
+		}
+
+		return newMaster;
+	}
+
+	public static void waitForSentinelsRecognizeEachOthers() throws InterruptedException {
+		// During failover, master has been changed
+		// It means that sentinels need to recognize other sentinels from new master's hello channel
+		// Without recognizing, Sentinels cannot run failover
+
+		// Sentinels need to take some time to recognize each other...
+		// http://redis.io/topics/sentinel
+		// Sentinel Rule #8: Every Sentinel publishes a message to every monitored master 
+		// Pub/Sub channel __sentinel__:hello, every five seconds, blabla...
+
+		// FIXME There're no command for sentinel to list recognized sentinels
+		// so sleep wisely (channel's hello message interval + margin)
+		Thread.sleep(5000 + 500);
+	}
+
+	private static boolean isMasterRecognized(Jedis sentinelJedis, String masterName, HostAndPort master) {
+		List<String> sentinelMasterInfos = sentinelJedis.sentinelGetMasterAddrByName(masterName);
+		if (sentinelMasterInfos == null)
+			return false;
+
+		HostAndPort sentinelMaster = new HostAndPort(sentinelMasterInfos.get(0), 
+				Integer.parseInt(sentinelMasterInfos.get(1)));
+
+		return sentinelMaster.equals(master);
+	}
+
+	private static boolean isSlavesRecognized(Jedis sentinelJedis, String masterName, List<HostAndPort> slaves) {
+		List<Map<String, String>> slavesMap = sentinelJedis.sentinelSlaves(masterName);
+
+		if (slavesMap.size() != slaves.size())
+			return false;
+
+		int slavesRecognized = 0;
+
+		for (HostAndPort slave : slaves) {
+			if (isSlaveFoundInSlavesMap(slavesMap, slave))
+				slavesRecognized++;
+		}
+
+		return slavesRecognized == slaves.size();
+	}
+
+	private static boolean isSlaveFoundInSlavesMap(List<Map<String,String>> slavesMap, HostAndPort slave) {
+		for (Map<String, String> slaveMap : slavesMap) {
+			HostAndPort sentinelSlave = new HostAndPort(slaveMap.get("ip"), 
+					Integer.parseInt(slaveMap.get("port")));
+
+			if (sentinelSlave.equals(slave))
+				return true;
+		}
+
+		return false;
+	}
+
+}


### PR DESCRIPTION
In JedisSentinelTest and JedisSentinelPoolTest, there're many FIXMEs to wait for replication and sentinels setup using much time of sleep.
It's so inefficient (wastes some seconds), and tests can fail under some situation. (slow cpu, heavy load to other processes)

I implemented functions to wait based on replication and sentinels status, and JedisSentinelPool's status.
With applying to tests, tests succeed with reasonable sleep.

> FIXME: (In Redis 2.6.16) There're no command for sentinel to list recognized sentinels, so I cannot remove all of sleep codes.

Belows are change notes for commit.
# 
- remove FIXME sleep codes for Sentinel related tests
  - target : JedisSentinelTest, JedisSentinelPoolTest
  - add functions for Sentinel tests (JedisSentinelTestUtil)
    - waitForSentinelRecognizeRedisReplication
    - waitForNewPromotedMaster
    - waitForSentinelsRecognizeEachOthers
      - TODO: there're no command for sentinel to list recognized sentinel
      - sleep 5.5 sec (sentinel say hello to master's pubsub channel every 5 sec to recognize other sentinels)
- set HostAndPort class to public(no longer inner) class
  - reasons
    - We cannot know JedisSentinelPool's current master if HostAndPort class is private inner class
    - HostAndPort classes are duplicated (main/test)
  - make getter method and parameterized constructor
    - set fields once, get anytime
