### PR TITLE
`initPool` when MasterListener re-subscribed

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -230,6 +230,7 @@ public class JedisSentinelPool extends Pool<Jedis> {
 		j = new Jedis(host, port);
 
 		try {
+		    initPool(toHostAndPort(j.sentinelGetMasterAddrByName(masterName)));
 		    j.subscribe(new JedisPubSubAdapter() {
 			@Override
 			public void onMessage(String channel, String message) {


### PR DESCRIPTION
JedisSentinelPool fail to track master redis when the master redis on sentinel down is not equals with one on sentinel restart.

Here is PoC codes.

JedisSentinelSample.java:

``` java
// set and get a entry with fixed intervals
public class JedisSentinelSample {

    public static void main(String[] args) throws InterruptedException {
        Collection<String> sentinels = Arrays.asList("localhost:26381");
        JedisSentinelPool pool = new JedisSentinelPool("mymaster", new HashSet<>(sentinels));

        while (true) {
            Jedis j = null;
            try {
                j = pool.getResource();
                j.set("fooKey", "fooVal");
                System.out.println(new Date() + "\t" + pool.getCurrentHostMaster() + ": " + j.get("fooKey"));
                pool.returnResource(j);
            } catch (JedisException e){
                if (j != null) pool.returnBrokenResource(j);
                System.out.println(new Date() + "\t" + e.getMessage());
            }
            Thread.sleep(3000);
        }
    }
}
```

poc.sh:

``` bash

set -eux

redis1_port=26379
redis2_port=26380
sentinel_port=26381

main() {
  kill_all_redis

  start_redis1
  start_redis2
  start_sentinel

  echo 'run JedisSentinelSample.java'
  sleep 15

  stop_redis1

  echo 'failover'
  sleep 10

  # restart to clean
  stop_sentinel
  stop_redis2
  start_redis1
  start_redis2
  start_sentinel

  sleep 30
  echo might throw exceptions: "READONLY You can't write against a read only slave."

  stop_sentinel
  stop_redis1
  stop_redis2
}

kill_all_redis() {
  lsof -i :$redis1_port -i :$redis2_port -i :$sentinel_port -sTCP:LISTEN -Fp \
    | sed -n -e 's/^p//p' \
    | xargs -I{} kill {}
  while lsof -i :$redis1_port -i :$redis2_port -i :$sentinel_port -sTCP:LISTEN >/dev/null
  do sleep 0.2; done
}

start_redis1() {
  local pid_file="$(tempfile)"
  cat <<EOF | redis-server -
daemonize yes
port $redis1_port
pidfile $pid_file
save ""
appendonly no
client-output-buffer-limit pubsub 256k 128k 5
EOF
  redis1_pid="$pid_file"
  rm -fr -- -
}

stop_redis1() {
  kill_and_wait $(cat $redis1_pid)
}

kill_and_wait() {
  kill $1
  while [[ "$(ps -p $1 -o comm=)" = redis-server ]]
  do sleep 0.3; done
}

start_redis2() {
  local pid_file="$(tempfile)"
  cat <<EOF | redis-server -
daemonize yes
port $redis2_port
pidfile $pid_file
save ""
appendonly no
client-output-buffer-limit pubsub 256k 128k 5
slaveof localhost $redis1_port
EOF
  redis2_pid="$pid_file"
  rm -fr -- -
}

stop_redis2() {
  kill_and_wait $(cat $redis2_pid)
}

start_sentinel() {
  local pid_file="$(tempfile)"
  local conf="$(tempfile)"
  cat <<EOF > "$conf"
daemonize yes
port $sentinel_port
pidfile $pid_file
sentinel monitor mymaster 127.0.0.1 $redis1_port 1
sentinel down-after-milliseconds mymaster 2000
sentinel failover-timeout mymaster 120000
sentinel parallel-syncs mymaster 1
EOF
  redis-server "$conf" --sentinel
  sentinel_pid="$pid_file"
}

stop_sentinel() {
  kill_and_wait $(cat $sentinel_pid)
}

main
```
