### PR TITLE
JedisCluster.zrevrangeByScore: max, min are flipped to min, max in call

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -802,7 +802,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
-        return connection.zrevrangeByScore(key, min, max);
+        return connection.zrevrangeByScore(key, max, min);
       }
     }.run(key);
   }
@@ -823,7 +823,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
-        return connection.zrevrangeByScore(key, min, max);
+        return connection.zrevrangeByScore(key, max, min);
       }
     }.run(key);
   }
@@ -845,7 +845,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
-        return connection.zrevrangeByScore(key, min, max, offset, count);
+        return connection.zrevrangeByScore(key, max, min, offset, count);
       }
     }.run(key);
   }
@@ -865,7 +865,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     return new JedisClusterCommand<Set<Tuple>>(connectionHandler, timeout, maxRedirections) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
-        return connection.zrevrangeByScoreWithScores(key, min, max);
+        return connection.zrevrangeByScoreWithScores(key, max, min);
       }
     }.run(key);
   }
@@ -887,7 +887,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
-        return connection.zrevrangeByScore(key, min, max, offset, count);
+        return connection.zrevrangeByScore(key, max, min, offset, count);
       }
     }.run(key);
   }
@@ -907,7 +907,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     return new JedisClusterCommand<Set<Tuple>>(connectionHandler, timeout, maxRedirections) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
-        return connection.zrevrangeByScoreWithScores(key, min, max);
+        return connection.zrevrangeByScoreWithScores(key, max, min);
       }
     }.run(key);
   }


### PR DESCRIPTION
Fixes #827 
