### PR TITLE
Minimize output stream allocations

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -249,7 +249,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
     public Set<byte[]> keys(final byte[] pattern) {
 	checkIsInMulti();
 	client.keys(pattern);
-	return new HashSet<byte[]>(client.getBinaryMultiBulkReply());
+	final HashSet<byte[]> keySet = new HashSet<byte[]>(
+		client.getBinaryMultiBulkReply());
+	return keySet;
     }
 
     /**
@@ -513,7 +515,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 
     /**
      * Set the the respective keys to the respective values. MSET will replace
-     * old values with new values, while {@link #msetnx(byte[]...) MSETNX} will
+     * old values with new values, while {@link #msetnx(String...) MSETNX} will
      * not perform any operation at all even if just a single key already
      * exists.
      * <p>
@@ -526,7 +528,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * either see the changes to both A and B at once, or no modification at
      * all.
      * 
-     * @see #msetnx(byte[]...)
+     * @see #msetnx(String...)
      * 
      * @param keysvalues
      * @return Status code reply Basically +OK as MSET can't fail
@@ -539,7 +541,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 
     /**
      * Set the the respective keys to the respective values.
-     * {@link #mset(byte[]...) MSET} will replace old values with new values,
+     * {@link #mset(String...) MSET} will replace old values with new values,
      * while MSETNX will not perform any operation at all even if just a single
      * key already exists.
      * <p>
@@ -552,8 +554,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * either see the changes to both A and B at once, or no modification at
      * all.
      * 
-     * @see #mset(byte[]...)
-     *
+     * @see #mset(String...)
+     * 
      * @param keysvalues
      * @return Integer reply, specifically: 1 if the all the keys were set 0 if
      *         no key was set (at least one key already existed)
@@ -565,7 +567,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
     }
 
     /**
-     * DECRRBY work just like {@link #decr(byte[]) INCR} but instead to
+     * IDECRBY work just like {@link #decr(String) INCR} but instead to
      * decrement by 1 the decrement is integer.
      * <p>
      * INCR commands are limited to 64 bit signed integers.
@@ -649,7 +651,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
     }
 
     /**
-     * INCRBYFLOAT work just like {@link #incrBy(byte[], long)} INCRBY} but increments
+     * INCRBYFLOAT work just like {@link #incrBy(byte[]) INCRBY} but increments
      * by floats instead of integers.
      * <p>
      * INCRBYFLOAT commands are limited to double precision floating point
@@ -667,8 +669,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * @see #decr(byte[])
      * @see #decrBy(byte[], long)
      * 
-     * @param key the key to increment
-     * @param integer the value to increment by
+     * @param key
+     * @param integer
      * @return Integer reply, this commands will reply with the new value of key
      *         after the increment.
      */
