### PR TITLE
Unify evalsha and eval signatures to use varargs in both Jedis and PipelineBase

### DIFF
--- a/src/main/java/redis/clients/jedis/PipelineBase.java
+++ b/src/main/java/redis/clients/jedis/PipelineBase.java
@@ -1284,7 +1284,7 @@ abstract class PipelineBase extends Queable implements BinaryRedisPipeline,
     }
 
     public Response<String> eval(String script) {
-	return this.eval(script, 0, new String[0]);
+	return this.eval(script, 0);
     }
 
     public Response<String> eval(String script, List<String> keys,
@@ -1293,8 +1293,8 @@ abstract class PipelineBase extends Queable implements BinaryRedisPipeline,
 	return this.eval(script, keys.size(), argv);
     }
 
-    public Response<String> eval(String script, int numKeys, String[] argv) {
-	getClient(script).eval(script, numKeys, argv);
+    public Response<String> eval(String script, int numKeys, String... args) {
+	getClient(script).eval(script, numKeys, args);
 	return getResponse(BuilderFactory.STRING);
     }
 


### PR DESCRIPTION
`PipelineBase`'s `evalsha` and `eval` were inconsistent with the methods in `Jedis`; PR makes the former also accept varargs.
