### PR TITLE
Accept long parameter for pexpire

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -1091,7 +1091,12 @@ public class BinaryClient extends Connection {
 	sendCommand(RESTORE, key, toByteArray(ttl), serializedValue);
     }
 
+    @Deprecated
     public void pexpire(final byte[] key, final int milliseconds) {
+	pexpire(key, (long) milliseconds);
+    }
+
+    public void pexpire(final byte[] key, final long milliseconds) {
 	sendCommand(PEXPIRE, key, toByteArray(milliseconds));
     }
 

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -3314,7 +3314,12 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 	return client.getStatusCodeReply();
     }
 
+    @Deprecated
     public Long pexpire(final byte[] key, final int milliseconds) {
+	return pexpire(key, (long) milliseconds);
+    }
+
+    public Long pexpire(final byte[] key, final long milliseconds) {
 	checkIsInMulti();
 	client.pexpire(key, milliseconds);
 	return client.getIntegerReply();

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -777,7 +777,12 @@ public class Client extends BinaryClient implements Commands {
 	restore(SafeEncoder.encode(key), ttl, serializedValue);
     }
 
+    @Deprecated
     public void pexpire(final String key, final int milliseconds) {
+	pexpire(key, (long) milliseconds);
+    }
+
+    public void pexpire(final String key, final long milliseconds) {
 	pexpire(SafeEncoder.encode(key), milliseconds);
     }
 

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3060,7 +3060,12 @@ public class Jedis extends BinaryJedis implements JedisCommands,
 	return client.getStatusCodeReply();
     }
 
+    @Deprecated
     public Long pexpire(final String key, final int milliseconds) {
+	return pexpire(key, (long) milliseconds);
+    }
+
+    public Long pexpire(final String key, final long milliseconds) {
 	checkIsInMulti();
 	client.pexpire(key, milliseconds);
 	return client.getIntegerReply();

--- a/src/main/java/redis/clients/jedis/PipelineBase.java
+++ b/src/main/java/redis/clients/jedis/PipelineBase.java
@@ -1080,12 +1080,22 @@ abstract class PipelineBase extends Queable implements BinaryRedisPipeline,
 	return getResponse(BuilderFactory.LONG);
     }
 
+    @Deprecated
     public Response<Long> pexpire(String key, int milliseconds) {
+	return pexpire(key, (long) milliseconds);
+    }
+
+    @Deprecated
+    public Response<Long> pexpire(byte[] key, int milliseconds) {
+	return pexpire(key, (long) milliseconds);
+    }
+
+    public Response<Long> pexpire(String key, long milliseconds) {
 	getClient(key).pexpire(key, milliseconds);
 	return getResponse(BuilderFactory.LONG);
     }
 
-    public Response<Long> pexpire(byte[] key, int milliseconds) {
+    public Response<Long> pexpire(byte[] key, long milliseconds) {
 	getClient(key).pexpire(key, milliseconds);
 	return getResponse(BuilderFactory.LONG);
     }

--- a/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
@@ -474,9 +474,16 @@ public class AllKindOfValuesCommandsTest extends JedisCommandTestBase {
 	long status = jedis.pexpire("foo", 10000);
 	assertEquals(0, status);
 
-	jedis.set("foo", "bar");
-	status = jedis.pexpire("foo", 10000);
+	jedis.set("foo1", "bar1");
+	status = jedis.pexpire("foo1", 10000);
 	assertEquals(1, status);
+
+	jedis.set("foo2", "bar2");
+	status = jedis.pexpire("foo2", 200000000000L);
+	assertEquals(1, status);
+
+	long pttl = jedis.pttl("foo2");
+	assertTrue(pttl > 100000000000L);
     }
 
     @Test


### PR DESCRIPTION
Splitting https://github.com/xetorthio/jedis/pull/575 into two steps.  This is the first, which adds pexpire(key, long) methods and deprecates pexpire(key, int) methods.
