### PR TITLE
Fix Pool (and JedisSentinelPool) 's race condition

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -98,10 +98,10 @@ public class JedisSentinelPool extends Pool<Jedis> {
 
     private void initPool(HostAndPort master) {
 	if (!master.equals(currentHostMaster)) {
+	    initPool(poolConfig, new JedisFactory(master.getHost(), master.getPort(),
+			    timeout, password, database));
 	    currentHostMaster = master;
 	    log.info("Created JedisPool to master at " + master);
-	    initPool(poolConfig, new JedisFactory(master.getHost(), master.getPort(),
-		    timeout, password, database));
 	}
     }
 

--- a/src/main/java/redis/clients/util/Pool.java
+++ b/src/main/java/redis/clients/util/Pool.java
@@ -9,6 +9,7 @@ import redis.clients.jedis.exceptions.JedisException;
 
 public abstract class Pool<T> {
     protected GenericObjectPool<T> internalPool;
+    protected Object lock = new Object();
 
     /**
      * Using this constructor means you have to set and initialize the
@@ -25,32 +26,38 @@ public abstract class Pool<T> {
     public void initPool(final GenericObjectPoolConfig poolConfig,
 	    PooledObjectFactory<T> factory) {
 
-	if (this.internalPool != null) {
-	    try {
-		closeInternalPool();
-	    } catch (Exception e) {
-	    }
+    synchronized (lock) {
+		if (this.internalPool != null) {
+		    try {
+			closeInternalPool();
+		    } catch (Exception e) {
+		    }
+		}
+		
+		this.internalPool = new GenericObjectPool<T>(factory, poolConfig);
 	}
-
-	this.internalPool = new GenericObjectPool<T>(factory, poolConfig);
     }
 
     public T getResource() {
-	try {
-	    return internalPool.borrowObject();
-	} catch (Exception e) {
-	    throw new JedisConnectionException(
-		    "Could not get a resource from the pool", e);
+    synchronized (lock) {
+		try {
+		    return internalPool.borrowObject();
+		} catch (Exception e) {
+		    throw new JedisConnectionException(
+			    "Could not get a resource from the pool", e);
+		}
 	}
     }
 
     public void returnResourceObject(final T resource) {
-	try {
-	    internalPool.returnObject(resource);
-	} catch (Exception e) {
-	    throw new JedisException(
-		    "Could not return the resource to the pool", e);
-	}
+    synchronized (lock) {
+		try {
+		    internalPool.returnObject(resource);
+		} catch (Exception e) {
+		    throw new JedisException(
+			    "Could not return the resource to the pool", e);
+		}
+    }
     }
 
     public void returnBrokenResource(final T resource) {
@@ -66,12 +73,14 @@ public abstract class Pool<T> {
     }
 
     protected void returnBrokenResourceObject(final T resource) {
-	try {
-	    internalPool.invalidateObject(resource);
-	} catch (Exception e) {
-	    throw new JedisException(
-		    "Could not return the resource to the pool", e);
-	}
+    synchronized (lock) {
+		try {
+		    internalPool.invalidateObject(resource);
+		} catch (Exception e) {
+		    throw new JedisException(
+			    "Could not return the resource to the pool", e);
+		}
+    }
     }
 
     protected void closeInternalPool() {

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
@@ -13,6 +13,7 @@ import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPubSub;
 import redis.clients.jedis.JedisSentinelPool;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 
 public class JedisSentinelPoolTest extends JedisTestBase {
     private static final String MASTER_NAME = "mymaster";
@@ -57,26 +58,53 @@ public class JedisSentinelPoolTest extends JedisTestBase {
 
     private void doSegFaultMaster(JedisSentinelPool pool)
 	    throws InterruptedException {
-	HostAndPort oldMaster = pool.getCurrentHostMaster();
+    HostAndPort oldMaster = pool.getCurrentHostMaster();
 
-	// jedis connection should be master
-	Jedis jedis = pool.getResource();
-	assertEquals("PONG", jedis.ping());
+    // 1. test master
+    checkMasterAlive(pool);
 
-	try {
-	    jedis.debug(DebugParams.SEGFAULT());
-	} catch (Exception e) {
-	}
+    // 2. kill master
+    killMaster(pool);
+    
+    // 3. wait for failover
+    waitForFailover(pool, oldMaster);
 
-	waitForFailover(pool, oldMaster);
-	Thread.sleep(100);
-
-	jedis = pool.getResource();
-	assertEquals("PONG", jedis.ping());
-	assertEquals("foobared", jedis.configGet("requirepass").get(1));
-	assertEquals(2, jedis.getDB().intValue());
+    // 4. test new master
+    checkMasterAlive(pool);
     }
 
+    private void checkMasterAlive(JedisSentinelPool pool) {
+	Jedis jedis = null;
+	try {
+        jedis = pool.getResource();
+        assertEquals("PONG", jedis.ping());
+        assertEquals("foobared", jedis.configGet("requirepass").get(1));
+        assertEquals(2, jedis.getDB().intValue());
+    } catch (JedisConnectionException e) {
+        if (null != jedis)
+            pool.returnBrokenResource(jedis);
+
+        jedis = null;
+        throw e;
+    } finally {
+        if (null != jedis)
+            pool.returnResource(jedis);
+    }
+    }
+    
+    private void killMaster(JedisSentinelPool pool) {
+	Jedis jedis = pool.getResource();
+    try {
+        jedis.debug(DebugParams.SEGFAULT());
+    } catch (JedisConnectionException e) {
+         // it's OK because "debug segfault" makes Redis Server killed and Jedis throws JedisConnectionException
+    } finally {
+         // Redis Server already closed
+         if (null != jedis)
+              pool.returnBrokenResource(jedis);
+    }
+    }
+    
     private void waitForFailover(JedisSentinelPool pool, HostAndPort oldMaster)
 	    throws InterruptedException {
 	waitForJedisSentinelPoolRecognizeNewMaster(pool);
@@ -131,7 +159,7 @@ public class JedisSentinelPoolTest extends JedisTestBase {
 
 	    }
 	}, "*");
-
+	
 	String[] chunks = newmaster.get().split(" ");
 	HostAndPort newMaster = new HostAndPort(chunks[3],
 		Integer.parseInt(chunks[4]));


### PR DESCRIPTION
This PR is a splitted version of #499.
(with remove some lines from diff which are annoying about space vs tab, some refactoring on JedisSentinelPoolTest)
## In short
- Fix Pool instance to thread-safe while initPool() is calling multiple time.
  - assertOpen() could be failed before applying
- Fix JedisSentinelPool to change master information after initPool
- Fix JedisSentinelPoolTest to remove resource leak
  - It could be throw JedisConnectionError - cannot get resource before applying
## Details about race conditions

Current master resolves JedisSentinelPoolTest's timing issue by taking additional sleep.
But I think it is caused by race conditions, could reproduce outside of Jedis.
- JedisSentinelPool.initPool()

```
    private void initPool(HostAndPort master) {
    if (!master.equals(currentHostMaster)) {
        currentHostMaster = master;
        log.info("Created JedisPool to master at " + master);
        initPool(poolConfig, new JedisFactory(master.getHost(), master.getPort(),
            timeout, password, database));
    }
    }
```

There is race condition between changing master information and initPool().
User could know master is changed by getting master information, but pool is not changed yet.
We can synchronize this method, but I think changing sequence (pool re-init and change master info) would be OK.
(If we have more time to talk, we need to talk about JedisSentinelPool's preferred state when initPool() throws Exception.)
- Pool<T>.initPool()

```
public void initPool(final GenericObjectPoolConfig poolConfig,
        PooledObjectFactory<T> factory) {

    if (this.internalPool != null) {
        try {
        closeInternalPool();
        } catch (Exception e) {
        }
    }

    this.internalPool = new GenericObjectPool<T>(factory, poolConfig);
    }
```

There is race condition between closeInternalPool and renew internalPool.
Using JedisSentinelPool means we're in multi-thread.
(JedisSentinelPool makes a thread subscribing Sentinel's channel)
It means user can request borrowing or returning Jedis instance to JedisSentinelPool while internal pool is closed but not yet to renew internal pool.
