### PR TITLE
Implement Closeable for Jedis, BinaryJedis etc.

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -948,6 +948,12 @@ public class BinaryClient extends Connection {
 	super.disconnect();
     }
 
+    @Override
+    public void close() {
+	db = 0;
+	super.close();
+    }
+
     public void resetState() {
 	if (isInMulti())
 	    discard();

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -2,6 +2,7 @@ package redis.clients.jedis;
 
 import static redis.clients.jedis.Protocol.toByteArray;
 
+import java.io.Closeable;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -19,7 +20,7 @@ import redis.clients.util.SafeEncoder;
 
 public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 	MultiKeyBinaryCommands, AdvancedBinaryJedisCommands,
-	BinaryScriptingCommands {
+	BinaryScriptingCommands, Closeable {
     protected Client client = null;
 
     public BinaryJedis(final String host) {
@@ -1733,6 +1734,11 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
     public String unwatch() {
 	client.unwatch();
 	return client.getStatusCodeReply();
+    }
+
+    @Override
+	public void close() {
+	client.close();
     }
 
     /**

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -15,7 +16,7 @@ import redis.clients.util.RedisInputStream;
 import redis.clients.util.RedisOutputStream;
 import redis.clients.util.SafeEncoder;
 
-public class Connection {
+public class Connection implements Closeable {
     private String host;
     private int port = Protocol.DEFAULT_PORT;
     private Socket socket;
@@ -142,6 +143,11 @@ public class Connection {
 	    }
 	}
     }
+
+    @Override
+    public void close() {
+	disconnect();
+   }
 
     public void disconnect() {
 	if (isConnected()) {


### PR DESCRIPTION
This allows a Jedis object to participate in try-with-resources when
using Java 7+. This change is fully backwards compatible to Java 6 and
previous releases of the Jedis client.
