### PR TITLE
Support CLUSTER SLOTS command

### DIFF
--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -1011,4 +1011,8 @@ public void clusterSetSlotStable(final int slot) {
     public void clusterFailover() {
 	cluster(Protocol.CLUSTER_FAILOVER);
     }
+    
+    public void clusterSlots() {
+	cluster(Protocol.CLUSTER_SLOTS);
+    }
 }

--- a/src/main/java/redis/clients/jedis/ClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/ClusterCommands.java
@@ -38,4 +38,6 @@ public interface ClusterCommands {
     List<String> clusterSlaves(final String nodeId);
     
     String clusterFailover();
+    
+    List<Object> clusterSlots();
 }

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3489,6 +3489,13 @@ public class Jedis extends BinaryJedis implements JedisCommands,
 	client.clusterFailover();
 	return client.getStatusCodeReply();
     }
+    
+    @Override
+    public List<Object> clusterSlots() {
+	checkIsInMulti();
+	client.clusterSlots();
+	return client.getObjectMultiBulkReply();
+    }
 
     public String asking() {
 	checkIsInMulti();

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -59,6 +59,7 @@ public final class Protocol {
     public static final String CLUSTER_REPLICATE = "replicate";
     public static final String CLUSTER_SLAVES = "slaves";
     public static final String CLUSTER_FAILOVER = "failover";
+    public static final String CLUSTER_SLOTS = "slots";
     public static final String PUBSUB_CHANNELS= "channels";
     public static final String PUBSUB_NUMSUB = "numsub";
     public static final String PUBSUB_NUM_PAT = "numpat";

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
@@ -45,6 +45,8 @@ public class ClusterCommandsTest extends JedisTestBase {
 	node1.clusterDelSlots(1, 2, 3, 4, 5, 500);
 	node1.clusterSetSlotNode(5000, node1Id);
 	node1.clusterDelSlots(5000, 10000);
+	node1.clusterDelSlots(3000, 3001, 3002);
+	node2.clusterDelSlots(4000, 4001, 4002);
 	node1.clusterAddSlots(6000);
 	node1.clusterDelSlots(6000);
 	waitForGossip();
@@ -133,6 +135,35 @@ public class ClusterCommandsTest extends JedisTestBase {
 	String nodeId = nodes[0].split(" ")[0];
 	String status = node1.clusterSetSlotMigrating(5000, nodeId);
 	assertEquals("OK", status);
+    }
+    
+    @Test
+    public void clusterSlots() {
+	// please see cluster slot output format from below commit
+	// @see:
+	// https://github.com/antirez/redis/commit/e14829de3025ffb0d3294e5e5a1553afd9f10b60
+	String status = node1.clusterAddSlots(3000, 3001, 3002);
+	assertEquals("OK", status);
+	status = node2.clusterAddSlots(4000, 4001, 4002);
+	assertEquals("OK", status);
+
+	List<Object> slots = node1.clusterSlots();
+	assertNotNull(slots);
+	assertTrue(slots.size() > 0);
+
+	for (Object slotInfoObj : slots) {
+	    List<Object> slotInfo = (List<Object>) slotInfoObj;
+	    assertNotNull(slots);
+	    assertTrue(slots.size() >= 2);
+
+	    assertTrue(slotInfo.get(0) instanceof Long);
+	    assertTrue(slotInfo.get(1) instanceof Long);
+
+	    if (slots.size() > 2) {
+		// assigned slots
+		assertTrue(slotInfo.get(2) instanceof List);
+	    }
+	}
     }
 
 }


### PR DESCRIPTION
- CLUSTER SLOTS returns a Redis-formatted mapping from slot ranges to IP/Port pairs serving that slot range
- description link including output format
  - https://github.com/antirez/redis/commit/e14829de3025ffb0d3294e5e5a1553afd9f10b60
- Unit test included

It's also documented to http://redis.io/topics/cluster-spec.

```
Clients usually need to fetch a complete list of slots and mapped node addresses in two different moments:

- At startup in order to populate the initial slots configuration.
- When a MOVED redirection is received.

Note that a client may handle the MOVED redirection updating just the moved slot in its table, however this is usually not efficient since often the configuration of multiple slots is modified at once (for example if a slave is promoted to master, all the slots served by the old master will be remapped). It is much simpler to react to a MOVED redirection fetching the full map of slots - nodes from scratch.
In order to retrieve the slots configuration Redis Cluster offers (starting with 3.0.0 beta-7) an alternative to the CLUSTER NODES command that does not require parsing, and only provides the information strictly needed to clients.
The new command is called CLUSTER SLOTS and provides an array of slots ranges, and the associated master and slave nodes serving the specified range.
```

Redis suggests clients to renew slot mapping information when a MOVED has occurred.
So I'm planning to reflect it based on this PR.

Please review and comment! Thanks.
