### PR TITLE
Fixes a bug : resetState() throws exception with executed Transaction

### DIFF
--- a/src/main/java/redis/clients/jedis/Transaction.java
+++ b/src/main/java/redis/clients/jedis/Transaction.java
@@ -41,6 +41,7 @@ public class Transaction extends MultiKeyPipelineBase {
 	// Discard QUEUED or ERROR
 	client.getMany(getPipelinedResponseLength());
 	client.exec();
+	inTransaction = false;
 
 	List<Object> unformatted = client.getObjectMultiBulkReply();
 	if (unformatted == null) {
@@ -61,6 +62,7 @@ public class Transaction extends MultiKeyPipelineBase {
 	// Discard QUEUED or ERROR
 	client.getMany(getPipelinedResponseLength());
 	client.exec();
+	inTransaction = false;
 
 	List<Object> unformatted = client.getObjectMultiBulkReply();
 	if (unformatted == null) {

--- a/src/test/java/redis/clients/jedis/tests/commands/TransactionCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/TransactionCommandsTest.java
@@ -303,4 +303,21 @@ public class TransactionCommandsTest extends JedisCommandTestBase {
 	assertEquals(1, resp.size());
 	assertEquals("foo", jedis.get("mykey"));
     }
+    
+    @Test
+    public void testResetStateWithFullyExecutedTransaction() {
+	Jedis jedis2 = new Jedis(jedis.getClient().getHost(), jedis.getClient().getPort());
+	jedis2.auth("foobared");
+	
+	Transaction t = jedis2.multi();
+	t.set("mykey", "foo");
+	t.get("mykey");
+	
+	List<Object> resp = t.exec();
+	assertNotNull(resp);
+	assertEquals(2, resp.size());
+	
+	jedis2.resetState();
+	jedis2.close();
+    }
 }


### PR DESCRIPTION
It fixes #796.

Pipeline is fine to flip "in transaction" flag properly, but Transaction's exec() is not.
So when Jedis instance is cleaned up, resetState() is called and referenced from Jedis but already executed Transaction's clear() calls discard() again.
