### PR TITLE
ShardedJedis can take optional parameters for h/s/z scan commands

### DIFF
--- a/src/main/java/redis/clients/jedis/ShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedis.java
@@ -528,13 +528,28 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands {
 	return j.hscan(key, cursor);
     }
     
+    public ScanResult<Entry<String, String>> hscan(String key, int cursor, final ScanParams params) {
+    	Jedis j = getShard(key);
+    	return j.hscan(key, cursor, params);
+    }
+    
     public ScanResult<String> sscan(String key, int cursor) {
 	Jedis j = getShard(key);
 	return j.sscan(key, cursor);
     }
     
+    public ScanResult<String> sscan(String key, int cursor, final ScanParams params) {
+    	Jedis j = getShard(key);
+    	return j.sscan(key, cursor, params);
+    }
+    
     public ScanResult<Tuple> zscan(String key, int cursor) {
 	Jedis j = getShard(key);
 	return j.zscan(key, cursor);
+    }
+    
+    public ScanResult<Tuple> zscan(String key, int cursor, final ScanParams params) {
+    	Jedis j = getShard(key);
+    	return j.zscan(key, cursor, params);
     }
 }


### PR DESCRIPTION
Hello.
Jonathan pushed *scan commands to Jedis master branch, it's amazing!

I wish to add some functionalities to new commands.
Since sharding algorithm is based on key, h/s/z scan using option parameters can make sense to ShardedJedis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xetorthio/jedis/491)
<!-- Reviewable:end -->
