### PR TITLE
Another getrange function which returns byte[] instead of String

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -2658,6 +2658,11 @@ public class Jedis extends BinaryJedis implements JedisCommands,
 	client.getrange(key, startOffset, endOffset);
 	return client.getBulkReply();
     }
+    
+    public byte[] getrange(byte[] key, long startOffset, long endOffset) {
+	client.getrange(key, startOffset, endOffset);
+	return client.getBinaryBulkReply();
+    }
 
     /**
      * Retrieve the configuration of a running Redis server. Not all the


### PR DESCRIPTION
When use 'getrange' for bytes processing, an intermediate String is unnecessary and it could easily mess things up.
E.g. 'R\xf2\xact\x01\x00\x00\x00\x00' is the raw value we stored in Redis, in current version of Jedis, we must first get a String representation of these bytes, and then call s.getBytes() to get the byte[]. More importantly, the string charset stuff could easily mess things up (means the result from s.getBytes() could be different from what we really have in Redis)
