### PR TITLE
Fixed critical JedisCluster bug : hlen calls hdel

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -394,7 +394,7 @@ public class JedisCluster implements JedisCommands, BasicCommands {
 		maxRedirections) {
 	    @Override
 	    public Long execute(Jedis connection) {
-		return connection.hdel(key);
+		return connection.hlen(key);
 	    }
 	}.run(key);
     }


### PR DESCRIPTION
Thank @wasifevive for finding critical bug from #683.
It causes data loss, and users can confuse hdel's result to hlen's result, so it's working.
So it's serious bug.
