### PR TITLE
ttl can return -1 or -2

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -317,9 +317,11 @@ public class Jedis extends BinaryJedis implements JedisCommands,
      * 
      * @param key
      * @return Integer reply, returns the remaining time to live in seconds of a
-     *         key that has an EXPIRE. 
-     *         If the Key does not have an associated expire, -1 is returned.
-     *         If the Key does not exists, -2 is returned. 
+     *         key that has an EXPIRE.
+     *         In Redis 2.6 or older, if the Key does not exists or does not
+     *         have an associated expire, -1 is returned.
+     *         In Redis 2.8 or newer, if the Key does not have an associated expire, -1 is returned 
+     *         or if the Key does not exists, -2 is returned. 
      */
     public Long ttl(final String key) {
 	checkIsInMulti();


### PR DESCRIPTION
When using ttl, it can return -1 if Key does not have an associated TTL or -2 if Key does not exists.
Improving Javadoc to mention it.

`redis_version:2.8.6`

```
> ttl test
(integer) -2

> set test "true"
OK

> ttl test
(integer) -1
```
