### PR TITLE
Follow up changes on "pubsub numsub" output (Fixes #714)

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -105,6 +105,26 @@ public class BuilderFactory {
 
     };
     
+    public static final Builder<Map<String, String>> PUBSUB_NUMSUB_MAP = new Builder<Map<String, String>>() {
+	@SuppressWarnings("unchecked")
+	public Map<String, String> build(Object data) {
+	    final List<Object> flatHash = (List<Object>) data;
+	    final Map<String, String> hash = new HashMap<String, String>();
+	    final Iterator<Object> iterator = flatHash.iterator();
+	    while (iterator.hasNext()) {
+		hash.put(SafeEncoder.encode((byte[]) iterator.next()),
+			String.valueOf((Long) iterator.next()));
+	    }
+
+	    return hash;
+	}
+
+	public String toString() {
+	    return "PUBSUB_NUMSUB_MAP<String, String>";
+	}
+
+    };
+    
     public static final Builder<Set<String>> STRING_SET = new Builder<Set<String>>() {
 	@SuppressWarnings("unchecked")
 	public Set<String> build(Object data) {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3388,7 +3388,7 @@ public class Jedis extends BinaryJedis implements JedisCommands,
     public Map<String, String> pubsubNumSub(String... channels) {
 	checkIsInMulti();
 	client.pubsubNumSub(channels);
-	return BuilderFactory.STRING_MAP
+	return BuilderFactory.PUBSUB_NUMSUB_MAP
 		.build(client.getBinaryMultiBulkReply());
     }
 


### PR DESCRIPTION
Please see #714 for more details.
- String, String to String, Long
- We're avoiding to break backward compatibility
  - convert Long to String so that return type is same to old type

Actually we can change pubsubNumSub() return type to Map<String, Long>, but it breaks backward compatibility.
