### PR TITLE
fix "cluster nodes" parse error when slot is in transition (fixes #635)

### DIFF
--- a/src/main/java/redis/clients/util/ClusterNodeInformation.java
+++ b/src/main/java/redis/clients/util/ClusterNodeInformation.java
@@ -1,0 +1,48 @@
+package redis.clients.util;
+
+import redis.clients.jedis.HostAndPort;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ClusterNodeInformation {
+    private HostAndPort node;
+    private List<Integer> availableSlots;
+    private List<Integer> slotsBeingImported;
+    private List<Integer> slotsBeingMigrated;
+
+    public ClusterNodeInformation(HostAndPort node) {
+	this.node = node;
+	this.availableSlots = new ArrayList<Integer>();
+        this.slotsBeingImported = new ArrayList<Integer>();
+        this.slotsBeingMigrated = new ArrayList<Integer>();
+    }
+
+    public void addAvailableSlot(int slot) {
+        availableSlots.add(slot);
+    }
+
+    public void addSlotBeingImported(int slot) {
+        slotsBeingImported.add(slot);
+    }
+
+    public void addSlotBeingMigrated(int slot) {
+        slotsBeingMigrated.add(slot);
+    }
+
+    public HostAndPort getNode() {
+        return node;
+    }
+
+    public List<Integer> getAvailableSlots() {
+        return availableSlots;
+    }
+
+    public List<Integer> getSlotsBeingImported() {
+        return slotsBeingImported;
+    }
+
+    public List<Integer> getSlotsBeingMigrated() {
+        return slotsBeingMigrated;
+    }
+}

--- a/src/main/java/redis/clients/util/ClusterNodeInformationParser.java
+++ b/src/main/java/redis/clients/util/ClusterNodeInformationParser.java
@@ -1,0 +1,81 @@
+package redis.clients.util;
+
+import redis.clients.jedis.HostAndPort;
+
+public class ClusterNodeInformationParser {
+    private static final String HOST_MYSELF_IDENTIFIER = ":0";
+    private static final String SLOT_IMPORT_IDENTIFIER = "-<-";
+    private static final String SLOT_IN_TRANSITION_IDENTIFIER = "[";
+    public static final int SLOT_INFORMATIONS_START_INDEX = 8;
+    public static final int HOST_AND_PORT_INDEX = 1;
+
+    public ClusterNodeInformation parse(String nodeInfo, HostAndPort current) {
+	String[] nodeInfoPartArray = nodeInfo.split(" ");
+
+	HostAndPort node = getHostAndPortFromNodeLine(nodeInfoPartArray,
+		current);
+	ClusterNodeInformation info = new ClusterNodeInformation(node);
+
+	if (nodeInfoPartArray.length >= SLOT_INFORMATIONS_START_INDEX) {
+	    String[] slotInfoPartArray = extractSlotParts(nodeInfoPartArray);
+	    fillSlotInformation(slotInfoPartArray, info);
+	}
+
+	return info;
+    }
+
+    private String[] extractSlotParts(String[] nodeInfoPartArray) {
+	String[] slotInfoPartArray = new String[nodeInfoPartArray.length
+		- SLOT_INFORMATIONS_START_INDEX];
+	for (int i = SLOT_INFORMATIONS_START_INDEX; i < nodeInfoPartArray.length; i++) {
+	    slotInfoPartArray[i - SLOT_INFORMATIONS_START_INDEX] = nodeInfoPartArray[i];
+	}
+	return slotInfoPartArray;
+    }
+
+    public HostAndPort getHostAndPortFromNodeLine(String[] nodeInfoPartArray,
+	    HostAndPort current) {
+	String stringHostAndPort = nodeInfoPartArray[HOST_AND_PORT_INDEX];
+	if (HOST_MYSELF_IDENTIFIER.equals(stringHostAndPort)) {
+	    return current;
+	}
+
+	String[] arrayHostAndPort = stringHostAndPort.split(":");
+	return new HostAndPort(arrayHostAndPort[0],
+		Integer.valueOf(arrayHostAndPort[1]));
+    }
+
+    private void fillSlotInformation(String[] slotInfoPartArray,
+	    ClusterNodeInformation info) {
+	for (String slotRange : slotInfoPartArray) {
+	    fillSlotInformationFromSlotRange(slotRange, info);
+	}
+    }
+
+    private void fillSlotInformationFromSlotRange(String slotRange,
+	    ClusterNodeInformation info) {
+	if (slotRange.startsWith(SLOT_IN_TRANSITION_IDENTIFIER)) {
+	    // slot is in transition
+	    int slot = Integer.parseInt(slotRange.substring(1).split("-")[0]);
+
+	    if (slotRange.contains(SLOT_IMPORT_IDENTIFIER)) {
+		// import
+		info.addSlotBeingImported(slot);
+	    } else {
+		// migrate (->-)
+		info.addSlotBeingMigrated(slot);
+	    }
+	} else if (slotRange.contains("-")) {
+	    // slot range
+	    String[] slotRangePart = slotRange.split("-");
+	    for (int slot = Integer.valueOf(slotRangePart[0]); slot <= Integer
+		    .valueOf(slotRangePart[1]); slot++) {
+		info.addAvailableSlot(slot);
+	    }
+	} else {
+	    // single slot
+	    info.addAvailableSlot(Integer.valueOf(slotRange));
+	}
+    }
+
+}

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterNodeInformationParserTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterNodeInformationParserTest.java
@@ -1,0 +1,63 @@
+package redis.clients.jedis.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.util.ClusterNodeInformation;
+import redis.clients.util.ClusterNodeInformationParser;
+
+public class JedisClusterNodeInformationParserTest extends Assert {
+    private ClusterNodeInformationParser parser;
+
+    @Before
+    public void setUp() {
+	parser = new ClusterNodeInformationParser();
+    }
+
+    @Test
+    public void testParseNodeMyself() {
+	String nodeInfo = "9b0d2ab38ee31482c95fdb2c7847a0d40e88d518 :0 myself,master - 0 0 1 connected 0-5460";
+	HostAndPort current = new HostAndPort("localhost", 7379);
+	ClusterNodeInformation clusterNodeInfo = parser
+		.parse(nodeInfo, current);
+	assertEquals(clusterNodeInfo.getNode(), current);
+    }
+
+    @Test
+    public void testParseNormalState() {
+	String nodeInfo = "5f4a2236d00008fba7ac0dd24b95762b446767bd 192.168.0.3:7380 master - 0 1400598804016 2 connected 5461-10922";
+	HostAndPort current = new HostAndPort("localhost", 7379);
+	ClusterNodeInformation clusterNodeInfo = parser
+		.parse(nodeInfo, current);
+	assertNotEquals(clusterNodeInfo.getNode(), current);
+	assertEquals(clusterNodeInfo.getNode(), new HostAndPort("192.168.0.3",
+		7380));
+
+	for (int slot = 5461; slot <= 10922; slot++) {
+	    assertTrue(clusterNodeInfo.getAvailableSlots().contains(slot));
+	}
+
+	assertTrue(clusterNodeInfo.getSlotsBeingImported().isEmpty());
+	assertTrue(clusterNodeInfo.getSlotsBeingMigrated().isEmpty());
+    }
+
+    @Test
+    public void testParseSlotBeingMigrated() {
+	String nodeInfo = "5f4a2236d00008fba7ac0dd24b95762b446767bd :0 myself,master - 0 0 1 connected 0-5459 [5460->-5f4a2236d00008fba7ac0dd24b95762b446767bd] [5461-<-5f4a2236d00008fba7ac0dd24b95762b446767bd]";
+	HostAndPort current = new HostAndPort("localhost", 7379);
+	ClusterNodeInformation clusterNodeInfo = parser
+		.parse(nodeInfo, current);
+	assertEquals(clusterNodeInfo.getNode(), current);
+
+	for (int slot = 0; slot <= 5459; slot++) {
+	    assertTrue(clusterNodeInfo.getAvailableSlots().contains(slot));
+	}
+
+	assertEquals(1, clusterNodeInfo.getSlotsBeingMigrated().size());
+	assertTrue(clusterNodeInfo.getSlotsBeingMigrated().contains(5460));
+	assertEquals(1, clusterNodeInfo.getSlotsBeingImported().size());
+	assertTrue(clusterNodeInfo.getSlotsBeingImported().contains(5461));
+    }
+
+}


### PR DESCRIPTION
It fixes #635 

Though it's not documented, "cluster nodes" shows slot information being imported or migrated.

Below is src/cluster.c from latest Redis unstable branch.

```
    /* Just for MYSELF node we also dump info about slots that
     * we are migrating to other instances or importing from other
     * instances. */
    if (node->flags & REDIS_NODE_MYSELF) {
        for (j = 0; j < REDIS_CLUSTER_SLOTS; j++) {
            if (server.cluster->migrating_slots_to[j]) {
                ci = sdscatprintf(ci," [%d->-%.40s]",j,
                    server.cluster->migrating_slots_to[j]->name);
            } else if (server.cluster->importing_slots_from[j]) {
                ci = sdscatprintf(ci," [%d-<-%.40s]",j,
                    server.cluster->importing_slots_from[j]->name);
            }
        }
    }
```

So Jedis should able to parse it.

Btw, module that parses cluster nodes information could be complicated, so I've refactored to move to another class.
- extract cluster nodes info. parser from JedisClusterConnectionHandler
  - ClusterNodeInformation & ClusterNodeInformationParser
  - user can use it with "cluster nodes" command result, not only JedisClusterConnectionHandler
- unit test for migrating slot included
