### PR TITLE
(#535 with backward compatibility) Introduce *scan with "string" cursor parameter to support unsigned long cursor

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -1150,6 +1150,12 @@ public class BinaryClient extends Connection {
 	sendCommand(HINCRBYFLOAT, key, field, toByteArray(increment));
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531
+     */
     public void scan(int cursor, final ScanParams params) {
 	final List<byte[]> args = new ArrayList<byte[]>();
 	args.add(toByteArray(cursor));
@@ -1157,6 +1163,12 @@ public class BinaryClient extends Connection {
 	sendCommand(SCAN, args.toArray(new byte[args.size()][]));
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public void hscan(final byte[] key, int cursor, final ScanParams params) {
 	final List<byte[]> args = new ArrayList<byte[]>();
 	args.add(key);
@@ -1164,7 +1176,13 @@ public class BinaryClient extends Connection {
 	args.addAll(params.getParams());
 	sendCommand(HSCAN, args.toArray(new byte[args.size()][]));
     }
-
+    
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public void sscan(final byte[] key, int cursor, final ScanParams params) {
 	final List<byte[]> args = new ArrayList<byte[]>();
 	args.add(key);
@@ -1172,11 +1190,48 @@ public class BinaryClient extends Connection {
 	args.addAll(params.getParams());
 	sendCommand(SSCAN, args.toArray(new byte[args.size()][]));
     }
-
+    
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public void zscan(final byte[] key, int cursor, final ScanParams params) {
 	final List<byte[]> args = new ArrayList<byte[]>();
 	args.add(key);
 	args.add(toByteArray(cursor));
+	args.addAll(params.getParams());
+	sendCommand(ZSCAN, args.toArray(new byte[args.size()][]));
+    }
+    
+    public void scan(final byte[] cursor, final ScanParams params) {
+	final List<byte[]> args = new ArrayList<byte[]>();
+	args.add(cursor);
+	args.addAll(params.getParams());
+	sendCommand(SCAN, args.toArray(new byte[args.size()][]));
+    }
+
+    public void hscan(final byte[] key, final byte[] cursor, final ScanParams params) {
+	final List<byte[]> args = new ArrayList<byte[]>();
+	args.add(key);
+	args.add(cursor);
+	args.addAll(params.getParams());
+	sendCommand(HSCAN, args.toArray(new byte[args.size()][]));
+    }
+
+    public void sscan(final byte[] key, final byte[] cursor, final ScanParams params) {
+	final List<byte[]> args = new ArrayList<byte[]>();
+	args.add(key);
+	args.add(cursor);
+	args.addAll(params.getParams());
+	sendCommand(SSCAN, args.toArray(new byte[args.size()][]));
+    }
+
+    public void zscan(final byte[] key, final byte[] cursor, final ScanParams params) {
+	final List<byte[]> args = new ArrayList<byte[]>();
+	args.add(key);
+	args.add(cursor);
 	args.addAll(params.getParams());
 	sendCommand(ZSCAN, args.toArray(new byte[args.size()][]));
     }

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -833,16 +833,50 @@ public class Client extends BinaryClient implements Commands {
 		increment);
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public void hscan(final String key, int cursor, final ScanParams params) {
 	hscan(SafeEncoder.encode(key), cursor, params);
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public void sscan(final String key, int cursor, final ScanParams params) {
 	sscan(SafeEncoder.encode(key), cursor, params);
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public void zscan(final String key, int cursor, final ScanParams params) {
 	zscan(SafeEncoder.encode(key), cursor, params);
+    }
+    
+    public void scan(final String cursor, final ScanParams params) {
+	scan(SafeEncoder.encode(cursor), params);
+    }
+    
+    public void hscan(final String key, final String cursor, final ScanParams params) {
+	hscan(SafeEncoder.encode(key), SafeEncoder.encode(cursor), params);
+    }
+    
+    public void sscan(final String key, final String cursor, final ScanParams params) {
+	sscan(SafeEncoder.encode(key), SafeEncoder.encode(cursor), params);
+    }
+    
+    public void zscan(final String key, final String cursor, final ScanParams params) {
+	zscan(SafeEncoder.encode(key), SafeEncoder.encode(cursor), params);
     }
 
     public void cluster(final String subcommand, final int... args) {

--- a/src/main/java/redis/clients/jedis/Commands.java
+++ b/src/main/java/redis/clients/jedis/Commands.java
@@ -297,13 +297,45 @@ public interface Commands {
 
     public void bitop(BitOP op, final String destKey, String... srcKeys);
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public void scan(int cursor, final ScanParams params);
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public void hscan(final String key, int cursor, final ScanParams params);
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public void sscan(final String key, int cursor, final ScanParams params);
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public void zscan(final String key, int cursor, final ScanParams params);
 
+    public void scan(final String cursor, final ScanParams params);
+
+    public void hscan(final String key, final String cursor, final ScanParams params);
+
+    public void sscan(final String key, final String cursor, final ScanParams params);
+
+    public void zscan(final String key, final String cursor, final ScanParams params);
+    
     public void waitReplicas(int replicas, long timeout);
 }

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3096,10 +3096,22 @@ public class Jedis extends BinaryJedis implements JedisCommands,
 	return (relpy != null ? new Double(relpy) : null);
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public ScanResult<String> scan(int cursor) {
 	return scan(cursor, new ScanParams());
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public ScanResult<String> scan(int cursor, final ScanParams params) {
 	checkIsInMulti();
 	client.scan(cursor, params);
@@ -3113,11 +3125,23 @@ public class Jedis extends BinaryJedis implements JedisCommands,
 	return new ScanResult<String>(newcursor, results);
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public ScanResult<Map.Entry<String, String>> hscan(final String key,
 	    int cursor) {
 	return hscan(key, cursor, new ScanParams());
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public ScanResult<Map.Entry<String, String>> hscan(final String key,
 	    int cursor, final ScanParams params) {
 	checkIsInMulti();
@@ -3135,10 +3159,22 @@ public class Jedis extends BinaryJedis implements JedisCommands,
 	return new ScanResult<Map.Entry<String, String>>(newcursor, results);
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public ScanResult<String> sscan(final String key, int cursor) {
 	return sscan(key, cursor, new ScanParams());
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public ScanResult<String> sscan(final String key, int cursor,
 	    final ScanParams params) {
 	checkIsInMulti();
@@ -3153,16 +3189,105 @@ public class Jedis extends BinaryJedis implements JedisCommands,
 	return new ScanResult<String>(newcursor, results);
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public ScanResult<Tuple> zscan(final String key, int cursor) {
 	return zscan(key, cursor, new ScanParams());
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public ScanResult<Tuple> zscan(final String key, int cursor,
 	    final ScanParams params) {
 	checkIsInMulti();
 	client.zscan(key, cursor, params);
 	List<Object> result = client.getObjectMultiBulkReply();
 	int newcursor = Integer.parseInt(new String((byte[]) result.get(0)));
+	List<Tuple> results = new ArrayList<Tuple>();
+	List<byte[]> rawResults = (List<byte[]>) result.get(1);
+	Iterator<byte[]> iterator = rawResults.iterator();
+	while (iterator.hasNext()) {
+	    results.add(new Tuple(SafeEncoder.encode(iterator.next()), Double
+		    .valueOf(SafeEncoder.encode(iterator.next()))));
+	}
+	return new ScanResult<Tuple>(newcursor, results);
+    }
+    
+    public ScanResult<String> scan(final String cursor) {
+	return scan(cursor, new ScanParams());
+    }
+    
+    public ScanResult<String> scan(final String cursor, final ScanParams params) {
+	checkIsInMulti();
+	client.scan(cursor, params);
+	List<Object> result = client.getObjectMultiBulkReply();
+	String newcursor = new String((byte[]) result.get(0));
+	List<String> results = new ArrayList<String>();
+	List<byte[]> rawResults = (List<byte[]>) result.get(1);
+	for (byte[] bs : rawResults) {
+	    results.add(SafeEncoder.encode(bs));
+	}
+	return new ScanResult<String>(newcursor, results);
+    }
+    
+    public ScanResult<Map.Entry<String, String>> hscan(final String key,
+	    final String cursor) {
+	return hscan(key, cursor, new ScanParams());
+    }
+    
+    public ScanResult<Map.Entry<String, String>> hscan(final String key,
+	    final String cursor, final ScanParams params) {
+	checkIsInMulti();
+	client.hscan(key, cursor, params);
+	List<Object> result = client.getObjectMultiBulkReply();
+	String newcursor = new String((byte[]) result.get(0));
+	List<Map.Entry<String, String>> results = new ArrayList<Map.Entry<String, String>>();
+	List<byte[]> rawResults = (List<byte[]>) result.get(1);
+	Iterator<byte[]> iterator = rawResults.iterator();
+	while (iterator.hasNext()) {
+	    results.add(new AbstractMap.SimpleEntry<String, String>(SafeEncoder
+		    .encode(iterator.next()), SafeEncoder.encode(iterator
+			    .next())));
+	}
+	return new ScanResult<Map.Entry<String, String>>(newcursor, results);
+    }
+    
+    public ScanResult<String> sscan(final String key, final String cursor) {
+	return sscan(key, cursor, new ScanParams());
+    }
+    
+    public ScanResult<String> sscan(final String key, final String cursor,
+	    final ScanParams params) {
+	checkIsInMulti();
+	client.sscan(key, cursor, params);
+	List<Object> result = client.getObjectMultiBulkReply();
+	String newcursor = new String((byte[]) result.get(0));
+	List<String> results = new ArrayList<String>();
+	List<byte[]> rawResults = (List<byte[]>) result.get(1);
+	for (byte[] bs : rawResults) {
+	    results.add(SafeEncoder.encode(bs));
+	}
+	return new ScanResult<String>(newcursor, results);
+    }
+    
+    public ScanResult<Tuple> zscan(final String key, final String cursor) {
+	return zscan(key, cursor, new ScanParams());
+    }
+    
+    public ScanResult<Tuple> zscan(final String key, final String cursor,
+	    final ScanParams params) {
+	checkIsInMulti();
+	client.zscan(key, cursor, params);
+	List<Object> result = client.getObjectMultiBulkReply();
+	String newcursor = new String((byte[]) result.get(0));
 	List<Tuple> results = new ArrayList<Tuple>();
 	List<byte[]> rawResults = (List<byte[]>) result.get(1);
 	Iterator<byte[]> iterator = rawResults.iterator();

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -1396,6 +1396,12 @@ public class JedisCluster implements JedisCommands, BasicCommands {
 	return null;
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     @Override
     public ScanResult<Entry<String, String>> hscan(final String key,
 	    final int cursor) {
@@ -1408,6 +1414,12 @@ public class JedisCluster implements JedisCommands, BasicCommands {
 	}.run(null);
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     @Override
     public ScanResult<String> sscan(final String key, final int cursor) {
 	return new JedisClusterCommand<ScanResult<String>>(connectionHandler,
@@ -1419,8 +1431,48 @@ public class JedisCluster implements JedisCommands, BasicCommands {
 	}.run(null);
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     @Override
     public ScanResult<Tuple> zscan(final String key, final int cursor) {
+	return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler,
+		timeout, maxRedirections) {
+	    @Override
+	    public ScanResult<Tuple> execute() {
+		return connectionHandler.getConnection().zscan(key, cursor);
+	    }
+	}.run(null);
+    }
+    
+    @Override
+    public ScanResult<Entry<String, String>> hscan(final String key,
+	    final String cursor) {
+	return new JedisClusterCommand<ScanResult<Entry<String, String>>>(
+		connectionHandler, timeout, maxRedirections) {
+	    @Override
+	    public ScanResult<Entry<String, String>> execute() {
+		return connectionHandler.getConnection().hscan(key, cursor);
+	    }
+	}.run(null);
+    }
+    
+    @Override
+    public ScanResult<String> sscan(final String key, final String cursor) {
+	return new JedisClusterCommand<ScanResult<String>>(connectionHandler,
+		timeout, maxRedirections) {
+	    @Override
+	    public ScanResult<String> execute() {
+		return connectionHandler.getConnection().sscan(key, cursor);
+	    }
+	}.run(null);
+    }
+    
+    @Override
+    public ScanResult<Tuple> zscan(final String key, final String cursor) {
 	return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler,
 		timeout, maxRedirections) {
 	    @Override

--- a/src/main/java/redis/clients/jedis/JedisCommands.java
+++ b/src/main/java/redis/clients/jedis/JedisCommands.java
@@ -211,9 +211,33 @@ public interface JedisCommands {
 
     Long bitcount(final String key, long start, long end);
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     ScanResult<Map.Entry<String, String>> hscan(final String key, int cursor);
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     ScanResult<String> sscan(final String key, int cursor);
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     ScanResult<Tuple> zscan(final String key, int cursor);
+    
+    ScanResult<Map.Entry<String, String>> hscan(final String key, final String cursor);
+    
+    ScanResult<String> sscan(final String key, final String cursor);
+    
+    ScanResult<Tuple> zscan(final String key, final String cursor);
 }

--- a/src/main/java/redis/clients/jedis/MultiKeyCommands.java
+++ b/src/main/java/redis/clients/jedis/MultiKeyCommands.java
@@ -70,5 +70,13 @@ public interface MultiKeyCommands {
 
     Long bitop(BitOP op, final String destKey, String... srcKeys);
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     ScanResult<String> scan(int cursor);
+    
+    ScanResult<String> scan(final String cursor);
 }

--- a/src/main/java/redis/clients/jedis/ScanParams.java
+++ b/src/main/java/redis/clients/jedis/ScanParams.java
@@ -12,6 +12,7 @@ import redis.clients.util.SafeEncoder;
 
 public class ScanParams {
     private List<byte[]> params = new ArrayList<byte[]>();
+    public final static String SCAN_POINTER_START = String.valueOf(0);
 
     public void match(final String pattern) {
 	params.add(MATCH.raw);

--- a/src/main/java/redis/clients/jedis/ScanResult.java
+++ b/src/main/java/redis/clients/jedis/ScanResult.java
@@ -3,18 +3,43 @@ package redis.clients.jedis;
 import java.util.List;
 
 public class ScanResult<T> {
-    private int cursor;
+    private String cursor;
     private List<T> results;
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public ScanResult(int cursor, List<T> results) {
+	this.cursor = String.valueOf(cursor);
+	this.results = results;
+    }
+
+    public ScanResult(String cursor, List<T> results) {
 	this.cursor = cursor;
 	this.results = results;
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531
+     * @return int(currently), but will be changed to String, so be careful to prepare! 
+     */
     public int getCursor() {
-	return cursor;
+	return Integer.parseInt(cursor);
     }
 
+    /**
+     * FIXME: This method should be changed to getCursor() on next major release
+     */
+    public String getStringCursor() {
+	return cursor;
+    }
+    
     public List<T> getResult() {
 	return results;
     }

--- a/src/main/java/redis/clients/jedis/ShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedis.java
@@ -523,17 +523,50 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands {
 	return j.bitcount(key, start, end);
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public ScanResult<Entry<String, String>> hscan(String key, int cursor) {
 	Jedis j = getShard(key);
 	return j.hscan(key, cursor);
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public ScanResult<String> sscan(String key, int cursor) {
 	Jedis j = getShard(key);
 	return j.sscan(key, cursor);
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to bug (scan cursor should be unsigned long)
+     * And will be removed on next major release
+     * @see https://github.com/xetorthio/jedis/issues/531 
+     */
     public ScanResult<Tuple> zscan(String key, int cursor) {
+	Jedis j = getShard(key);
+	return j.zscan(key, cursor);
+    }
+    
+    public ScanResult<Entry<String, String>> hscan(String key, final String cursor) {
+	Jedis j = getShard(key);
+	return j.hscan(key, cursor);
+    }
+    
+    public ScanResult<String> sscan(String key, final String cursor) {
+	Jedis j = getShard(key);
+	return j.sscan(key, cursor);
+    }
+    
+    public ScanResult<Tuple> zscan(String key, final String cursor) {
 	Jedis j = getShard(key);
 	return j.zscan(key, cursor);
     }

--- a/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
@@ -10,6 +10,7 @@ import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.util.SafeEncoder;
+import static redis.clients.jedis.ScanParams.SCAN_POINTER_START;
 
 public class AllKindOfValuesCommandsTest extends JedisCommandTestBase {
     final byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };
@@ -510,9 +511,9 @@ public class AllKindOfValuesCommandsTest extends JedisCommandTestBase {
 	jedis.set("b", "b");
 	jedis.set("a", "a");
 
-	ScanResult<String> result = jedis.scan(0);
+	ScanResult<String> result = jedis.scan(SCAN_POINTER_START);
 
-	assertEquals(0, result.getCursor());
+	assertEquals(SCAN_POINTER_START, result.getStringCursor());
 	assertFalse(result.getResult().isEmpty());
     }
 
@@ -524,9 +525,9 @@ public class AllKindOfValuesCommandsTest extends JedisCommandTestBase {
 	jedis.set("b", "b");
 	jedis.set("a", "a");
 	jedis.set("aa", "aa");
-	ScanResult<String> result = jedis.scan(0, params);
+	ScanResult<String> result = jedis.scan(SCAN_POINTER_START, params);
 
-	assertEquals(0, result.getCursor());
+	assertEquals(SCAN_POINTER_START, result.getStringCursor());
 	assertFalse(result.getResult().isEmpty());
     }
 
@@ -539,7 +540,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandTestBase {
 	    jedis.set("a" + i, "a" + i);
 	}
 
-	ScanResult<String> result = jedis.scan(0, params);
+	ScanResult<String> result = jedis.scan(SCAN_POINTER_START, params);
 
 	assertFalse(result.getResult().isEmpty());
     }

--- a/src/test/java/redis/clients/jedis/tests/commands/HashesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/HashesCommandsTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
+import static redis.clients.jedis.ScanParams.SCAN_POINTER_START;
 
 public class HashesCommandsTest extends JedisCommandTestBase {
     final byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };
@@ -295,9 +296,9 @@ public class HashesCommandsTest extends JedisCommandTestBase {
 	jedis.hset("foo", "b", "b");
 	jedis.hset("foo", "a", "a");
 
-	ScanResult<Map.Entry<String, String>> result = jedis.hscan("foo", 0);
+	ScanResult<Map.Entry<String, String>> result = jedis.hscan("foo", SCAN_POINTER_START);
 
-	assertEquals(0, result.getCursor());
+	assertEquals(SCAN_POINTER_START, result.getStringCursor());
 	assertFalse(result.getResult().isEmpty());
     }
 
@@ -309,10 +310,10 @@ public class HashesCommandsTest extends JedisCommandTestBase {
 	jedis.hset("foo", "b", "b");
 	jedis.hset("foo", "a", "a");
 	jedis.hset("foo", "aa", "aa");
-	ScanResult<Map.Entry<String, String>> result = jedis.hscan("foo", 0,
-		params);
+	ScanResult<Map.Entry<String, String>> result = jedis.hscan("foo", 
+		SCAN_POINTER_START, params);
 
-	assertEquals(0, result.getCursor());
+	assertEquals(SCAN_POINTER_START, result.getStringCursor());
 	assertFalse(result.getResult().isEmpty());
     }
 
@@ -325,8 +326,8 @@ public class HashesCommandsTest extends JedisCommandTestBase {
 	    jedis.hset("foo", "a" + i, "a" + i);
 	}
 
-	ScanResult<Map.Entry<String, String>> result = jedis.hscan("foo", 0,
-		params);
+	ScanResult<Map.Entry<String, String>> result = jedis.hscan("foo", 
+		SCAN_POINTER_START, params);
 
 	assertFalse(result.getResult().isEmpty());
     }

--- a/src/test/java/redis/clients/jedis/tests/commands/SetCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/SetCommandsTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
+import static redis.clients.jedis.ScanParams.SCAN_POINTER_START;
 
 public class SetCommandsTest extends JedisCommandTestBase {
     final byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };
@@ -457,9 +458,9 @@ public class SetCommandsTest extends JedisCommandTestBase {
     public void sscan() {
 	jedis.sadd("foo", "a", "b");
 
-	ScanResult<String> result = jedis.sscan("foo", 0);
+	ScanResult<String> result = jedis.sscan("foo", SCAN_POINTER_START);
 
-	assertEquals(0, result.getCursor());
+	assertEquals(SCAN_POINTER_START, result.getStringCursor());
 	assertFalse(result.getResult().isEmpty());
     }
 
@@ -469,9 +470,9 @@ public class SetCommandsTest extends JedisCommandTestBase {
 	params.match("a*");
 
 	jedis.sadd("foo", "b", "a", "aa");
-	ScanResult<String> result = jedis.sscan("foo", 0, params);
+	ScanResult<String> result = jedis.sscan("foo", SCAN_POINTER_START, params);
 
-	assertEquals(0, result.getCursor());
+	assertEquals(SCAN_POINTER_START, result.getStringCursor());
 	assertFalse(result.getResult().isEmpty());
     }
 
@@ -482,7 +483,7 @@ public class SetCommandsTest extends JedisCommandTestBase {
 
 	jedis.sadd("foo", "a1", "a2", "a3", "a4", "a5");
 
-	ScanResult<String> result = jedis.sscan("foo", 0, params);
+	ScanResult<String> result = jedis.sscan("foo", SCAN_POINTER_START, params);
 
 	assertFalse(result.getResult().isEmpty());
     }

--- a/src/test/java/redis/clients/jedis/tests/commands/SortedSetCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/SortedSetCommandsTest.java
@@ -10,6 +10,7 @@ import redis.clients.jedis.ScanResult;
 import redis.clients.jedis.Tuple;
 import redis.clients.jedis.ZParams;
 import redis.clients.util.SafeEncoder;
+import static redis.clients.jedis.ScanParams.SCAN_POINTER_START;
 
 public class SortedSetCommandsTest extends JedisCommandTestBase {
     final byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };
@@ -894,9 +895,9 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
 	jedis.zadd("foo", 1, "a");
 	jedis.zadd("foo", 2, "b");
 
-	ScanResult<Tuple> result = jedis.zscan("foo", 0);
+	ScanResult<Tuple> result = jedis.zscan("foo", SCAN_POINTER_START);
 
-	assertEquals(0, result.getCursor());
+	assertEquals(SCAN_POINTER_START, result.getStringCursor());
 	assertFalse(result.getResult().isEmpty());
     }
 
@@ -908,9 +909,9 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
 	jedis.zadd("foo", 2, "b");
 	jedis.zadd("foo", 1, "a");
 	jedis.zadd("foo", 11, "aa");
-	ScanResult<Tuple> result = jedis.zscan("foo", 0, params);
+	ScanResult<Tuple> result = jedis.zscan("foo", SCAN_POINTER_START, params);
 
-	assertEquals(0, result.getCursor());
+	assertEquals(SCAN_POINTER_START, result.getStringCursor());
 	assertFalse(result.getResult().isEmpty());
     }
 
@@ -925,7 +926,7 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
 	jedis.zadd("foo", 4, "a4");
 	jedis.zadd("foo", 5, "a5");
 
-	ScanResult<Tuple> result = jedis.zscan("foo", 0, params);
+	ScanResult<Tuple> result = jedis.zscan("foo", SCAN_POINTER_START, params);
 
 	assertFalse(result.getResult().isEmpty());
     }


### PR DESCRIPTION
This PR fixes #531.
It's backward compatibility version of #535, so please see #535 for details.
## Changelog
- overload all *scan method to change "int" cursor to "string" cursor
- set @Deprecated and leave reason to deprecate and when to remove to
  current *scan method
- modify unit tests to make it work with new *scan method
