### PR TITLE
BinaryShardedJedis.disconnect() may occur memory leak

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
@@ -31,8 +31,12 @@ public class BinaryShardedJedis extends Sharded<Jedis, JedisShardInfo>
 
     public void disconnect() {
 	for (Jedis jedis : getAllShards()) {
-	    jedis.quit();
-	    jedis.disconnect();
+		try {
+			jedis.quit();
+			jedis.disconnect();
+		} catch (Exception e) {
+			// ignore the exception node, so that all other normal nodes can release all connections.
+		}
 	}
     }
 


### PR DESCRIPTION
Scenario:
When the middle node of cluster goes down, BinaryShardedJedis.disconnect() will unable to release connections of the following nodes, this causes memory leak.

Solution:
Ignore the exception node, so that all other normal nodes can release all connections.
