### PR TITLE
make jedis unit tests pass to Redis 2.8.1 (cleaned ver. of #486)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,17 @@ save ""
 appendonly no
 endef
 
+define REDIS6_CONF
+daemonize yes
+port 6384
+requirepass foobared
+masterauth foobared
+pidfile /tmp/redis6.pid
+logfile /tmp/redis6.log
+save ""
+appendonly no
+endef
+
 define REDIS_SENTINEL1
 port 26379
 daemonize yes
@@ -91,6 +102,7 @@ export REDIS2_CONF
 export REDIS3_CONF
 export REDIS4_CONF
 export REDIS5_CONF
+export REDIS6_CONF
 export REDIS_SENTINEL1
 export REDIS_SENTINEL2
 export REDIS_SENTINEL3
@@ -101,8 +113,11 @@ start:
 	echo "$$REDIS3_CONF" | redis-server -
 	echo "$$REDIS4_CONF" | redis-server -
 	echo "$$REDIS5_CONF" | redis-server -
+	echo "$$REDIS6_CONF" | redis-server -
 	echo "$$REDIS_SENTINEL1" > /tmp/sentinel1.conf && redis-server /tmp/sentinel1.conf --sentinel
+	@sleep 0.5
 	echo "$$REDIS_SENTINEL2" > /tmp/sentinel2.conf && redis-server /tmp/sentinel2.conf --sentinel
+	@sleep 0.5
 	echo "$$REDIS_SENTINEL3" > /tmp/sentinel3.conf && redis-server /tmp/sentinel3.conf --sentinel
 
 stop:
@@ -112,76 +127,26 @@ stop:
 	kill `cat /tmp/redis3.pid` || true
 	kill `cat /tmp/redis4.pid` || true
 	kill `cat /tmp/redis5.pid` || true
+	kill `cat /tmp/redis6.pid` || true
 	kill `cat /tmp/sentinel1.pid`
 	kill `cat /tmp/sentinel2.pid`
 	kill `cat /tmp/sentinel3.pid`
 
 test:
-	echo "$$REDIS1_CONF" | redis-server -
-	echo "$$REDIS2_CONF" | redis-server -
-	echo "$$REDIS3_CONF" | redis-server -
-	echo "$$REDIS4_CONF" | redis-server -
-	echo "$$REDIS5_CONF" | redis-server -
-	echo "$$REDIS_SENTINEL1" | redis-server - --sentinel
-	echo "$$REDIS_SENTINEL2" | redis-server - --sentinel
-	echo "$$REDIS_SENTINEL3" | redis-server - --sentinel
-
+	make start
 	mvn clean compile test
-
-	kill `cat /tmp/redis1.pid`
-	kill `cat /tmp/redis2.pid`
-	# this get's segfaulted by the tests
-	kill `cat /tmp/redis3.pid` || true
-	kill `cat /tmp/redis4.pid` || true
-	kill `cat /tmp/redis5.pid` || true
-	kill `cat /tmp/sentinel1.pid`
-	kill `cat /tmp/sentinel2.pid`
-	kill `cat /tmp/sentinel3.pid`
+	make stop
 
 deploy:
-	echo "$$REDIS1_CONF" | redis-server -
-	echo "$$REDIS2_CONF" | redis-server -
-	echo "$$REDIS3_CONF" | redis-server -
-	echo "$$REDIS4_CONF" | redis-server -
-	echo "$$REDIS5_CONF" | redis-server -
-	echo "$$REDIS_SENTINEL1" | redis-server - --sentinel
-	echo "$$REDIS_SENTINEL2" | redis-server - --sentinel
-	echo "$$REDIS_SENTINEL3" | redis-server - --sentinel
-
+	make start
 	mvn clean deploy
-
-	kill `cat /tmp/redis1.pid`
-	kill `cat /tmp/redis2.pid`
-	# this get's segfaulted by the tests
-	kill `cat /tmp/redis3.pid` || true
-	kill `cat /tmp/redis4.pid` || true
-	kill `cat /tmp/redis5.pid` || true
-	kill `cat /tmp/sentinel1.pid`
-	kill `cat /tmp/sentinel2.pid`
-	kill `cat /tmp/sentinel3.pid`
+	make stop
 
 release:
-	echo "$$REDIS1_CONF" | redis-server -
-	echo "$$REDIS2_CONF" | redis-server -
-	echo "$$REDIS3_CONF" | redis-server -
-	echo "$$REDIS4_CONF" | redis-server -
-	echo "$$REDIS5_CONF" | redis-server -
-	echo "$$REDIS_SENTINEL1" | redis-server - --sentinel
-	echo "$$REDIS_SENTINEL2" | redis-server - --sentinel
-	echo "$$REDIS_SENTINEL3" | redis-server - --sentinel
-
+	make start
 	mvn release:clean
 	mvn release:prepare
 	mvn release:perform
-
-	kill `cat /tmp/redis1.pid`
-	kill `cat /tmp/redis2.pid`
-	# this get's segfaulted by the tests
-	kill `cat /tmp/redis3.pid` || true
-	kill `cat /tmp/redis4.pid` || true
-	kill `cat /tmp/redis5.pid` || true 
-	kill `cat /tmp/sentinel1.pid`
-	kill `cat /tmp/sentinel2.pid`
-	kill `cat /tmp/sentinel3.pid`
+	make stop
 
 .PHONY: test

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
   </scm>
 
 	<properties>
-		<redis-hosts>localhost:6379,localhost:6380,localhost:6381,localhost:6382,localhost:6383</redis-hosts>
-		<sentinel-hosts>localhost:26379,localhost:26380</sentinel-hosts>
-    <github.global.server>github</github.global.server>
+		<redis-hosts>localhost:6379,localhost:6380,localhost:6381,localhost:6382,localhost:6383,localhost:6384</redis-hosts>
+		<sentinel-hosts>localhost:26379,localhost:26380,localhost:26381</sentinel-hosts>
+    	<github.global.server>github</github.global.server>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/redis/clients/jedis/HostAndPort.java
+++ b/src/main/java/redis/clients/jedis/HostAndPort.java
@@ -1,6 +1,8 @@
 package redis.clients.jedis;
 
 public class HostAndPort {
+	public static final String LOCALHOST_STR = "localhost";
+	
 	private String host;
 	private int port;
 	
@@ -22,11 +24,11 @@ public class HostAndPort {
 	    if (obj instanceof HostAndPort) {
 			HostAndPort hp = (HostAndPort) obj;
 			
-			// localhost and 127.0.0.1 is same
-			return port == hp.port && 
-				(host.equals(hp.host) || 
-						(host.equals("localhost") && hp.host.equals("127.0.0.1")) || 
-						(host.equals("127.0.0.1") && hp.host.equals("localhost")) );
+            String thisHost = convertHost(host);
+            String hpHost = convertHost(hp.host);
+            return port == hp.port &&
+            		thisHost.equals(hpHost);
+
 	    }
 	    
 	    return false;
@@ -36,4 +38,13 @@ public class HostAndPort {
 	public String toString() {
 	    return host + ":" + port;
 	}
+	
+    private String convertHost(String host) {
+        if (host.equals("127.0.0.1"))
+                return LOCALHOST_STR;
+        else if (host.equals("::1"))
+                return LOCALHOST_STR;
+
+        return host;
+    }
 }

--- a/src/test/java/redis/clients/jedis/tests/HostAndPortUtil.java
+++ b/src/test/java/redis/clients/jedis/tests/HostAndPortUtil.java
@@ -27,14 +27,17 @@ public class HostAndPortUtil {
         HostAndPort defaulthnp5 = new HostAndPort("localhost", Protocol.DEFAULT_PORT + 4);
         redisHostAndPortList.add(defaulthnp5);
         
-        HostAndPort defaulthnp6 = new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT);
-        sentinelHostAndPortList.add(defaulthnp6);
+        HostAndPort defaulthnp6 = new HostAndPort("localhost", Protocol.DEFAULT_PORT + 5);
+        redisHostAndPortList.add(defaulthnp6);
         
-        HostAndPort defaulthnp7 = new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 1);
+        HostAndPort defaulthnp7 = new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT);
         sentinelHostAndPortList.add(defaulthnp7);
         
-        HostAndPort defaulthnp8 = new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 2);
+        HostAndPort defaulthnp8 = new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 1);
         sentinelHostAndPortList.add(defaulthnp8);
+        
+        HostAndPort defaulthnp9 = new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 2);
+        sentinelHostAndPortList.add(defaulthnp9);
 
         String envRedisHosts = System.getProperty("redis-hosts");
         String envSentinelHosts = System.getProperty("sentinel-hosts");


### PR DESCRIPTION
It's a cleaned version of #486.

I modified unit tests to pass at Redis 2.8.1.

To pass unit tests at Redis 2.8.1, I've fixed some issues.
- commented JedisSentinelTest.clear() and add Redis instance for JedisSentinelTest's slave
  - If slave try to promote master itself, New Sentinel forces to demote it
    - JedisSentinelTest.clear() has no effect, and wait infinitely
    - Slave (6380) is not reusable for another unit tests (as master)
  - previously JedisSentinelTest uses Redis instance (port 6380) shared to Sharding unit tests.
- ipv6 applied to Redis 2.8
  - currently localhost and 127.0.0.1 and ::1 is all same
- Makefile: sleep some time for launch each sentinel (workaround to sentinel's issue)
  - issue to sentinel leader vote: https://github.com/antirez/redis/issues/1419
    - sentinel may confused to vote with sentinels launched approximately same time
