### PR TITLE
Fix CRC16 encode : string to bytes

### DIFF
--- a/src/main/java/redis/clients/util/JedisClusterCRC16.java
+++ b/src/main/java/redis/clients/util/JedisClusterCRC16.java
@@ -59,7 +59,7 @@ public class JedisClusterCRC16 {
     }
 
     public static int getCRC16(String key) {
-	return getCRC16(key.getBytes());
+	return getCRC16(SafeEncoder.encode(key));
     }
 
 }

--- a/src/test/java/redis/clients/jedis/tests/utils/JedisClusterCRC16Test.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/JedisClusterCRC16Test.java
@@ -9,6 +9,7 @@ import java.util.Map.Entry;
 import org.junit.Test;
 
 import redis.clients.util.JedisClusterCRC16;
+import redis.clients.util.SafeEncoder;
 
 public class JedisClusterCRC16Test {
 
@@ -21,7 +22,7 @@ public class JedisClusterCRC16Test {
 	    assertEquals(entry.getValue().intValue(), JedisClusterCRC16.getCRC16(entry.getKey()));
 	    
 	    // byte array version
-	    assertEquals(entry.getValue().intValue(), JedisClusterCRC16.getCRC16(entry.getKey().getBytes()));
+	    assertEquals(entry.getValue().intValue(), JedisClusterCRC16.getCRC16(SafeEncoder.encode(entry.getKey())));
 	}
     }
     


### PR DESCRIPTION
It's related to https://github.com/xetorthio/jedis/commit/96c762b8806f153ec5e5d57d010d25c2ad90a94b#commitcomment-7903844

Conversion of String key in CRC16 should use SafeEncoder.encode() instead of String.getBytes().

@Fomky Could you please check it can support GBK?

Please review and comment!
Thanks! 
