### PR TITLE
Append 'package' command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,11 @@ test:
 	mvn -Dtest=${TEST} clean compile test
 	make stop
 
+package:
+	make start
+	mvn clean package
+	make stop
+
 deploy:
 	make start
 	mvn clean deploy


### PR DESCRIPTION
If users wish to build Jedis with source, `mvn package` may help.
But `package` command is not found in Makefile.

So I've update Makefile and PR.

Please review and comment! Thanks!
