### PR TITLE
Fixes #791 Exceptions in close cause empty JedisPool and then deadlock

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
+import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.util.JedisURIHelper;
 import redis.clients.util.Pool;
 
@@ -112,10 +113,17 @@ public class JedisPool extends Pool<Jedis> {
     }
 
     public void returnResource(final Jedis resource) {
-	if (resource != null) {
-	    resource.resetState();
-	    returnResourceObject(resource);
-	}
+    if (resource != null) {
+        try {
+            resource.resetState();
+            returnResourceObject(resource);
+        }
+        catch (Exception e) {
+            returnBrokenResource(resource);
+            throw new JedisException(
+                    "Could not return the resource to the pool", e);
+        }
+    }
     }
 
     public int getNumActive() {


### PR DESCRIPTION
This is a fix for https://github.com/xetorthio/jedis/issues/791 which is giving us problems in our production code.

Creating a test for this was a bit interesting without Mockito, but managed to mock the failing behaviour and create a test for the defect, even if it is not the most prettiest of tests out there. :)
