### PR TITLE
SafeEncoder Bug: Added null check before encoding

### DIFF
--- a/src/main/java/redis/clients/util/SafeEncoder.java
+++ b/src/main/java/redis/clients/util/SafeEncoder.java
@@ -33,6 +33,8 @@ public class SafeEncoder {
 
     public static String encode(final byte[] data) {
         try {
+            if (data == null)
+                return null;
             return new String(data, Protocol.CHARSET);
         } catch (UnsupportedEncodingException e) {
             throw new JedisException(e);


### PR DESCRIPTION
I added a NULL Check here since there is a scenario where a Lua script can return a NULL response that causes an NPE here.
