### PR TITLE
Reflect recent version to maven dependency explain

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Or use it as a maven dependency:
 <dependency>
     <groupId>redis.clients</groupId>
     <artifactId>jedis</artifactId>
-    <version>2.2.1</version>
+    <version>2.4.2</version>
     <type>jar</type>
     <scope>compile</scope>
 </dependency>


### PR DESCRIPTION
This PR is from https://github.com/xetorthio/jedis/issues/600.

We have been releasing jedis, but we didn't change README.md's maven dependency to reflect recent version.
