### PR TITLE
Fix deadlock state from JedisClusterInfoCache

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -118,7 +118,7 @@ public class JedisClusterInfoCache {
 	}
     }
 
-    public synchronized void assignSlotsToNode(List<Integer> targetSlots,
+    public void assignSlotsToNode(List<Integer> targetSlots,
 	    HostAndPort targetNode) {
 	w.lock();
 	try {
@@ -137,7 +137,7 @@ public class JedisClusterInfoCache {
 	}
     }
 
-    public synchronized JedisPool getNode(String nodeKey) {
+    public JedisPool getNode(String nodeKey) {
 	r.lock();
 	try {
 	    return nodes.get(nodeKey);
@@ -146,7 +146,7 @@ public class JedisClusterInfoCache {
 	}
     }
 
-    public synchronized JedisPool getSlotPool(int slot) {
+    public JedisPool getSlotPool(int slot) {
 	r.lock();
 	try {
 	    return slots.get(slot);
@@ -155,7 +155,7 @@ public class JedisClusterInfoCache {
 	}
     }
 
-    public synchronized Map<String, JedisPool> getNodes() {
+    public Map<String, JedisPool> getNodes() {
 	r.lock();
 	try {
 	    return new HashMap<String, JedisPool>(nodes);


### PR DESCRIPTION
It's related to comments on #742.

JedisClusterInfoCache already uses RWLock, so synchonized keyword is not necessary.
It just slows down whole throughput.

It's related to multi-thread issue, so we should check it more precisely.

Please review and comment! Thanks!
