### PR TITLE
Fixed Gradle build file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'eclipse'
 
 group = 'com.googlecode.jedis'
-archiveBaseName = 'jedis'
+archivesBaseName = 'jedis'
 version = '1.5.0'
 
 repositories {


### PR DESCRIPTION
when running Gradle 2.0 - unable to build due to 
No such property: archiveBaseName for class: org.gradle.api.internal.project.DefaultProject_Decorated

Fixed the name of archiveBaseName to archivesBaseName
