### PR TITLE
Fix multi in Pipeline and sync() - JedisDataException (fixes #547)

### DIFF
--- a/src/main/java/redis/clients/jedis/Pipeline.java
+++ b/src/main/java/redis/clients/jedis/Pipeline.java
@@ -31,6 +31,12 @@ public class Pipeline extends MultiKeyPipelineBase {
 	    return values;
 	}
 
+	public void setResponseDependency(Response<?> dependency) {
+	    for (Response<?> response : responses) {
+		response.setDependency(dependency);
+	    }
+	}
+
 	public void addResponse(Response<?> response) {
 	    responses.add(response);
 	}
@@ -106,6 +112,7 @@ public class Pipeline extends MultiKeyPipelineBase {
     public Response<List<Object>> exec() {
 	client.exec();
 	Response<List<Object>> response = super.getResponse(currentMulti);
+	currentMulti.setResponseDependency(response);
 	currentMulti = null;
 	return response;
     }

--- a/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
@@ -252,6 +252,27 @@ public class PipeliningTest extends Assert {
     }
 
     @Test
+    public void multiWithSync() {
+	jedis.set("foo", "314");
+	jedis.set("bar", "foo");
+	jedis.set("hello", "world");
+	Pipeline p = jedis.pipelined();
+	Response<String> r1 = p.get("bar");
+	p.multi();
+	Response<String> r2 = p.get("foo");
+	p.exec();
+	Response<String> r3 = p.get("hello");
+	p.sync();
+	
+	// before multi
+	assertEquals("foo", r1.get());
+	// It should be readable whether exec's response was built or not
+	assertEquals("314", r2.get());
+	// after multi
+	assertEquals("world", r3.get());
+    }
+
+    @Test
     public void testDiscardInPipeline() {
 	Pipeline pipeline = jedis.pipelined();
 	pipeline.multi();


### PR DESCRIPTION
It's fixed version of #547.

Set dependency to Response when multi in pipeline and build dependency first if Response's dependency found and not built
- there's some dependency with exec response and command responses
  within multi
- if command responses's get() called before exec response's build(), it
  calls exec response's build() first
- unit test included
