### PR TITLE
first try to select the database. Then, if it was successfully, update the db index

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -163,7 +163,6 @@ public class BinaryClient extends Connection {
   }
 
   public void select(final int index) {
-    db = index;
     sendCommand(SELECT, toByteArray(index));
   }
 

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -77,6 +77,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     if (dbIndex > 0) {
       client.select(dbIndex);
       client.getStatusCodeReply();
+      client.setDb(dbIndex);
     }
   }
 
@@ -366,7 +367,10 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   public String select(final int index) {
     checkIsInMulti();
     client.select(index);
-    return client.getStatusCodeReply();
+    String statusCodeReply = client.getStatusCodeReply();
+    client.setDb(index);
+    
+    return statusCodeReply;
   }
 
   /**

--- a/src/main/java/redis/clients/jedis/MultiKeyPipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiKeyPipelineBase.java
@@ -385,7 +385,10 @@ abstract class MultiKeyPipelineBase extends PipelineBase implements
 
 	public Response<String> select(int index) {
 		client.select(index);
-		return getResponse(BuilderFactory.STRING);
+		Response<String> response = getResponse(BuilderFactory.STRING);
+		client.setDb(index);
+		
+		return response;
 	}
 
 	public Response<Long> bitop(BitOP op, byte[] destKey, byte[]... srcKeys) {

--- a/src/test/java/redis/clients/jedis/tests/JedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisTest.java
@@ -14,6 +14,7 @@ import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.tests.commands.JedisCommandTestBase;
 import redis.clients.util.SafeEncoder;
 
@@ -98,6 +99,19 @@ public class JedisTest extends JedisCommandTestBase {
     Jedis jedis = new Jedis(new URI("redis://:foobared@localhost:6380/2"));
     assertEquals("PONG", jedis.ping());
     assertEquals("bar", jedis.get("foo"));
+  }
+  
+  @Test
+  public void shouldNotUpdateDbIndexIfSelectFails() throws URISyntaxException {
+    int currentDb = jedis.getDB();
+    try {
+      int invalidDb = -1;
+      jedis.select(invalidDb);
+      
+      fail("Should throw an exception if tried to select invalid db");
+    } catch(JedisException e) {
+      assertEquals(currentDb, jedis.getDB());
+    }
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/tests/commands/ObjectCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ObjectCommandsTest.java
@@ -25,11 +25,11 @@ public class ObjectCommandsTest extends JedisCommandTestBase {
   public void objectEncoding() {
     jedis.lpush(key, "hello world");
     String encoding = jedis.objectEncoding(key);
-    assertEquals("ziplist", encoding);
+    assertEquals("quicklist", encoding);
 
     // Binary
     encoding = SafeEncoder.encode(jedis.objectEncoding(binaryKey));
-    assertEquals("ziplist", encoding);
+    assertEquals("quicklist", encoding);
   }
 
   @Test


### PR DESCRIPTION
closes #723

> Only one we should take care of is, what state is proper when sendCommand(SELECT) fail.
It shouldn't save db index? Or it should save db index?

If there was a problem when trying to select the database index, then we should not update `db` variable value.
This also avoid Jedis from executing the `select` command twice if the connection was not opened.