### PR TITLE
Add support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+jdk:
+  - openjdk6
+  - openjdk7
+  - oraclejdk7
+install: make travis-install
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PATH := ./redis-git/src:${PATH}
+
 define REDIS1_CONF
 daemonize yes
 port 6379
@@ -253,5 +255,9 @@ release:
 	mvn release:prepare
 	mvn release:perform
 	make stop
+
+travis-install:
+	[ ! -e redis-git ] && git clone https://github.com/antirez/redis.git redis-git || true
+	make -C redis-git -j4
 
 .PHONY: test


### PR DESCRIPTION
This configuration will test against openjdk6, openjdk7 and Oracle Java 7.  Because the unit tests do randomly fail, the build on travis will also randomly fail.  This is actually a good starting point though because once the unit tests are fix we will consistently start seeing green for all builds.