@@ -972,7 +974,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
     public List<byte[]> hvals(final byte[] key) {
 	checkIsInMulti();
 	client.hvals(key);
-	return client.getBinaryMultiBulkReply();
+	final List<byte[]> lresult = client.getBinaryMultiBulkReply();
+	return lresult;
     }
 
     /**
@@ -1177,7 +1180,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * O(N) (with N being the length of the list), setting the first or last
      * elements of the list is O(1).
      * 
-     * @see #lindex(byte[], long)
+     * @see #lindex(byte[], int)
      * 
      * @param key
      * @param index
@@ -1298,11 +1301,11 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 
     /**
      * Return all the members (elements) of the set value stored at key. This is
-     * just syntax glue for {@link #sinter(byte[]...)} SINTER}.
+     * just syntax glue for {@link #sinter(String...) SINTER}.
      * <p>
      * Time complexity O(N)
      * 
-     * @param key the key of the set
+     * @param key
      * @return Multi bulk reply
      */
     public Set<byte[]> smembers(final byte[] key) {
@@ -1319,8 +1322,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * <p>
      * Time complexity O(1)
      * 
-     * @param key the key of the set
-     * @param member the set member to remove
+     * @param key
+     * @param member
      * @return Integer reply, specifically: 1 if the new element was removed 0
      *         if the new element was not a member of the set
      */
@@ -1413,7 +1416,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
     /**
      * Return the members of a set resulting from the intersection of all the
      * sets hold at the specified keys. Like in
-     * {@link #lrange(byte[], long, long)} LRANGE} the result is sent to the client
+     * {@link #lrange(byte[], int, int) LRANGE} the result is sent to the client
      * as a multi-bulk reply (see the protocol specification for more
      * information). If just a single key is specified, then this command
      * produces the same result as {@link #smembers(byte[]) SMEMBERS}. Actually
@@ -1437,7 +1440,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
     }
 
     /**
-     * This commnad works exactly like {@link #sinter(byte[]...) SINTER} but
+     * This commnad works exactly like {@link #sinter(String...) SINTER} but
      * instead of being returned the resulting set is sotred as dstkey.
      * <p>
      * Time complexity O(N*M) worst case where N is the cardinality of the
@@ -1455,7 +1458,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 
     /**
      * Return the members of a set resulting from the union of all the sets hold
-     * at the specified keys. Like in {@link #lrange(byte[], long, long)} LRANGE}
+     * at the specified keys. Like in {@link #lrange(byte[], int, int) LRANGE}
      * the result is sent to the client as a multi-bulk reply (see the protocol
      * specification for more information). If just a single key is specified,
      * then this command produces the same result as {@link #smembers(byte[])
@@ -1477,7 +1480,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
     }
 
     /**
-     * This command works exactly like {@link #sunion(byte[]...) SUNION} but
+     * This command works exactly like {@link #sunion(String...) SUNION} but
      * instead of being returned the resulting set is stored as dstkey. Any
      * existing value in dstkey will be over-written.
      * <p>
@@ -1525,7 +1528,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
     }
 
     /**
-     * This command works exactly like {@link #sdiff(byte[]...) SDIFF} but
+     * This command works exactly like {@link #sdiff(String...) SDIFF} but
      * instead of being returned the resulting set is stored in dstkey.
      * 
      * @param dstkey
@@ -1719,14 +1722,16 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 	    final long end) {
 	checkIsInMulti();
 	client.zrangeWithScores(key, start, end);
-	return getBinaryTupledSet();
+	Set<Tuple> set = getBinaryTupledSet();
+	return set;
     }
 
     public Set<Tuple> zrevrangeWithScores(final byte[] key, final long start,
 	    final long end) {
 	checkIsInMulti();
 	client.zrevrangeWithScores(key, start, end);
-	return getBinaryTupledSet();
+	Set<Tuple> set = getBinaryTupledSet();
+	return set;
     }
 
     /**
@@ -1777,11 +1782,13 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * @see https://github.com/xetorthio/jedis/pull/498
      */
     public List<Object> multi(final TransactionBlock jedisTransaction) {
+	List<Object> results = null;
 	jedisTransaction.setClient(client);
 	client.multi();
 	client.getOne();	// expected OK
 	jedisTransaction.execute();
-	return jedisTransaction.exec();
+	results = jedisTransaction.exec();
+	return results;
     }
 
     protected void checkIsInMulti() {
@@ -2001,7 +2008,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * <p>
      * Time complexity: O(1)
      * 
-     * @see #brpop(int, byte[]...)
+     * @see #brpop(int, String...)
      * 
      * @param timeout
      * @param keys
@@ -2014,17 +2021,18 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      *         programming language used.
      */
     public List<byte[]> blpop(final int timeout, final byte[]... keys) {
-	return blpop(getArgsAddTimeout(timeout, keys));
-    }
-
-    private byte[][] getArgsAddTimeout (int timeout, byte[][] keys) {
-	int size = keys.length;
-	final byte[][] args = new byte[size + 1][];
-	for (int at = 0; at != size; ++at) {
-	    args[at] = keys[at];
+	checkIsInMulti();
+	final List<byte[]> args = new ArrayList<byte[]>();
+	for (final byte[] arg : keys) {
+	    args.add(arg);
 	}
-	args[size] = Protocol.toByteArray(timeout);
-	return args;
+	args.add(Protocol.toByteArray(timeout));
+
+	client.blpop(args.toArray(new byte[args.size()][]));
+	client.setTimeoutInfinite();
+	final List<byte[]> multiBulkReply = client.getBinaryMultiBulkReply();
+	client.rollbackTimeout();
+	return multiBulkReply;
     }
 
     /**
@@ -2129,7 +2137,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * <p>
      * Time complexity: O(1)
      * 
-     * @see #blpop(int, byte[]...)
+     * @see #blpop(int, String...)
      * 
      * @param timeout
      * @param keys
@@ -2142,39 +2150,59 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      *         programming language used.
      */
     public List<byte[]> brpop(final int timeout, final byte[]... keys) {
-	return brpop(getArgsAddTimeout(timeout, keys));
+	checkIsInMulti();
+	final List<byte[]> args = new ArrayList<byte[]>();
+	for (final byte[] arg : keys) {
+	    args.add(arg);
+	}
+	args.add(Protocol.toByteArray(timeout));
+
+	client.brpop(args.toArray(new byte[args.size()][]));
+	client.setTimeoutInfinite();
+	final List<byte[]> multiBulkReply = client.getBinaryMultiBulkReply();
+	client.rollbackTimeout();
+
+	return multiBulkReply;
     }
 
-    @Deprecated
     public List<byte[]> blpop(byte[] arg) {
-	return blpop(new byte[][]{arg});
+	checkIsInMulti();
+	byte[][] args = new byte[1][];
+	args[0] = arg;
+	client.blpop(args);
+	client.setTimeoutInfinite();
+	final List<byte[]> multiBulkReply = client.getBinaryMultiBulkReply();
+	client.rollbackTimeout();
+	return multiBulkReply;
     }
 
-    @Deprecated
     public List<byte[]> brpop(byte[] arg) {
-	return brpop(new byte[][]{arg});
+	checkIsInMulti();
+	byte[][] args = new byte[1][];
+	args[0] = arg;
+	client.brpop(args);
+	client.setTimeoutInfinite();
+	final List<byte[]> multiBulkReply = client.getBinaryMultiBulkReply();
+	client.rollbackTimeout();
+	return multiBulkReply;
     }
 
     public List<byte[]> blpop(byte[]... args) {
 	checkIsInMulti();
 	client.blpop(args);
 	client.setTimeoutInfinite();
-	try {
-	    return client.getBinaryMultiBulkReply();
-	} finally {
-	    client.rollbackTimeout();
-	}
+	final List<byte[]> multiBulkReply = client.getBinaryMultiBulkReply();
+	client.rollbackTimeout();
+	return multiBulkReply;
     }
 
     public List<byte[]> brpop(byte[]... args) {
 	checkIsInMulti();
 	client.brpop(args);
 	client.setTimeoutInfinite();
-	try {
-	    return client.getBinaryMultiBulkReply();
-	} finally {
-	    client.rollbackTimeout();
-	}
+	final List<byte[]> multiBulkReply = client.getBinaryMultiBulkReply();
+	client.rollbackTimeout();
+	return multiBulkReply;
     }
 
     /**
@@ -2429,7 +2457,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 	    final byte[] min, final byte[] max) {
 	checkIsInMulti();
 	client.zrangeByScoreWithScores(key, min, max);
-	return getBinaryTupledSet();
+	Set<Tuple> set = getBinaryTupledSet();
+	return set;
     }
 
     /**
@@ -2500,7 +2529,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 	    final int count) {
 	checkIsInMulti();
 	client.zrangeByScoreWithScores(key, min, max, offset, count);
-	return getBinaryTupledSet();
+	Set<Tuple> set = getBinaryTupledSet();
+	return set;
     }
 
     private Set<Tuple> getBinaryTupledSet() {
@@ -2557,7 +2587,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 	    final byte[] max, final byte[] min) {
 	checkIsInMulti();
 	client.zrevrangeByScoreWithScores(key, max, min);
-	return getBinaryTupledSet();
+	Set<Tuple> set = getBinaryTupledSet();
+	return set;
     }
 
     public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key,
@@ -2565,7 +2596,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 	    final int count) {
 	checkIsInMulti();
 	client.zrevrangeByScoreWithScores(key, max, min, offset, count);
-	return getBinaryTupledSet();
+	Set<Tuple> set = getBinaryTupledSet();
+	return set;
     }
 
     /**
@@ -2620,10 +2652,10 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * input keys N, before passing the input keys and the other (optional)
      * arguments.
      * <p>
-     * As the terms imply, the {@link #zinterstore(byte[], byte[]...)}
+     * As the terms imply, the {@link #zinterstore(String, String...)
      * ZINTERSTORE} command requires an element to be present in each of the
      * given inputs to be inserted in the result. The
-     * {@link #zunionstore(byte[], byte[]...)}} command inserts all
+     * {@link #zunionstore(String, String...) ZUNIONSTORE} command inserts all
      * elements across all inputs.
      * <p>
      * Using the WEIGHTS option, it is possible to add weight to each input
@@ -2642,10 +2674,10 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * sizes of the input sorted sets, and M being the number of elements in the
      * resulting sorted set
      * 
-     * @see #zunionstore(byte[], byte[]...)
-     * @see #zunionstore(byte[], ZParams, byte[]...)
-     * @see #zinterstore(byte[], byte[]...)
-     * @see #zinterstore(byte[], ZParams, byte[]...)
+     * @see #zunionstore(String, String...)
+     * @see #zunionstore(String, ZParams, String...)
+     * @see #zinterstore(String, String...)
+     * @see #zinterstore(String, ZParams, String...)
      * 
      * @param dstkey
      * @param sets
@@ -2664,10 +2696,10 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * input keys N, before passing the input keys and the other (optional)
      * arguments.
      * <p>
-     * As the terms imply, the {@link #zinterstore(byte[], byte[]...)
+     * As the terms imply, the {@link #zinterstore(String, String...)
      * ZINTERSTORE} command requires an element to be present in each of the
      * given inputs to be inserted in the result. The
-     * {@link #zunionstore(byte[], byte[]...) ZUNIONSTORE} command inserts all
+     * {@link #zunionstore(String, String...) ZUNIONSTORE} command inserts all
      * elements across all inputs.
      * <p>
      * Using the WEIGHTS option, it is possible to add weight to each input
@@ -2686,10 +2718,10 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * sizes of the input sorted sets, and M being the number of elements in the
      * resulting sorted set
      * 
-     * @see #zunionstore(byte[], byte[]...)
-     * @see #zunionstore(byte[], ZParams, byte[]...)
-     * @see #zinterstore(byte[], byte[]...)
-     * @see #zinterstore(byte[], ZParams, byte[]...)
+     * @see #zunionstore(String, String...)
+     * @see #zunionstore(String, ZParams, String...)
+     * @see #zinterstore(String, String...)
+     * @see #zinterstore(String, ZParams, String...)
      * 
      * @param dstkey
      * @param sets
@@ -2710,10 +2742,10 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * input keys N, before passing the input keys and the other (optional)
      * arguments.
      * <p>
-     * As the terms imply, the {@link #zinterstore(byte[], byte[]...)
+     * As the terms imply, the {@link #zinterstore(String, String...)
      * ZINTERSTORE} command requires an element to be present in each of the
      * given inputs to be inserted in the result. The
-     * {@link #zunionstore(byte[], byte[]...) ZUNIONSTORE} command inserts all
+     * {@link #zunionstore(String, String...) ZUNIONSTORE} command inserts all
      * elements across all inputs.
      * <p>
      * Using the WEIGHTS option, it is possible to add weight to each input
@@ -2732,10 +2764,10 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * sizes of the input sorted sets, and M being the number of elements in the
      * resulting sorted set
      * 
-     * @see #zunionstore(byte[], byte[]...)
-     * @see #zunionstore(byte[], ZParams, byte[]...)
-     * @see #zinterstore(byte[], byte[]...)
-     * @see #zinterstore(byte[], ZParams, byte[]...)
+     * @see #zunionstore(String, String...)
+     * @see #zunionstore(String, ZParams, String...)
+     * @see #zinterstore(String, String...)
+     * @see #zinterstore(String, ZParams, String...)
      * 
      * @param dstkey
      * @param sets
@@ -2754,10 +2786,10 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * input keys N, before passing the input keys and the other (optional)
      * arguments.
      * <p>
-     * As the terms imply, the {@link #zinterstore(byte[], byte[]...)
+     * As the terms imply, the {@link #zinterstore(String, String...)
      * ZINTERSTORE} command requires an element to be present in each of the
      * given inputs to be inserted in the result. The
-     * {@link #zunionstore(byte[], byte[]...) ZUNIONSTORE} command inserts all
+     * {@link #zunionstore(String, String...) ZUNIONSTORE} command inserts all
      * elements across all inputs.
      * <p>
      * Using the WEIGHTS option, it is possible to add weight to each input
@@ -2776,10 +2808,10 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * sizes of the input sorted sets, and M being the number of elements in the
      * resulting sorted set
      * 
-     * @see #zunionstore(byte[], byte[]...)
-     * @see #zunionstore(byte[], ZParams, byte[]...)
-     * @see #zinterstore(byte[], byte[]...)
-     * @see #zinterstore(byte[], ZParams, byte[]...)
+     * @see #zunionstore(String, String...)
+     * @see #zunionstore(String, ZParams, String...)
+     * @see #zinterstore(String, String...)
+     * @see #zinterstore(String, ZParams, String...)
      * 
      * @param dstkey
      * @param sets
@@ -2927,7 +2959,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      */
     public String shutdown() {
 	client.shutdown();
-	String status;
+	String status = null;
 	try {
 	    status = client.getStatusCodeReply();
 	} catch (JedisException ex) {
@@ -3093,7 +3125,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * configuration parameters are supported.
      * <p>
      * The list of configuration parameters supported by CONFIG SET can be
-     * obtained issuing a {@link #configGet(byte[]) CONFIG GET *} command.
+     * obtained issuing a {@link #configGet(String) CONFIG GET *} command.
      * <p>
      * The configuration set using CONFIG SET is immediately loaded by the Redis
      * server that will start acting as specified starting from the next
@@ -3197,11 +3229,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
     public byte[] brpoplpush(byte[] source, byte[] destination, int timeout) {
 	client.brpoplpush(source, destination, timeout);
 	client.setTimeoutInfinite();
-	try {
-	    return client.getBinaryBulkReply();
-	} finally {
-	    client.rollbackTimeout();
-	}
+	byte[] reply = client.getBinaryBulkReply();
+	client.rollbackTimeout();
+	return reply;
     }
 
     /**
@@ -3261,20 +3291,14 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 
     public void subscribe(BinaryJedisPubSub jedisPubSub, byte[]... channels) {
 	client.setTimeoutInfinite();
-	try {
-	    jedisPubSub.proceed(client, channels);
-	} finally {
-	    client.rollbackTimeout();
-	}
+	jedisPubSub.proceed(client, channels);
+	client.rollbackTimeout();
     }
 
     public void psubscribe(BinaryJedisPubSub jedisPubSub, byte[]... patterns) {
 	client.setTimeoutInfinite();
-	try {
-	    jedisPubSub.proceedWithPatterns(client, patterns);
-	} finally {
-	    client.rollbackTimeout();
-	}
+	jedisPubSub.proceedWithPatterns(client, patterns);
+	client.rollbackTimeout();
     }
 
     public Long getDB() {
@@ -3289,13 +3313,15 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
      * @return Script result
      */
     public Object eval(byte[] script, List<byte[]> keys, List<byte[]> args) {
-	return eval(script, toByteArray(keys.size()), getParams(keys, args));
+	client.setTimeoutInfinite();
+	client.eval(script, toByteArray(keys.size()), getParams(keys, args));
+	return client.getOne();
     }
 
     private byte[][] getParams(List<byte[]> keys, List<byte[]> args) {
-	final int keyCount = keys.size();
-	final int argCount = args.size();
-	byte[][] params = new byte[keyCount + argCount][];
+	int keyCount = keys.size();
+	int argCount = args.size();
+	byte[][] params = new byte[keyCount + args.size()][];
 
 	for (int i = 0; i < keyCount; i++)
 	    params[i] = keys.get(i);
@@ -3308,38 +3334,49 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 
     public Object eval(byte[] script, byte[] keyCount, byte[]... params) {
 	client.setTimeoutInfinite();
-	try {
-	    client.eval(script, keyCount, params);
-	    return client.getOne();
-	} finally {
-	    client.rollbackTimeout();
-	}
+	client.eval(script, keyCount, params);
+	return client.getOne();
     }
 
     public Object eval(byte[] script, int keyCount, byte[]... params) {
-	return eval(script, toByteArray(keyCount), params);
+	client.setTimeoutInfinite();
+	client.eval(script, SafeEncoder.encode(Integer.toString(keyCount)),
+		params);
+	return client.getOne();
     }
 
     public Object eval(byte[] script) {
-	return eval(script, 0);
+	client.setTimeoutInfinite();
+	client.eval(script, 0);
+	return client.getOne();
     }
 
     public Object evalsha(byte[] sha1) {
-	return evalsha(sha1, 1);
+	client.setTimeoutInfinite();
+	client.evalsha(sha1, 0);
+	return client.getOne();
     }
 
     public Object evalsha(byte[] sha1, List<byte[]> keys, List<byte[]> args) {
-	return evalsha(sha1, keys.size(), getParams(keys, args));
+
+	int keyCount = keys == null ? 0 : keys.size();
+	int argCount = args == null ? 0 : args.size();
+
+	byte[][] params = new byte[keyCount + argCount][];
+
+	for (int i = 0; i < keyCount; i++)
+	    params[i] = keys.get(i);
+
+	for (int i = 0; i < argCount; i++)
+	    params[keyCount + i] = args.get(i);
+
+	return evalsha(sha1, keyCount, params);
     }
 
     public Object evalsha(byte[] sha1, int keyCount, byte[]... params) {
 	client.setTimeoutInfinite();
-	try {
-	    client.evalsha(sha1, keyCount, params);
-	    return client.getOne();
-	} finally {
-	    client.rollbackTimeout();
-	}
+	client.evalsha(sha1, keyCount, params);
+	return client.getOne();
     }
 
     public String scriptFlush() {

--- a/src/main/java/redis/clients/jedis/BinaryJedisCommands.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCommands.java
@@ -218,17 +218,8 @@ public interface BinaryJedisCommands {
 
     Long rpushx(byte[] key, byte[]... arg);
 
-
-    /**
-     * @deprecated This command has no meaning.
-     */
-    @Deprecated
     List<byte[]> blpop(byte[] arg);
 
-    /**
-     * @deprecated This command has no meaning.
-     */
-    @Deprecated
     List<byte[]> brpop(byte[] arg);
 
     Long del(byte[] key);

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -42,6 +42,7 @@ public class Connection implements Closeable {
 	    if (!isConnected()) {
 		connect();
 	    }
+	    socket.setKeepAlive(true);
 	    socket.setSoTimeout(0);
 	} catch (SocketException ex) {
 	    broken = true;
@@ -52,6 +53,7 @@ public class Connection implements Closeable {
     public void rollbackTimeout() {
 	try {
 	    socket.setSoTimeout(timeout);
+	    socket.setKeepAlive(false);
 	} catch (SocketException ex) {
 	    broken = true;
 	    throw new JedisConnectionException(ex);

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -1845,56 +1845,54 @@ public class Jedis extends BinaryJedis implements JedisCommands,
      *         programming language used.
      */
     public List<String> blpop(final int timeout, final String... keys) {
-	return blpop(getArgsAddTimeout(timeout, keys));
-    }
-
-    private String[] getArgsAddTimeout (int timeout, String[] keys) {
-	final int keyCount = keys.length;
-	final String[] args = new String[keyCount + 1];
-	for (int at = 0; at != keyCount; ++at) {
-	    args[at] = keys[at];
+	checkIsInMulti();
+	List<String> args = new ArrayList<String>();
+	for (String arg : keys) {
+	    args.add(arg);
 	}
+	args.add(String.valueOf(timeout));
 
-	args[keyCount] = String.valueOf(timeout);
-	return args;
+	client.blpop(args.toArray(new String[args.size()]));
+	client.setTimeoutInfinite();
+	final List<String> multiBulkReply = client.getMultiBulkReply();
+	client.rollbackTimeout();
+	return multiBulkReply;
     }
 
     public List<String> blpop(String... args) {
-	checkIsInMulti();
 	client.blpop(args);
 	client.setTimeoutInfinite();
-	try {
-	    return client.getMultiBulkReply();
-	} finally {
-	    client.rollbackTimeout();
-	}
+	final List<String> multiBulkReply = client.getMultiBulkReply();
+	client.rollbackTimeout();
+	return multiBulkReply;
     }
 
     public List<String> brpop(String... args) {
-	checkIsInMulti();
 	client.brpop(args);
 	client.setTimeoutInfinite();
-	try {
-	    return client.getMultiBulkReply();
-	} finally {
-	    client.rollbackTimeout();
-	}
+	final List<String> multiBulkReply = client.getMultiBulkReply();
+	client.rollbackTimeout();
+	return multiBulkReply;
     }
 
-    /**
-     * @deprecated unusable command
-     */
-    @Deprecated
     public List<String> blpop(String arg) {
-	return blpop(new String[]{arg});
+	String[] args = new String[1];
+	args[0] = arg;
+	client.blpop(args);
+	client.setTimeoutInfinite();
+	final List<String> multiBulkReply = client.getMultiBulkReply();
+	client.rollbackTimeout();
+	return multiBulkReply;
     }
 
-    /**
-     * @deprecated unusable command
-     */
-    @Deprecated
     public List<String> brpop(String arg) {
-	return brpop(new String[]{arg});
+	String[] args = new String[1];
+	args[0] = arg;
+	client.brpop(args);
+	client.setTimeoutInfinite();
+	final List<String> multiBulkReply = client.getMultiBulkReply();
+	client.rollbackTimeout();
+	return multiBulkReply;
     }
 
     /**
@@ -2012,7 +2010,19 @@ public class Jedis extends BinaryJedis implements JedisCommands,
      *         programming language used.
      */
     public List<String> brpop(final int timeout, final String... keys) {
-	return brpop(getArgsAddTimeout(timeout, keys));
+	checkIsInMulti();
+	List<String> args = new ArrayList<String>();
+	for (String arg : keys) {
+	    args.add(arg);
+	}
+	args.add(String.valueOf(timeout));
+
+	client.brpop(args.toArray(new String[args.size()]));
+	client.setTimeoutInfinite();
+	List<String> multiBulkReply = client.getMultiBulkReply();
+	client.rollbackTimeout();
+
+	return multiBulkReply;
     }
 
     public Long zcount(final String key, final double min, final double max) {
@@ -2714,11 +2724,9 @@ public class Jedis extends BinaryJedis implements JedisCommands,
     public String brpoplpush(String source, String destination, int timeout) {
 	client.brpoplpush(source, destination, timeout);
 	client.setTimeoutInfinite();
-	try {
-	    return client.getBulkReply();
-	} finally {
-	    client.rollbackTimeout();
-	}
+	String reply = client.getBulkReply();
+	client.rollbackTimeout();
+	return reply;
     }
 
     /**
@@ -2853,22 +2861,16 @@ public class Jedis extends BinaryJedis implements JedisCommands,
 
     public Object eval(String script, int keyCount, String... params) {
 	client.setTimeoutInfinite();
-	try {
-	    client.eval(script, keyCount, params);
-	    return getEvalResult();
-	} finally {
-	    client.rollbackTimeout();
-	}
+	client.eval(script, keyCount, params);
+
+	return getEvalResult();
     }
 
     public void subscribe(final JedisPubSub jedisPubSub,
 	    final String... channels) {
 	client.setTimeoutInfinite();
-	try {
-	    jedisPubSub.proceed(client, channels);
-	} finally {
-	    client.rollbackTimeout();
-	}
+	jedisPubSub.proceed(client, channels);
+	client.rollbackTimeout();
     }
 
     public Long publish(final String channel, final String message) {
@@ -2881,12 +2883,10 @@ public class Jedis extends BinaryJedis implements JedisCommands,
     public void psubscribe(final JedisPubSub jedisPubSub,
 	    final String... patterns) {
 	checkIsInMulti();
+	connect();
 	client.setTimeoutInfinite();
-	try {
-	    jedisPubSub.proceedWithPatterns(client, patterns);
-	} finally {
-	    client.rollbackTimeout();
-	}
+	jedisPubSub.proceedWithPatterns(client, patterns);
+	client.rollbackTimeout();
     }
 
     protected static String[] getParams(List<String> keys, List<String> args) {
@@ -2944,6 +2944,7 @@ public class Jedis extends BinaryJedis implements JedisCommands,
     public Object evalsha(String sha1, int keyCount, String... params) {
 	checkIsInMulti();
 	client.evalsha(sha1, keyCount, params);
+
 	return getEvalResult();
     }
 
@@ -3502,12 +3503,28 @@ public class Jedis extends BinaryJedis implements JedisCommands,
 
     @Override
     public List<String> blpop(int timeout, String key) {
-	return blpop(key, String.valueOf(timeout));
+	checkIsInMulti();
+	List<String> args = new ArrayList<String>();
+	args.add(key);
+	args.add(String.valueOf(timeout));
+	client.blpop(args.toArray(new String[args.size()]));
+	client.setTimeoutInfinite();
+	final List<String> multiBulkReply = client.getMultiBulkReply();
+	client.rollbackTimeout();
+	return multiBulkReply;
     }
 
     @Override
     public List<String> brpop(int timeout, String key) {
-	return brpop(key, String.valueOf(timeout));
+	checkIsInMulti();
+	List<String> args = new ArrayList<String>();
+	args.add(key);
+	args.add(String.valueOf(timeout));
+	client.brpop(args.toArray(new String[args.size()]));
+	client.setTimeoutInfinite();
+	final List<String> multiBulkReply = client.getMultiBulkReply();
+	client.rollbackTimeout();
+	return multiBulkReply;
     }
 
 }

--- a/src/main/java/redis/clients/jedis/JedisCommands.java
+++ b/src/main/java/redis/clients/jedis/JedisCommands.java
@@ -216,18 +216,10 @@ public interface JedisCommands {
 
     Long rpushx(String key, String... string);
 
-    /**
-     * @deprecated unusable command
-     */
-    @Deprecated
     List<String> blpop(String arg);
     
     List<String> blpop(int timeout, String key);
 
-    /**
-     * @deprecated unusable command
-     */
-    @Deprecated
     List<String> brpop(String arg);
     
     List<String> brpop(int timeout, String key);


### PR DESCRIPTION
Addresses issues #779 and #775. Added a Protocol stream benchmark and measured a 73% increase for Multi Bulk and 87% increase for Status Reply.  The greatly reduces the number of temporary objects created and encoded for reading results. It also ensures that we will hear about it if a stream is not fully read. In the currently implementation a stream error could cause readByte to return -1 even though a byte is required by the protocol. All unit tests and benchmarks pass.
