### PR TITLE
handle nulls in JedisSentinelPool#return[Broken]Resource

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -75,12 +75,16 @@ public class JedisSentinelPool extends Pool<Jedis> {
     }
 
     public void returnBrokenResource(final Jedis resource) {
-	returnBrokenResourceObject(resource);
+	if (resource != null) {
+	    returnBrokenResourceObject(resource);
+	}
     }
 
     public void returnResource(final Jedis resource) {
-	resource.resetState();
-	returnResourceObject(resource);
+	if (resource != null) {
+	    resource.resetState();
+	    returnResourceObject(resource);
+	}
     }
 
     private volatile HostAndPort currentHostMaster;

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
@@ -80,6 +80,32 @@ public class JedisSentinelPoolTest extends JedisTestBase {
 	}
     }
 
+    @Test
+    public void returnResourceWithNullResource() {
+	GenericObjectPoolConfig config = new GenericObjectPoolConfig();
+	config.setMaxTotal(1);
+	config.setBlockWhenExhausted(false);
+	JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels,
+		config, 1000, "foobared", 2);
+
+	Jedis nullJedis = null;
+	pool.returnResource(nullJedis);
+	pool.destroy();
+    }
+
+    @Test
+    public void returnBrokenResourceWithNullResource() {
+	GenericObjectPoolConfig config = new GenericObjectPoolConfig();
+	config.setMaxTotal(1);
+	config.setBlockWhenExhausted(false);
+	JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels,
+		config, 1000, "foobared", 2);
+
+	Jedis nullJedis = null;
+	pool.returnBrokenResource(nullJedis);
+	pool.destroy();
+    }
+
     private void forceFailover(JedisSentinelPool pool)
 	    throws InterruptedException {
 	HostAndPort oldMaster = pool.getCurrentHostMaster();


### PR DESCRIPTION
JedisPool handles null checks for you when calling returnResource and returnBrokenResource.  JedisSentinelPool should do this too!
