### PR TITLE
Fix #550 : Removed redundant call to connectionPool.getResource()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ target/
 build/
 bin/
 tags
+.idea
+*.aof
+*.rdb

--- a/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
@@ -40,7 +40,7 @@ public class JedisSlotBasedConnectionHandler extends
 	    connectionPool = getRandomConnection();
 	}
 	currentConnection = connectionPool.getResource();
-	return connectionPool.getResource();
+	return currentConnection;
     }
 
 }


### PR DESCRIPTION
Removed redundant call to `connectionPool.getResource()` in method `getConnectionFromSlot(int slot)` in class `JedisSlotBasedConnectionHandler`
