### PR TITLE
Fix some timing issues related to JedisSentinelPool and ControlCommandsTest

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -98,10 +98,10 @@ public class JedisSentinelPool extends Pool<Jedis> {
 
     private void initPool(HostAndPort master) {
 	if (!master.equals(currentHostMaster)) {
+		initPool(poolConfig, new JedisFactory(master.getHost(), master.getPort(),
+			    timeout, password, database));
 	    currentHostMaster = master;
 	    log.info("Created JedisPool to master at " + master);
-	    initPool(poolConfig, new JedisFactory(master.getHost(), master.getPort(),
-		    timeout, password, database));
 	}
     }
 

--- a/src/main/java/redis/clients/util/Pool.java
+++ b/src/main/java/redis/clients/util/Pool.java
@@ -9,6 +9,7 @@ import redis.clients.jedis.exceptions.JedisException;
 
 public abstract class Pool<T> {
     protected GenericObjectPool<T> internalPool;
+    protected Object lock = new Object();
 
     /**
      * Using this constructor means you have to set and initialize the
@@ -25,32 +26,39 @@ public abstract class Pool<T> {
     public void initPool(final GenericObjectPoolConfig poolConfig,
 	    PooledObjectFactory<T> factory) {
 
-	if (this.internalPool != null) {
-	    try {
-		closeInternalPool();
-	    } catch (Exception e) {
-	    }
-	}
-
-	this.internalPool = new GenericObjectPool<T>(factory, poolConfig);
+    	synchronized (lock) {
+    		if (this.internalPool != null) {
+				try {
+					closeInternalPool();
+			    } catch (Exception e) {
+			    }
+    		}
+    		
+    		this.internalPool = new GenericObjectPool<T>(factory, poolConfig);
+    	}
+    	
     }
 
     public T getResource() {
-	try {
-	    return internalPool.borrowObject();
-	} catch (Exception e) {
-	    throw new JedisConnectionException(
-		    "Could not get a resource from the pool", e);
-	}
+    	synchronized (lock) {
+			try {
+			    return internalPool.borrowObject();
+			} catch (Exception e) {
+			    throw new JedisConnectionException(
+				    "Could not get a resource from the pool", e);
+			}
+    	}
     }
 
     public void returnResourceObject(final T resource) {
-	try {
-	    internalPool.returnObject(resource);
-	} catch (Exception e) {
-	    throw new JedisException(
-		    "Could not return the resource to the pool", e);
-	}
+    	synchronized (lock) {
+			try {
+			    internalPool.returnObject(resource);
+			} catch (Exception e) {
+			    throw new JedisException(
+				    "Could not return the resource to the pool", e);
+			}
+    	}
     }
 
     public void returnBrokenResource(final T resource) {
@@ -66,12 +74,14 @@ public abstract class Pool<T> {
     }
 
     protected void returnBrokenResourceObject(final T resource) {
-	try {
-	    internalPool.invalidateObject(resource);
-	} catch (Exception e) {
-	    throw new JedisException(
-		    "Could not return the resource to the pool", e);
-	}
+    	synchronized (lock) {
+			try {
+			    internalPool.invalidateObject(resource);
+			} catch (Exception e) {
+			    throw new JedisException(
+				    "Could not return the resource to the pool", e);
+			}
+    	}
     }
 
     protected void closeInternalPool() {

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
@@ -1,3 +1,4 @@
+
 package redis.clients.jedis.tests;
 
 import java.util.HashSet;
@@ -13,20 +14,21 @@ import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPubSub;
 import redis.clients.jedis.JedisSentinelPool;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 
 public class JedisSentinelPoolTest extends JedisTestBase {
     private static final String MASTER_NAME = "mymaster";
 
     protected static HostAndPort master = HostAndPortUtil.getRedisServers()
-	    .get(2);
+         .get(2);
     protected static HostAndPort slave1 = HostAndPortUtil.getRedisServers()
-	    .get(3);
+         .get(3);
     protected static HostAndPort slave2 = HostAndPortUtil.getRedisServers()
-	    .get(4);
+         .get(4);
     protected static HostAndPort sentinel1 = HostAndPortUtil
-	    .getSentinelServers().get(1);
+         .getSentinelServers().get(1);
     protected static HostAndPort sentinel2 = HostAndPortUtil
-	    .getSentinelServers().get(2);
+         .getSentinelServers().get(2);
 
     protected static Jedis sentinelJedis1;
 
@@ -34,119 +36,153 @@ public class JedisSentinelPoolTest extends JedisTestBase {
 
     @Before
     public void setUp() throws Exception {
-	sentinels.add(sentinel1.toString());
-	sentinels.add(sentinel2.toString());
+     sentinels.add(sentinel1.toString());
+     sentinels.add(sentinel2.toString());
 
-	sentinelJedis1 = new Jedis(sentinel1.getHost(), sentinel1.getPort());
+     sentinelJedis1 = new Jedis(sentinel1.getHost(), sentinel1.getPort());
     }
 
     @Test
     public void ensureSafeTwiceFailover() throws InterruptedException {
-	JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels,
-		new GenericObjectPoolConfig(), 1000, "foobared", 2);
+     JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels,
+          new GenericObjectPoolConfig(), 1000, "foobared", 2);
 
-	// perform failover
-	doSegFaultMaster(pool);
+     // perform failover
+     doSegFaultMaster(pool);
 
-	// perform failover once again
-	doSegFaultMaster(pool);
+     // perform failover once again
+     doSegFaultMaster(pool);
 
-	// you can test failover as much as possible
-	// but you need to prepare additional slave per failover
+     // you can test failover as much as possible
+     // but you need to prepare additional slave per failover
     }
 
     private void doSegFaultMaster(JedisSentinelPool pool)
-	    throws InterruptedException {
-	HostAndPort oldMaster = pool.getCurrentHostMaster();
+         throws InterruptedException {
+          HostAndPort oldMaster = pool.getCurrentHostMaster();
 
-	// jedis connection should be master
-	Jedis jedis = pool.getResource();
-	assertEquals("PONG", jedis.ping());
+          Jedis jedis = null;
 
-	try {
-	    jedis.debug(DebugParams.SEGFAULT());
-	} catch (Exception e) {
-	}
+          // 1. test master
+          try {
+               jedis = pool.getResource();
+               assertEquals("PONG", jedis.ping());
+          } catch (JedisConnectionException e) {
+               if (null != jedis)
+                    pool.returnBrokenResource(jedis);
 
-	waitForFailover(pool, oldMaster);
+               jedis = null;
+               throw e;
+          }
 
-	jedis = pool.getResource();
-	assertEquals("PONG", jedis.ping());
-	assertEquals("foobared", jedis.configGet("requirepass").get(1));
-	assertEquals(2, jedis.getDB().intValue());
+          // 2. kill master
+          try {
+              jedis.debug(DebugParams.SEGFAULT());
+          } catch (JedisConnectionException e) {
+               // it's OK because "debug segfault" makes Redis Server killed and Jedis throws JedisConnectionException
+          } finally {
+               // Redis Server already closed
+               if (null != jedis)
+                    pool.returnBrokenResource(jedis);
+          }
+
+          // 3. wait for failover
+          waitForFailover(pool, oldMaster);
+
+          jedis = null;
+
+          // 4. test new master
+          try {
+               jedis = pool.getResource();
+               assertEquals("PONG", jedis.ping());
+               assertEquals("foobared", jedis.configGet("requirepass").get(1));
+               assertEquals(2, jedis.getDB().intValue());
+
+          } catch (JedisConnectionException e) {
+               if (null != jedis)
+                    pool.returnBrokenResource(jedis);
+
+               jedis = null;
+               throw e;
+          } finally {
+               if (null != jedis)
+                    pool.returnResource(jedis);
+          }
+
     }
 
     private void waitForFailover(JedisSentinelPool pool, HostAndPort oldMaster)
-	    throws InterruptedException {
-	waitForJedisSentinelPoolRecognizeNewMaster(pool);
+         throws InterruptedException {
+     waitForJedisSentinelPoolRecognizeNewMaster(pool);
     }
 
     private void waitForJedisSentinelPoolRecognizeNewMaster(
-	    JedisSentinelPool pool) throws InterruptedException {
+         JedisSentinelPool pool) throws InterruptedException {
 
-	final AtomicReference<String> newmaster = new AtomicReference<String>(
-		"");
+     final AtomicReference<String> newmaster = new AtomicReference<String>(
+          "");
 
-	sentinelJedis1.psubscribe(new JedisPubSub() {
+     sentinelJedis1.psubscribe(new JedisPubSub() {
 
-	    @Override
-	    public void onMessage(String channel, String message) {
-		// TODO Auto-generated method stub
+         @Override
+         public void onMessage(String channel, String message) {
+          // TODO Auto-generated method stub
 
-	    }
+         }
 
-	    @Override
-	    public void onPMessage(String pattern, String channel,
-		    String message) {
-		if (channel.equals("+switch-master")) {
-		    newmaster.set(message);
-		    punsubscribe();
-		}
-		// TODO Auto-generated method stub
+         @Override
+         public void onPMessage(String pattern, String channel,
+              String message) {
+          if (channel.equals("+switch-master")) {
+              newmaster.set(message);
+              punsubscribe();
+          }
+          // TODO Auto-generated method stub
 
-	    }
+         }
 
-	    @Override
-	    public void onSubscribe(String channel, int subscribedChannels) {
-		// TODO Auto-generated method stub
+         @Override
+         public void onSubscribe(String channel, int subscribedChannels) {
+          // TODO Auto-generated method stub
 
-	    }
+         }
 
-	    @Override
-	    public void onUnsubscribe(String channel, int subscribedChannels) {
-		// TODO Auto-generated method stub
+         @Override
+         public void onUnsubscribe(String channel, int subscribedChannels) {
+          // TODO Auto-generated method stub
 
-	    }
+         }
 
-	    @Override
-	    public void onPUnsubscribe(String pattern, int subscribedChannels) {
-		// TODO Auto-generated method stub
+         @Override
+         public void onPUnsubscribe(String pattern, int subscribedChannels) {
+          // TODO Auto-generated method stub
 
-	    }
+         }
 
-	    @Override
-	    public void onPSubscribe(String pattern, int subscribedChannels) {
-		// TODO Auto-generated method stub
+         @Override
+         public void onPSubscribe(String pattern, int subscribedChannels) {
+          // TODO Auto-generated method stub
 
-	    }
-	}, "*");
+         }
+     }, "*");
 
-	String[] chunks = newmaster.get().split(" ");
-	HostAndPort newMaster = new HostAndPort(chunks[3],
-		Integer.parseInt(chunks[4]));
+     String[] chunks = newmaster.get().split(" ");
+     HostAndPort newMaster = new HostAndPort(chunks[3],
+          Integer.parseInt(chunks[4]));
 
-	while (true) {
-	    String host = pool.getCurrentHostMaster().getHost();
-	    int port = pool.getCurrentHostMaster().getPort();
+     while (true) {
+         String host = pool.getCurrentHostMaster().getHost();
+         int port = pool.getCurrentHostMaster().getPort();
 
-	    if (host.equals(newMaster.getHost()) && port == newMaster.getPort())
-		break;
+         if (host.equals(newMaster.getHost()) && port == newMaster.getPort()) {
+              break;
+         }
 
-	    System.out
-		    .println("JedisSentinelPool's master is not yet changed, sleep...");
+         System.out
+              .println("JedisSentinelPool's master is not yet changed, sleep...");
 
-	    Thread.sleep(100);
-	}
+         Thread.sleep(100);
+     }
     }
 
-}
+} 

--- a/src/test/java/redis/clients/jedis/tests/commands/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ControlCommandsTest.java
@@ -61,12 +61,18 @@ public class ControlCommandsTest extends JedisCommandTestBase {
     public void monitor() {
 	new Thread(new Runnable() {
 	    public void run() {
-		Jedis j = new Jedis("localhost");
-		j.auth("foobared");
-		for (int i = 0; i < 5; i++) {
-		    j.incr("foobared");
-		}
-		j.disconnect();
+	    	// sleep 0.1 sec so monitor runs before incr
+	    	try {
+				Thread.sleep(100);
+			} catch (InterruptedException e) {
+			}
+			
+	    	Jedis j = new Jedis("localhost");
+			j.auth("foobared");
+			for (int i = 0; i < 5; i++) {
+			    j.incr("foobared");
+			}
+			j.disconnect();
 	    }
 	}).start();
 


### PR DESCRIPTION
Sometimes unit tests hang or fail whether Redis (and Sentinels) are having issues or not.

Monitor command test sometimes hang when input thread run earlier than monitor thread.
JedisSentinelPoolTest sometimes fail when test requests jedis instance from pool but pool is being re-initialized because of master changed. (assertOpen() failed)

Below is commit log
# 
- Pool
  - synchronize all inner pool usages (to avoid timing issue)
- JedisSentinelPool
  - when master changed, change current master information after reinitialize inner pool
- ControlCommandsTest
  - fix monitor command test - monitor 
- JedisSentinelPoolTest
  - fix resource leak (jedis instance not returned to pool)
