### PR TITLE
BinaryJedis.multi(TransactionBlock) should not call discard when exception occurred

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -1685,13 +1685,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     public List<Object> multi(final TransactionBlock jedisTransaction) {
 	List<Object> results = null;
 	jedisTransaction.setClient(client);
-	try {
-	    client.multi();
-	    jedisTransaction.execute();
-	    results = jedisTransaction.exec();
-	} catch (Exception ex) {
-	    jedisTransaction.discard();
-	}
+    client.multi();
+    jedisTransaction.execute();
+    results = jedisTransaction.exec();
 	return results;
     }
 


### PR DESCRIPTION
I have found this bug from #496 (Thanks @dmk23 !)

In BinaryJedis.multi(TransactionBlock), exception normally occurred from `results = jedisTransaction.exec()`.
(If exception occurred from jedisTransaction.execute(), I think it's up to developer - should handle to TransactionBlock.execute() block)

When exception occurred from jedisTransaction.exec(), multi() & exec() already sent to Redis, transaction ended.
So discard() has no effect, and made another error (discard without multi)

I have removed discard() from BinaryJedis.multi(TransactionBlock), and also exception handling statements.

Below is commit log
# 
- In BinaryJedis.multi(TransactionBlock), multi & exec already fired before exception occured, so sending discard has no effect, and made another error
  - add unit test (error inside TransactionBlock)
    - Transaction with error - Redis discards transaction automatically (execabort)
    - Transaction with error - Redis doesn't roll back (force to execute all)
