### PR TITLE
BinaryShardedJedis.disconnect() may occur memory leak

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
@@ -30,8 +30,16 @@ public class BinaryShardedJedis extends Sharded<Jedis, JedisShardInfo> implement
 
   public void disconnect() {
     for (Jedis jedis : getAllShards()) {
-      jedis.quit();
-      jedis.disconnect();
+      try {
+        jedis.quit();
+      } catch (Exception e) {
+        // ignore the exception node, so that all other normal nodes can release all connections.
+      }
+      try {
+        jedis.disconnect();
+      } catch (Exception e) {
+        // ignore the exception node, so that all other normal nodes can release all connections.
+      }
     }
   }
 

--- a/src/test/java/redis/clients/jedis/tests/ShardedJedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ShardedJedisTest.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis.tests;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.junit.Assert;
@@ -11,14 +12,79 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.ShardedJedis;
-import redis.clients.jedis.ShardedJedisPipeline;
 import redis.clients.util.Hashing;
-import redis.clients.util.SafeEncoder;
 import redis.clients.util.Sharded;
 
 public class ShardedJedisTest extends Assert {
   private static HostAndPort redis1 = HostAndPortUtil.getRedisServers().get(0);
   private static HostAndPort redis2 = HostAndPortUtil.getRedisServers().get(1);
+
+  @Test
+  public void disconnect() throws InterruptedException {
+    List<JedisShardInfo> shards = new ArrayList<JedisShardInfo>(2);
+    // 6379
+    JedisShardInfo shard1 = new JedisShardInfo(redis1.getHost(), redis1.getPort());
+    shard1.setPassword("foobared");
+    shards.add(shard1);
+    // 6380
+    JedisShardInfo shard2 = new JedisShardInfo(redis2.getHost(), redis2.getPort());
+    shard2.setPassword("foobared");
+    shards.add(shard2);
+
+    ShardedJedis shardedJedis = null;
+    try {
+      shardedJedis = new ShardedJedis(shards);
+      // establish the connection for two redis servers
+      shardedJedis.set("a", "bar");
+      JedisShardInfo ak = shardedJedis.getShardInfo("a");
+      assertEquals(shard2, ak);
+      shardedJedis.set("b", "bar1");
+      JedisShardInfo bk = shardedJedis.getShardInfo("b");
+      assertEquals(shard1, bk);
+
+      Collection<Jedis> jedisList = shardedJedis.getAllShards();
+      Jedis[] jedisArray = jedisList.toArray(new Jedis[jedisList.size()]);
+      if (!jedisList.isEmpty()) {
+        Jedis jedis1 = jedisArray[0]; // redis1
+        String clientList = jedis1.clientList();
+        String addr = clientList.split(" ")[1].split("=")[1];
+        // kill 'redis1' client connection
+        jedis1.clientKill(addr);
+        assertEquals(true, jedis1.isConnected());
+        assertEquals(false, jedis1.getClient().getSocket().isClosed());
+        assertEquals(false, jedis1.getClient().isBroken()); // normal - not found
+
+        // test for original impl
+        // try {
+        // shardedJedis.disconnect();
+        // } catch (Exception e) {
+        // // ignore exception
+        // }
+        // // the two socket connections are all not closed
+        // assertEquals(true, jedis1.isConnected());
+        // assertEquals(false, jedis1.getClient().getSocket().isClosed());
+        // assertEquals(true, jedis1.getClient().isBroken()); // exception
+        // Jedis jedis2 = jedisArray[1];
+        // assertEquals(true, jedis2.isConnected());
+        // assertEquals(false, jedis2.getClient().getSocket().isClosed());
+        // assertEquals(false, jedis2.getClient().isBroken());
+
+        // test for new impl
+        shardedJedis.disconnect();
+        assertEquals(false, jedis1.isConnected());
+        assertEquals(true, jedis1.getClient().getSocket().isClosed());
+        assertEquals(true, jedis1.getClient().isBroken()); // exception
+        Jedis jedis2 = jedisArray[1];
+        assertEquals(false, jedis2.isConnected());
+        assertEquals(true, jedis2.getClient().getSocket().isClosed());
+        assertEquals(false, jedis2.getClient().isBroken()); // normal
+      }
+    } finally {
+      if (null != shardedJedis) {
+        shardedJedis.close();
+      }
+    }
+  }
 
   private List<String> getKeysDifferentShard(ShardedJedis jedis) {
     List<String> ret = new ArrayList<String>();


### PR DESCRIPTION
Scenario:
When the middle node of cluster goes down, BinaryShardedJedis.disconnect() will unable to release connections of the following nodes, this causes memory leak.

Solution:
Ignore the exception node, so that all other normal nodes can release all connections.

This pull request adds a unit test for this solution.
Thanks to @marcosnils's guide.
