### PR TITLE
add a returnBrokenResource method to ShardedJedisPool

### DIFF
--- a/src/main/java/redis/clients/jedis/ShardedJedisPool.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedisPool.java
@@ -32,6 +32,10 @@ public class ShardedJedisPool extends Pool<ShardedJedis> {
 	super(poolConfig, new ShardedJedisFactory(shards, algo, keyTagPattern));
     }
 
+    public void returnBrokenResource(final ShardedJedis resource) {
+	returnBrokenResourceObject(resource);
+    }
+
     /**
      * PoolableObjectFactory custom impl.
      */


### PR DESCRIPTION
this way we can throw away broken ShardedJedis objects (e.g. due to timeouts on one shard)
example code for usage:

```
    while (true) { 
            ShardedJedis jedis = pool.getResource(); 
            try { 
                result = jedis.get(someObj); 
                break; 
            } catch (JedisException e) { 
                if (++count == maxTries) 
                    throw new IOException(e); 
                pool.returnBrokenResource(jedis); 
                jedis = pool.getResource(); 
            } finally { 
                pool.returnResource(jedis);              
            } 
        } 
```
