### PR TITLE
Add BinaryJedis.pexpire which take a byte[] instead of String

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -337,6 +337,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   }
 
   /**
+   * @deprecated use BinaryJedis.pexpire(byte[], long) or Jedis.pexpire(String,long)
    * Set a timeout on the specified key. After the timeout the key will be automatically deleted by
    * the server. A key with an associated timeout is said to be volatile in Redis terminology.
    * <p>
@@ -357,6 +358,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    *         the key already has an associated timeout (this may happen only in Redis versions <
    *         2.1.3, Redis >= 2.1.3 will happily update the timeout), or the key does not exist.
    */
+  @Deprecated
   public Long pexpire(String key, final long milliseconds) {
     checkIsInMulti();
     client.pexpire(key, milliseconds);

--- a/src/main/java/redis/clients/jedis/BinaryJedisCommands.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCommands.java
@@ -23,7 +23,13 @@ public interface BinaryJedisCommands {
 
   Long expire(byte[] key, int seconds);
 
+  /**
+   * @deprecated String key operation on BinaryCommand. Use byte[] or JedisCommands
+   */
+  @Deprecated
   Long pexpire(final String key, final long milliseconds);
+
+  Long pexpire(byte[] key, final long milliseconds);
 
   Long expireAt(byte[] key, long unixTime);
 

--- a/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
@@ -78,6 +78,11 @@ public class BinaryShardedJedis extends Sharded<Jedis, JedisShardInfo> implement
     return j.expire(key, seconds);
   }
 
+  public Long pexpire(byte[] key, final long milliseconds) {
+    Jedis j = getShard(key);
+    return j.pexpire(key, milliseconds);
+  }
+  @Deprecated
   public Long pexpire(String key, final long milliseconds) {
     Jedis j = getShard(key);
     return j.pexpire(key, milliseconds);


### PR DESCRIPTION
Added pexpire in BinaryJedis with byte[] key. Wasn't consistent with rest of binaryJedis.

Deprecated the String version.