### PR TITLE
BinaryShardedJedis.disconnect() may occur memory leak

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
@@ -30,8 +30,16 @@ public class BinaryShardedJedis extends Sharded<Jedis, JedisShardInfo> implement
 
   public void disconnect() {
     for (Jedis jedis : getAllShards()) {
-      jedis.quit();
-      jedis.disconnect();
+      try {
+        jedis.quit();
+      } catch (Exception e) {
+        // ignore the exception node, so that all other normal nodes can release all connections.
+      }
+      try {
+        jedis.disconnect();
+      } catch (Exception e) {
+        // ignore the exception node, so that all other normal nodes can release all connections.
+      }
     }
   }
 


### PR DESCRIPTION
Scenario:
When the middle node of cluster goes down, BinaryShardedJedis.disconnect() will unable to release connections of the following nodes, this causes memory leak.

Solution:
Ignore the exception node, so that all other normal nodes can release all connections.

This pull request adds a unit test for this solution.
Thanks to @marcosnils's guide.
