### PR TITLE
Fix blpop and brpop in JedisCluster

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -1095,7 +1095,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
       public List<String> execute(Jedis connection) {
         return connection.blpop(arg);
       }
-    }.run(null);
+    }.run(arg);
   }
 
   @Override
@@ -1105,7 +1105,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
       public List<String> execute(Jedis connection) {
         return connection.brpop(arg);
       }
-    }.run(null);
+    }.run(arg);
   }
 
   @Override
@@ -1416,7 +1416,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
       public List<String> execute(Jedis connection) {
         return connection.blpop(timeout, key);
       }
-    }.run(null);
+    }.run(key);
   }
 
   @Override
@@ -1426,7 +1426,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
       public List<String> execute(Jedis connection) {
         return connection.brpop(timeout, key);
       }
-    }.run(null);
+    }.run(key);
   }
 
 }

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -154,15 +154,6 @@ public class JedisClusterTest extends Assert {
     assertEquals("test", node2.get("test"));
   }
 
-  @Test
-  public void testBlpop() {
-    Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
-    jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
-    JedisCluster jc = new JedisCluster(jedisClusterNode);
-    jc.lpush("foo", "bar");
-    assertEquals("bar", jc.blpop(0, "foo").get(1));
-  }
-  
   /**
    * slot->nodes 15363 node3 e
    */

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -154,6 +154,15 @@ public class JedisClusterTest extends Assert {
     assertEquals("test", node2.get("test"));
   }
 
+  @Test
+  public void testBlpop() {
+    Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
+    jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
+    JedisCluster jc = new JedisCluster(jedisClusterNode);
+    jc.lpush("foo", "bar");
+    assertEquals("bar", jc.blpop(0, "foo").get(1));
+  }
+  
   /**
    * slot->nodes 15363 node3 e
    */


### PR DESCRIPTION
Before when trying to execute RedisCluster's method blpop or brpop (for example redisCluster.blpop(0, QUEUE)) a JedisClusterException was thrown with the meassage "No way to dispatch this command to Redis Cluster.".
The first commit proposes a fix to this issue.
The second adds a test for the method.