### PR TITLE
make pexpire in BinaryJedis was take a byte[] instead of String

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisCommands.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCommands.java
@@ -23,7 +23,7 @@ public interface BinaryJedisCommands {
 
   Long expire(byte[] key, int seconds);
 
-  Long pexpire(final String key, final long milliseconds);
+  Long pexpire(byte[] key, final long milliseconds);
 
   Long expireAt(byte[] key, long unixTime);
 

--- a/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
@@ -78,7 +78,7 @@ public class BinaryShardedJedis extends Sharded<Jedis, JedisShardInfo> implement
     return j.expire(key, seconds);
   }
 
-  public Long pexpire(String key, final long milliseconds) {
+  public Long pexpire(byte[] key, final long milliseconds) {
     Jedis j = getShard(key);
     return j.pexpire(key, milliseconds);
   }


### PR DESCRIPTION
Updated pexpire in BinaryJedis to be byte[] key. Wasn't consistent with rest of binaryJedis