### PR TITLE
Implements #701, add close() to JedisCluster

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -2,12 +2,13 @@ package redis.clients.jedis;
 
 import redis.clients.jedis.BinaryClient.LIST_POSITION;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-public class JedisCluster implements JedisCommands, BasicCommands {
+public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     public static final short HASHSLOTS = 16384;
     private static final int DEFAULT_TIMEOUT = 1;
     private static final int DEFAULT_MAX_REDIRECTIONS = 5;
@@ -31,6 +32,21 @@ public class JedisCluster implements JedisCommands, BasicCommands {
 		jedisClusterNode);
 	this.timeout = timeout;
 	this.maxRedirections = maxRedirections;
+    }
+    
+    @Override
+    public void close() {
+	if (connectionHandler != null) {
+	    for (JedisPool pool : connectionHandler.getNodes().values()) {
+		try {
+		    if (pool != null) {
+			pool.destroy();
+		    }
+		} catch (Exception e) {
+		    // pass
+		}
+	    }
+	}
     }
 
     @Override


### PR DESCRIPTION
- add close() to JedisCluster
  - It destroys all of internal pools (a kind of shutdown hook)
- We should move close() to BinaryJedisCluster when #671 goes to master.
