### PR TITLE
fix build after CLUSTER NODES output has been changed

### DIFF
--- a/src/main/java/redis/clients/util/ClusterNodeInformationParser.java
+++ b/src/main/java/redis/clients/util/ClusterNodeInformationParser.java
@@ -3,7 +3,6 @@ package redis.clients.util;
 import redis.clients.jedis.HostAndPort;
 
 public class ClusterNodeInformationParser {
-    private static final String HOST_MYSELF_IDENTIFIER = ":0";
     private static final String SLOT_IMPORT_IDENTIFIER = "-<-";
     private static final String SLOT_IN_TRANSITION_IDENTIFIER = "[";
     public static final int SLOT_INFORMATIONS_START_INDEX = 8;
@@ -36,13 +35,13 @@ public class ClusterNodeInformationParser {
     public HostAndPort getHostAndPortFromNodeLine(String[] nodeInfoPartArray,
 	    HostAndPort current) {
 	String stringHostAndPort = nodeInfoPartArray[HOST_AND_PORT_INDEX];
-	if (HOST_MYSELF_IDENTIFIER.equals(stringHostAndPort)) {
-	    return current;
-	}
 
 	String[] arrayHostAndPort = stringHostAndPort.split(":");
-	return new HostAndPort(arrayHostAndPort[0],
-		Integer.valueOf(arrayHostAndPort[1]));
+	return new HostAndPort(
+		arrayHostAndPort[0].isEmpty() ? current.getHost()
+			: arrayHostAndPort[0],
+		arrayHostAndPort[1].isEmpty() ? current.getPort() : Integer
+			.valueOf(arrayHostAndPort[1]));
     }
 
     private void fillSlotInformation(String[] slotInfoPartArray,

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterNodeInformationParserTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterNodeInformationParserTest.java
@@ -17,7 +17,7 @@ public class JedisClusterNodeInformationParserTest extends Assert {
 
     @Test
     public void testParseNodeMyself() {
-	String nodeInfo = "9b0d2ab38ee31482c95fdb2c7847a0d40e88d518 :0 myself,master - 0 0 1 connected 0-5460";
+	String nodeInfo = "9b0d2ab38ee31482c95fdb2c7847a0d40e88d518 :7379 myself,master - 0 0 1 connected 0-5460";
 	HostAndPort current = new HostAndPort("localhost", 7379);
 	ClusterNodeInformation clusterNodeInfo = parser
 		.parse(nodeInfo, current);
@@ -44,7 +44,7 @@ public class JedisClusterNodeInformationParserTest extends Assert {
 
     @Test
     public void testParseSlotBeingMigrated() {
-	String nodeInfo = "5f4a2236d00008fba7ac0dd24b95762b446767bd :0 myself,master - 0 0 1 connected 0-5459 [5460->-5f4a2236d00008fba7ac0dd24b95762b446767bd] [5461-<-5f4a2236d00008fba7ac0dd24b95762b446767bd]";
+	String nodeInfo = "5f4a2236d00008fba7ac0dd24b95762b446767bd :7379 myself,master - 0 0 1 connected 0-5459 [5460->-5f4a2236d00008fba7ac0dd24b95762b446767bd] [5461-<-5f4a2236d00008fba7ac0dd24b95762b446767bd]";
 	HostAndPort current = new HostAndPort("localhost", 7379);
 	ClusterNodeInformation clusterNodeInfo = parser
 		.parse(nodeInfo, current);


### PR DESCRIPTION
- https://github.com/antirez/redis/issues/1848
  - Redis change broke our unit test
- we don't need to handle :0 by changes
