### PR TITLE
Fix zrangebylex with pipelined (parameters reversed)

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryRedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/BinaryRedisPipeline.java
@@ -209,9 +209,9 @@ public interface BinaryRedisPipeline {
     
     Response<Long> zlexcount(final byte[] key, final byte[] min, final byte[] max);
     
-    Response<Set<byte[]>> zrangeByLex(final byte[] key, final byte[] max, final byte[] min);
+    Response<Set<byte[]>> zrangeByLex(final byte[] key, final byte[] min, final byte[] max);
 
-    Response<Set<byte[]>> zrangeByLex(final byte[] key, final byte[] max, final byte[] min,
+    Response<Set<byte[]>> zrangeByLex(final byte[] key, final byte[] min, final byte[] max,
 	    int offset, int count);
     
     Response<Long> zremrangeByLex(final byte[] key, final byte[] min, final byte[] max);

--- a/src/main/java/redis/clients/jedis/PipelineBase.java
+++ b/src/main/java/redis/clients/jedis/PipelineBase.java
@@ -1039,27 +1039,27 @@ abstract class PipelineBase extends Queable implements BinaryRedisPipeline,
     }
 
     @Override
-    public Response<Set<byte[]>> zrangeByLex(final byte[] key, final byte[] max, final byte[] min) {
+    public Response<Set<byte[]>> zrangeByLex(final byte[] key, final byte[] min, final byte[] max) {
 	getClient(key).zrangeByLex(key, min, max);
 	return getResponse(BuilderFactory.BYTE_ARRAY_ZSET);
     }
 
     @Override
-    public Response<Set<String>> zrangeByLex(final String key, final String max, final String min) {
+    public Response<Set<String>> zrangeByLex(final String key, final String min, final String max) {
 	getClient(key).zrangeByLex(key, min, max);
 	return getResponse(BuilderFactory.STRING_ZSET);
     }
 
     @Override
-    public Response<Set<byte[]>> zrangeByLex(final byte[] key, final byte[] max,
-	    final byte[] min, final int offset, final int count) {
+    public Response<Set<byte[]>> zrangeByLex(final byte[] key, final byte[] min,
+	    final byte[] max, final int offset, final int count) {
 	getClient(key).zrangeByLex(key, min, max, offset, count);
 	return getResponse(BuilderFactory.BYTE_ARRAY_ZSET);
     }
 
     @Override
-    public Response<Set<String>> zrangeByLex(final String key, final String max,
-	    final String min, final int offset, final int count) {
+    public Response<Set<String>> zrangeByLex(final String key, final String min,
+	    final String max, final int offset, final int count) {
 	getClient(key).zrangeByLex(key, min, max, offset, count);
 	return getResponse(BuilderFactory.STRING_ZSET);
     }

--- a/src/main/java/redis/clients/jedis/RedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/RedisPipeline.java
@@ -187,9 +187,9 @@ public interface RedisPipeline {
     
     Response<Long> zlexcount(final String key, final String min, final String max);
     
-    Response<Set<String>> zrangeByLex(final String key, final String max, final String min);
+    Response<Set<String>> zrangeByLex(final String key, final String min, final String max);
 
-    Response<Set<String>> zrangeByLex(final String key, final String max, final String min,
+    Response<Set<String>> zrangeByLex(final String key, final String min, final String max,
 	    final int offset, final int count);
     
     Response<Long> zremrangeByLex(final String key, final String start, final String end);


### PR DESCRIPTION
I found this bug while implementing #753.
Previously zrangebylex with pipeline may return nothing (reversed min and max), so it should be included to 2.6.1.

Sorry about this bug, and please review and comment.
Thanks!
