### PR TITLE
Fix Pipeline throws NPE using exec without multi (fixes #623)

### DIFF
--- a/src/main/java/redis/clients/jedis/Pipeline.java
+++ b/src/main/java/redis/clients/jedis/Pipeline.java
@@ -104,12 +104,18 @@ public class Pipeline extends MultiKeyPipelineBase {
     }
 
     public Response<String> discard() {
+	if (currentMulti == null)
+	    throw new JedisDataException("DISCARD without MULTI");
+
 	client.discard();
 	currentMulti = null;
 	return getResponse(BuilderFactory.STRING);
     }
 
     public Response<List<Object>> exec() {
+	if (currentMulti == null)
+	    throw new JedisDataException("EXEC without MULTI");
+
 	client.exec();
 	Response<List<Object>> response = super.getResponse(currentMulti);
 	currentMulti.setResponseDependency(response);
@@ -118,6 +124,9 @@ public class Pipeline extends MultiKeyPipelineBase {
     }
 
     public Response<String> multi() {
+	if (currentMulti != null)
+	    throw new JedisDataException("MULTI calls can not be nested");
+
 	client.multi();
 	Response<String> response = getResponse(BuilderFactory.STRING); // Expecting
 									// OK

--- a/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
@@ -272,6 +272,26 @@ public class PipeliningTest extends Assert {
 	assertEquals("world", r3.get());
     }
 
+    @Test(expected = JedisDataException.class)
+    public void pipelineExecShoudThrowJedisDataExceptionWhenNotInMulti() {
+	Pipeline pipeline = jedis.pipelined();
+	pipeline.exec();
+    }
+
+    @Test(expected = JedisDataException.class)
+    public void pipelineDiscardShoudThrowJedisDataExceptionWhenNotInMulti() {
+	Pipeline pipeline = jedis.pipelined();
+	pipeline.discard();
+    }
+
+    @Test(expected = JedisDataException.class)
+    public void pipelineMultiShoudThrowJedisDataExceptionWhenAlreadyInMulti() {
+	Pipeline pipeline = jedis.pipelined();
+	pipeline.multi();
+	pipeline.set("foo", "3");
+	pipeline.multi();
+    }
+
     @Test
     public void testDiscardInPipeline() {
 	Pipeline pipeline = jedis.pipelined();


### PR DESCRIPTION
It's fixed patch to #623.

Currently Pipeline doesn't check current state (multi or not) when commands related to multi are received.
So it could throw NPE, as #623 stated.

I changed Pipeline to check current state when multi / exec / discard commands are received.
If it's wrong state, Pipeline throws JedisDataException.

Following is wrong states.
- exec without multi
- discard without multi
- multi within multi

Actually Redis returns ERR and we can pick.
But Jedis' Pipeline + multi has some complex sequence, so it can just throw NPE without ERR.

User can use Pipeline + Multi properly to avoid this issue.
But throwing NPE is really a serious problem, so Jedis should be properly handled.
(I think it should be hot-fix.)

@xetorthio @marcosnils Please review and comment! Thanks!
