### PR TITLE
Update Gradle build to use Apache Commons Pool 2.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     testCompile 'junit:junit:4.11'
-    compile 'commons-pool:commons-pool:1.6'
+    compile 'org.apache.commons:commons-pool2:2.0'
 }
 
 


### PR DESCRIPTION
Trivial patch for part of issue 479 - fix issue with Gradle build file referencing commons pool 1.6.
