### PR TITLE
add a number of null check to return methods.

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -80,11 +80,15 @@ public class JedisPool extends Pool<Jedis> {
     }
 
     public void returnBrokenResource(final Jedis resource) {
-	returnBrokenResourceObject(resource);
+	if (resource != null) {
+	    returnBrokenResourceObject(resource);
+	}
     }
 
     public void returnResource(final Jedis resource) {
-	resource.resetState();
-	returnResourceObject(resource);
+	if (resource != null) {
+	    resource.resetState();
+	    returnResourceObject(resource);
+	}
     }
 }

--- a/src/main/java/redis/clients/util/Pool.java
+++ b/src/main/java/redis/clients/util/Pool.java
@@ -54,11 +54,15 @@ public abstract class Pool<T> {
     }
 
     public void returnBrokenResource(final T resource) {
-	returnBrokenResourceObject(resource);
+	if (resource != null) {
+	    returnBrokenResourceObject(resource);
+	}
     }
 
     public void returnResource(final T resource) {
-	returnResourceObject(resource);
+	if (resource != null) {
+	    returnResourceObject(resource);
+	}
     }
 
     public void destroy() {


### PR DESCRIPTION
This allows calling these methods on error cleanup paths without having
to surround them with if checks all the time.
