### PR TITLE
added feature : JedisPool / JedisSentinelPool resets returning object's state (watched, multi)

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -29,13 +29,19 @@ public class BinaryClient extends Connection {
     }
 
     private boolean isInMulti;
-
+    
     private String password;
 
     private long db;
 
+	private boolean isInWatch;
+
     public boolean isInMulti() {
 	return isInMulti;
+    }
+
+    public boolean isInWatch() {
+    return isInWatch;
     }
 
     public BinaryClient(final String host) {
@@ -447,19 +453,23 @@ public class BinaryClient extends Connection {
     public void discard() {
 	sendCommand(DISCARD);
 	isInMulti = false;
+	isInWatch = false;
     }
 
     public void exec() {
 	sendCommand(EXEC);
 	isInMulti = false;
+	isInWatch = false;
     }
 
     public void watch(final byte[]... keys) {
 	sendCommand(WATCH, keys);
+	isInWatch = true;
     }
 
     public void unwatch() {
 	sendCommand(UNWATCH);
+	isInWatch = false;
     }
 
     public void sort(final byte[] key) {
@@ -911,6 +921,14 @@ public class BinaryClient extends Connection {
     public void disconnect() {
 	db = 0;
 	super.disconnect();
+    }
+    
+    public void resetState() {
+    	if (isInMulti())
+    		discard();
+    	
+    	if (isInWatch())
+    		unwatch();
     }
 
     private void sendEvalCommand(Command command, byte[] script,

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -1709,6 +1709,11 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     public void disconnect() {
 	client.disconnect();
     }
+    
+    public void resetState() {
+	client.resetState();
+	client.getAll();
+    }
 
     public String watch(final byte[]... keys) {
 	client.watch(keys);

--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -84,6 +84,7 @@ public class JedisPool extends Pool<Jedis> {
     }
 
     public void returnResource(final Jedis resource) {
+    resource.resetState();
 	returnResourceObject(resource);
     }
 }

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -79,6 +79,7 @@ public class JedisSentinelPool extends Pool<Jedis> {
     }
 
     public void returnResource(final Jedis resource) {
+    resource.resetState();
 	returnResourceObject(resource);
     }
 

--- a/src/test/java/redis/clients/jedis/tests/commands/TransactionCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/TransactionCommandsTest.java
@@ -12,10 +12,12 @@ import org.junit.Test;
 
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol.Keyword;
+import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.Response;
 import redis.clients.jedis.Transaction;
 import redis.clients.jedis.TransactionBlock;
 import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.exceptions.JedisException;
 
 public class TransactionCommandsTest extends JedisCommandTestBase {
     final byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };
@@ -293,5 +295,49 @@ public class TransactionCommandsTest extends JedisCommandTestBase {
 	List<Object> results = t.exec();
 
 	assertNull(results);
+    }
+    
+    @Test
+    public void testResetStateWhenInMulti() {
+    	jedis.auth("foobared");
+    	
+    	Transaction t = jedis.multi();
+    	t.set("foooo", "barrr");
+    	
+    	jedis.resetState();
+    	assertEquals(null, jedis.get("foooo"));
+    }
+    
+    @Test
+    public void testResetStateWhenInMultiWithinPipeline() {
+    	jedis.auth("foobared");
+    	
+    	Pipeline p = jedis.pipelined();
+    	p.multi();
+    	p.set("foooo", "barrr");
+
+    	jedis.resetState();
+    	assertEquals(null, jedis.get("foooo"));
+    }
+
+    @Test
+    public void testResetStateWhenInWatch() {
+    	jedis.watch("mykey", "somekey");
+    	
+    	// state reset : unwatch
+    	jedis.resetState();
+    	
+    	Transaction t = jedis.multi();
+
+    	nj.connect();
+    	nj.auth("foobared");
+    	nj.set("mykey", "bar");
+    	nj.disconnect();
+
+    	t.set("mykey", "foo");
+    	List<Object> resp = t.exec();
+    	assertNotNull(resp);
+    	assertEquals(1, resp.size());
+    	assertEquals("foo", jedis.get("mykey"));
     }
 }


### PR DESCRIPTION
It's based on requests #500, and it seems to make sense.
- BinaryClient / BinaryJedis : added feature to reset its state (watched, multi)
- JedisPool / JedisSentinelPool : calls new feature (reset state) when Jedis object returns to pool

I used flag for check 'watched', but 'unwatch' command is no problem for non-watched status.
So, flag can be removed if we call 'unwatch' every reset state.
