### PR TITLE
Fix ControlCommandsTest to don't hang from monitor test because of timing issue

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/commands/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ControlCommandsTest.java
@@ -61,6 +61,11 @@ public class ControlCommandsTest extends JedisCommandTestBase {
     public void monitor() {
 	new Thread(new Runnable() {
 	    public void run() {
+    	try {
+    		// sleep 100ms to make sure that monitor thread runs first 
+    		Thread.sleep(100);
+    	} catch (InterruptedException e) {
+    	}
 		Jedis j = new Jedis("localhost");
 		j.auth("foobared");
 		for (int i = 0; i < 5; i++) {


### PR DESCRIPTION
Monitor command test sometimes hang when input thread run earlier than monitor thread.

I modified test to input thread waits for monitor thread to start, and resume running.
(Actually I implemented this by sleep 100ms.)

ps. This issue is spllited PR from #499 
