### PR TITLE
Mark @Duplicated to TransactionBlock and PipelineBlock related classes / methods

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -1696,6 +1696,13 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 	return new Transaction(client);
     }
 
+    @Deprecated
+    /**
+     * This method is deprecated due to its error prone
+     * and will be removed on next major release
+     * You can use multi() instead
+     * @see https://github.com/xetorthio/jedis/pull/498
+     */
     public List<Object> multi(final TransactionBlock jedisTransaction) {
 	List<Object> results = null;
 	jedisTransaction.setClient(client);
@@ -2119,14 +2126,12 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 	return client.getStatusCodeReply();
     }
 
+    @Deprecated
     /**
-     * Starts a pipeline, which is a very efficient way to send lots of command
-     * and read all the responses when you finish sending them. Try to avoid
-     * this version and use pipelined() when possible as it will give better
-     * performance.
-     * 
-     * @param jedisPipeline
-     * @return The results of the command in the same order you've run them.
+     * This method is deprecated due to its error prone with multi
+     * and will be removed on next major release
+     * You can use pipelined() instead
+     * @see https://github.com/xetorthio/jedis/pull/498
      */
     public List<Object> pipelined(final PipelineBlock jedisPipeline) {
 	jedisPipeline.setClient(client);

--- a/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
@@ -482,6 +482,12 @@ public class BinaryShardedJedis extends Sharded<Jedis, JedisShardInfo>
     }
 
     @Deprecated
+    /**
+     * This method is deprecated due to its error prone with multi
+     * and will be removed on next major release
+     * You can use pipelined() instead
+     * @see https://github.com/xetorthio/jedis/pull/498
+     */
     public List<Object> pipelined(ShardedJedisPipeline shardedJedisPipeline) {
 	shardedJedisPipeline.setShardedJedis(this);
 	shardedJedisPipeline.execute();

--- a/src/main/java/redis/clients/jedis/PipelineBlock.java
+++ b/src/main/java/redis/clients/jedis/PipelineBlock.java
@@ -1,5 +1,11 @@
 package redis.clients.jedis;
 
+@Deprecated
+/**
+ * This method is deprecated due to its error prone with multi
+ * and will be removed on next major release
+ * @see https://github.com/xetorthio/jedis/pull/498
+ */
 public abstract class PipelineBlock extends Pipeline {
     public abstract void execute();
 }

--- a/src/main/java/redis/clients/jedis/TransactionBlock.java
+++ b/src/main/java/redis/clients/jedis/TransactionBlock.java
@@ -2,6 +2,12 @@ package redis.clients.jedis;
 
 import redis.clients.jedis.exceptions.JedisException;
 
+@Deprecated
+/**
+ * This class is deprecated due to its error prone
+ * and will be removed on next major release
+ * @see https://github.com/xetorthio/jedis/pull/498
+ */
 public abstract class TransactionBlock extends Transaction {
     public TransactionBlock(Client client) {
 	super(client);

--- a/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
@@ -15,7 +15,6 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Pipeline;
-import redis.clients.jedis.PipelineBlock;
 import redis.clients.jedis.Response;
 import redis.clients.jedis.Tuple;
 import redis.clients.jedis.exceptions.JedisDataException;
@@ -35,21 +34,10 @@ public class PipeliningTest extends Assert {
 
     @Test
     public void pipeline() throws UnsupportedEncodingException {
-	List<Object> results = jedis.pipelined(new PipelineBlock() {
-	    public void execute() {
-		set("foo", "bar");
-		get("foo");
-	    }
-	});
-
-	assertEquals(2, results.size());
-	assertEquals("OK", results.get(0));
-	assertEquals("bar", results.get(1));
-
 	Pipeline p = jedis.pipelined();
 	p.set("foo", "bar");
 	p.get("foo");
-	results = p.syncAndReturnAll();
+	List<Object> results = p.syncAndReturnAll();
 
 	assertEquals(2, results.size());
 	assertEquals("OK", results.get(0));


### PR DESCRIPTION
We did agree to remove TransactionBlock and PipelineBlock talked on #498.
And we introduced semver, those will be removed to next major release. (breaking backward compatibility)

Since those methods/classes are not marked to @Duplicated, I did it and request to merge.
And remove all unit tests using TransactionBlock and PipelineBlock.
