### PR TITLE
Don't throw an exception when calling zadd with an emtpy collection.  

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -1595,8 +1595,14 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands,
 
     public Long zadd(final byte[] key, final Map<byte[], Double> scoreMembers) {
 	checkIsInMulti();
-	client.zaddBinary(key, scoreMembers);
-	return client.getIntegerReply();
+        if (scoreMembers.isEmpty()) {
+            //empty map would throw a strange exception
+            return Long.valueOf(0);
+        }
+        else {
+            client.zaddBinary(key, scoreMembers);
+            return client.getIntegerReply();
+        }
     }
 
     public Set<byte[]> zrange(final byte[] key, final long start, final long end) {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -1492,8 +1492,14 @@ public class Jedis extends BinaryJedis implements JedisCommands,
 
     public Long zadd(final String key, final Map<String, Double> scoreMembers) {
 	checkIsInMulti();
-	client.zadd(key, scoreMembers);
-	return client.getIntegerReply();
+        if (scoreMembers.isEmpty()) {
+            //empty map would throw a strange exception
+            return Long.valueOf(0);
+        }
+        else {
+            client.zadd(key, scoreMembers);
+            return client.getIntegerReply();
+        }
     }
 
     public Set<String> zrange(final String key, final long start, final long end) {

--- a/src/test/java/redis/clients/jedis/tests/commands/VariadicCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/VariadicCommandsTest.java
@@ -145,6 +145,12 @@ public class VariadicCommandsTest extends JedisCommandTestBase {
 	status = jedis.zadd(bfoo, bscoreMembers);
 	assertEquals(1, status);
 
+        status = jedis.zadd("foo", new HashMap<String, Double>());
+        assertEquals(0, status);
+
+        status = jedis.zadd(bfoo, new HashMap<byte[], Double>());
+        assertEquals(0, status);
+        
     }
 
     @Test


### PR DESCRIPTION
The current exception doesn't seem to make sense in this context,
and I don't see any reason why not to just allow it and return 0.