### PR TITLE
changing DB datatype from Long to int to save some bytes

### DIFF
--- a/src/main/java/redis/clients/jedis/BasicCommands.java
+++ b/src/main/java/redis/clients/jedis/BasicCommands.java
@@ -34,7 +34,7 @@ public interface BasicCommands {
 
   String slaveofNoOne();
 
-  Long getDB();
+  int getDB();
 
   String debug(DebugParams params);
 

--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -36,7 +36,7 @@ public class BinaryClient extends Connection {
 
   private String password;
 
-  private long db;
+  private int db;
 
   private boolean isInWatch;
 
@@ -927,7 +927,7 @@ public class BinaryClient extends Connection {
     sendCommand(GETRANGE, key, toByteArray(startOffset), toByteArray(endOffset));
   }
 
-  public Long getDB() {
+  public int getDB() {
     return db;
   }
 

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -2865,7 +2865,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     }
   }
 
-  public Long getDB() {
+  public int getDB() {
     return client.getDB();
   }
 

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -1299,10 +1299,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   }
 
   @Override
-  public Long getDB() {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+  public int getDB() {
+    return new JedisClusterCommand<Integer>(connectionHandler, timeout, maxRedirections) {
       @Override
-      public Long execute(Jedis connection) {
+      public Integer execute(Jedis connection) {
         return connection.getDB();
       }
     }.run(null);

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
@@ -1,6 +1,5 @@
 package redis.clients.jedis.tests;
 
-import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -174,16 +173,16 @@ public class JedisPoolTest extends Assert {
         "foobared");
 
     Jedis jedis0 = pool.getResource();
-    assertEquals(0L, jedis0.getDB().longValue());
+    assertEquals(0, jedis0.getDB());
 
     jedis0.select(1);
-    assertEquals(1L, jedis0.getDB().longValue());
+    assertEquals(1, jedis0.getDB());
 
     pool.returnResource(jedis0);
 
     Jedis jedis1 = pool.getResource();
     assertTrue("Jedis instance was not reused", jedis1 == jedis0);
-    assertEquals(0L, jedis1.getDB().longValue());
+    assertEquals(0, jedis1.getDB());
 
     pool.returnResource(jedis1);
     pool.destroy();

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
@@ -178,7 +178,7 @@ public class JedisSentinelPoolTest extends JedisTestBase {
     Jedis afterFailoverJedis = pool.getResource();
     assertEquals("PONG", afterFailoverJedis.ping());
     assertEquals("foobared", afterFailoverJedis.configGet("requirepass").get(1));
-    assertEquals(2, afterFailoverJedis.getDB().intValue());
+    assertEquals(2, afterFailoverJedis.getDB());
 
     // returning both connections to the pool should not throw
     beforeFailoverJedis.close();

--- a/src/test/java/redis/clients/jedis/tests/JedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisTest.java
@@ -106,13 +106,13 @@ public class JedisTest extends JedisCommandTestBase {
     jedis.auth("foobared");
     assertEquals(jedis.getClient().getHost(), "localhost");
     assertEquals(jedis.getClient().getPort(), 6380);
-    assertEquals(jedis.getDB(), (Long) 0L);
+    assertEquals(jedis.getDB(), 0);
 
     jedis = new Jedis("redis://localhost:6380/");
     jedis.auth("foobared");
     assertEquals(jedis.getClient().getHost(), "localhost");
     assertEquals(jedis.getClient().getPort(), 6380);
-    assertEquals(jedis.getDB(), (Long) 0L);
+    assertEquals(jedis.getDB(), 0);
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
@@ -349,9 +349,9 @@ public class AllKindOfValuesCommandsTest extends JedisCommandTestBase {
 
   @Test
   public void getDB() {
-    assertEquals(0, jedis.getDB().longValue());
+    assertEquals(0, jedis.getDB());
     jedis.select(1);
-    assertEquals(1, jedis.getDB().longValue());
+    assertEquals(1, jedis.getDB());
   }
 
   @Test


### PR DESCRIPTION
@HeartSaVioR as discussed in the other PR #835, changing DB datatype from `Long` to `int`.