### PR TITLE
version bump to 2.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'eclipse'
 
 group = 'com.googlecode.jedis'
 archivesBaseName = 'jedis'
-version = '1.5.0'
+version = '2.6.1'
 
 repositories {
    mavenCentral()


### PR DESCRIPTION
when doing `./gradlew jar` the output jar was called `./build/libs/jedis-1.5.0.jar`, thought it should be the same version number as the release.
