### PR TITLE
Removed deprecated int based weights

### DIFF
--- a/src/main/java/redis/clients/jedis/ZParams.java
+++ b/src/main/java/redis/clients/jedis/ZParams.java
@@ -28,25 +28,8 @@ public class ZParams {
 	 * 
 	 * @param weights
 	 *            weights.
-	 * @deprecated Use {@link #weightsByDouble(double...)} instead
 	 */
-    @Deprecated
-    public ZParams weights(final int... weights) {
-	params.add(WEIGHTS.raw);
-	for (final int weight : weights) {
-	    params.add(Protocol.toByteArray(weight));
-	}
-
-	return this;
-    }
-
-	/**
-	 * Set weights.
-	 * 
-	 * @param weights
-	 *            weights.
-	 */
-    public ZParams weightsByDouble(final double... weights) {
+    public ZParams weights(final double... weights) {
 	params.add(WEIGHTS.raw);
 	for (final double weight : weights) {
 	    params.add(Protocol.toByteArray(weight));

--- a/src/test/java/redis/clients/jedis/tests/commands/SortedSetCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/SortedSetCommandsTest.java
@@ -783,7 +783,7 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
 	jedis.zadd("bar", 2, "b");
 
 	ZParams params = new ZParams();
-	params.weightsByDouble(2, 2.5);
+	params.weights(2, 2.5);
 	params.aggregate(ZParams.Aggregate.SUM);
 	long result = jedis.zunionstore("dst", params, "foo", "bar");
 
@@ -802,7 +802,7 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
 	jedis.zadd(bbar, 2, bb);
 
 	ZParams bparams = new ZParams();
-	bparams.weightsByDouble(2, 2.5);
+	bparams.weights(2, 2.5);
 	bparams.aggregate(ZParams.Aggregate.SUM);
 	long bresult = jedis.zunionstore(SafeEncoder.encode("dst"), bparams,
 		bfoo, bbar);
@@ -855,7 +855,7 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
 	jedis.zadd("bar", 2, "a");
 
 	ZParams params = new ZParams();
-	params.weightsByDouble(2, 2.5);
+	params.weights(2, 2.5);
 	params.aggregate(ZParams.Aggregate.SUM);
 	long result = jedis.zinterstore("dst", params, "foo", "bar");
 
@@ -872,7 +872,7 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
 	jedis.zadd(bbar, 2, ba);
 
 	ZParams bparams = new ZParams();
-	bparams.weightsByDouble(2, 2.5);
+	bparams.weights(2, 2.5);
 	bparams.aggregate(ZParams.Aggregate.SUM);
 	long bresult = jedis.zinterstore(SafeEncoder.encode("dst"), bparams,
 		bfoo, bbar);


### PR DESCRIPTION
This is the second pull request (first one is #710) which removes the deprecated support for int weights. It replaces the deprecated old method for setting the weights with the new one, which resided under an alternative name in ZParam until now. This breaks the backward compatibility and should be scheduled for version 3.0.0.
