### PR TITLE
Changed weights from ints to doubles

### DIFF
--- a/src/main/java/redis/clients/jedis/ZParams.java
+++ b/src/main/java/redis/clients/jedis/ZParams.java
@@ -23,7 +23,30 @@ public class ZParams {
 
     private List<byte[]> params = new ArrayList<byte[]>();
 
-    public ZParams weights(final double... weights) {
+	/**
+	 * Set weights.
+	 * 
+	 * @param weights
+	 *            weights.
+	 * @deprecated Use {@link #weightsByDouble(double...)} instead
+	 */
+    @Deprecated
+    public ZParams weights(final int... weights) {
+	params.add(WEIGHTS.raw);
+	for (final int weight : weights) {
+	    params.add(Protocol.toByteArray(weight));
+	}
+
+	return this;
+    }
+
+	/**
+	 * Set weights.
+	 * 
+	 * @param weights
+	 *            weights.
+	 */
+    public ZParams weightsByDouble(final double... weights) {
 	params.add(WEIGHTS.raw);
 	for (final double weight : weights) {
 	    params.add(Protocol.toByteArray(weight));

--- a/src/test/java/redis/clients/jedis/tests/commands/SortedSetCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/SortedSetCommandsTest.java
@@ -783,7 +783,7 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
 	jedis.zadd("bar", 2, "b");
 
 	ZParams params = new ZParams();
-	params.weights(2, 2.5);
+	params.weightsByDouble(2, 2.5);
 	params.aggregate(ZParams.Aggregate.SUM);
 	long result = jedis.zunionstore("dst", params, "foo", "bar");
 
@@ -802,7 +802,7 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
 	jedis.zadd(bbar, 2, bb);
 
 	ZParams bparams = new ZParams();
-	bparams.weights(2, 2.5);
+	bparams.weightsByDouble(2, 2.5);
 	bparams.aggregate(ZParams.Aggregate.SUM);
 	long bresult = jedis.zunionstore(SafeEncoder.encode("dst"), bparams,
 		bfoo, bbar);
@@ -855,7 +855,7 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
 	jedis.zadd("bar", 2, "a");
 
 	ZParams params = new ZParams();
-	params.weights(2, 2.5);
+	params.weightsByDouble(2, 2.5);
 	params.aggregate(ZParams.Aggregate.SUM);
 	long result = jedis.zinterstore("dst", params, "foo", "bar");
 
@@ -872,7 +872,7 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
 	jedis.zadd(bbar, 2, ba);
 
 	ZParams bparams = new ZParams();
-	bparams.weights(2, 2.5);
+	bparams.weightsByDouble(2, 2.5);
 	bparams.aggregate(ZParams.Aggregate.SUM);
 	long bresult = jedis.zinterstore(SafeEncoder.encode("dst"), bparams,
 		bfoo, bbar);


### PR DESCRIPTION
ZUNIONSTORE and ZINTERSTORE support double values for the weight, but jedis currently uses ints. This pull request adds support for double weights to ZParam. The test has been adopted to use decimal values to prove that this works. The old method for the old int based weights has been deprecated.
