### PR TITLE
Fix invalid link to download (it's deprecated) - replace to releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All of the following redis features are supported:
 ## How do I use it?
 
 You can download the latest build at: 
-    http://github.com/xetorthio/jedis/downloads
+    http://github.com/xetorthio/jedis/releases
 
 Or use it as a maven dependency:
 


### PR DESCRIPTION
https://github.com/xetorthio/jedis/downloads is deprecated from Github, and we didn't use it for a while.
We already moved to releases, so we should replace link from README.md
