### PR TITLE
added timeout for pubsub

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -36,6 +36,18 @@ public class Connection {
         this.timeout = timeout;
     }
 
+    public void setPubSubTimeout(int timeout) {
+        try {
+            if(!isConnected()) {
+                connect();
+            }
+            socket.setKeepAlive(true);
+            socket.setSoTimeout(timeout);
+        } catch (SocketException ex) {
+            throw new JedisException(ex);
+        }
+    }
+
     public void setTimeoutInfinite() {
         try {
             if(!isConnected()) {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -2755,6 +2755,14 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     client.rollbackTimeout();
     }
 
+    public void psubscribe(final JedisPubSub jedisPubSub, int timeout,
+        final String... patterns) {
+    checkIsInMulti();
+    connect();
+    client.setPubSubTimeout(timeout);
+    jedisPubSub.proceedWithPatterns(client, patterns);
+    client.rollbackTimeout();
+    }    
     protected static String[] getParams(List<String> keys, List<String> args) {
 	int keyCount = keys.size();
 	int argCount = args.size();


### PR DESCRIPTION
I have a firewall issue where an open socket gets severed after a period of time. I needed to implement a timeout for the pubsub, and (separately) implement an ack mechanism. I didn't want to alter the existing method with an infinite timeout. 
