### PR TITLE
Fix BinaryJedis.eval() method bug (argument)

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -3140,12 +3140,13 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 
     private byte[][] getParams(List<byte[]> keys, List<byte[]> args) {
 	int keyCount = keys.size();
+	int argCount = args.size();
 	byte[][] params = new byte[keyCount + args.size()][];
 
 	for (int i = 0; i < keyCount; i++)
 	    params[i] = keys.get(i);
 
-	for (int i = 0; i < keys.size(); i++)
+	for (int i = 0; i < argCount; i++)
 	    params[keyCount + i] = args.get(i);
 
 	return params;

--- a/src/test/java/redis/clients/jedis/tests/commands/ScriptingCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ScriptingCommandsTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import redis.clients.jedis.BinaryJedis;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.util.SafeEncoder;
 
@@ -13,7 +14,7 @@ public class ScriptingCommandsTest extends JedisCommandTestBase {
     @SuppressWarnings("unchecked")
     @Test
     public void evalMultiBulk() {
-	String script = "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}";
+	String script = "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2],ARGV[3]}";
 	List<String> keys = new ArrayList<String>();
 	keys.add("key1");
 	keys.add("key2");
@@ -21,14 +22,42 @@ public class ScriptingCommandsTest extends JedisCommandTestBase {
 	List<String> args = new ArrayList<String>();
 	args.add("first");
 	args.add("second");
+	args.add("third");
 
 	List<String> response = (List<String>) jedis.eval(script, keys, args);
 
-	assertEquals(4, response.size());
+	assertEquals(5, response.size());
 	assertEquals("key1", response.get(0));
 	assertEquals("key2", response.get(1));
 	assertEquals("first", response.get(2));
 	assertEquals("second", response.get(3));
+	assertEquals("third", response.get(4));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void evalMultiBulkWithBinaryJedis() {
+    	String script = "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2],ARGV[3]}";
+    	List<byte[]> keys = new ArrayList<byte[]>();
+    	keys.add("key1".getBytes());
+    	keys.add("key2".getBytes());
+
+    	List<byte[]> args = new ArrayList<byte[]>();
+    	args.add("first".getBytes());
+    	args.add("second".getBytes());
+    	args.add("third".getBytes());
+
+    	BinaryJedis binaryJedis = new BinaryJedis(hnp.getHost(), hnp.getPort(), 500);
+    	binaryJedis.connect();
+    	binaryJedis.auth("foobared");
+        
+    	List<byte[]> responses = (List<byte[]>) binaryJedis.eval(script.getBytes(), keys, args);
+    	assertEquals(5, responses.size());
+    	assertEquals("key1", new String(responses.get(0)));
+    	assertEquals("key2", new String(responses.get(1)));
+    	assertEquals("first", new String(responses.get(2)));
+    	assertEquals("second", new String(responses.get(3)));
+    	assertEquals("third", new String(responses.get(4)));
     }
 
     @Test


### PR DESCRIPTION
This PR resolves #414.

Main cause is, there are difference from Jedis.eval() and BinaryJedis.eval().
It means BinaryJedis has bug, and we couldn't check automatically because unit test only checks Jedis.eval().
