### PR TITLE
PSETEX should take a long parameter

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -1088,7 +1088,12 @@ public class BinaryClient extends Connection {
     sendCommand(PTTL, key);
   }
 
+  @Deprecated
   public void psetex(final byte[] key, final int milliseconds, final byte[] value) {
+    psetex(key, (long) milliseconds, value);
+  }
+
+  public void psetex(final byte[] key, final long milliseconds, final byte[] value) {
     sendCommand(PSETEX, key, toByteArray(milliseconds), value);
   }
 

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -3090,7 +3090,12 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     return client.getIntegerReply();
   }
 
+  @Deprecated
   public String psetex(final byte[] key, final int milliseconds, final byte[] value) {
+    return psetex(key, (long) milliseconds, value);
+  }
+
+  public String psetex(final byte[] key, final long milliseconds, final byte[] value) {
     checkIsInMulti();
     client.psetex(key, milliseconds, value);
     return client.getStatusCodeReply();

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -789,7 +789,12 @@ public class Client extends BinaryClient implements Commands {
     incrByFloat(SafeEncoder.encode(key), increment);
   }
 
+  @Deprecated
   public void psetex(final String key, final int milliseconds, final String value) {
+    psetex(key, (long) milliseconds, value);
+  }
+
+  public void psetex(final String key, final long milliseconds, final String value) {
     psetex(SafeEncoder.encode(key), milliseconds, SafeEncoder.encode(value));
   }
 

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -2900,7 +2900,12 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     return client.getIntegerReply();
   }
 
+  @Deprecated
   public String psetex(final String key, final int milliseconds, final String value) {
+    return psetex(key, (long) milliseconds, value);
+  }
+
+  public String psetex(final String key, final long milliseconds, final String value) {
     checkIsInMulti();
     client.psetex(key, milliseconds, value);
     return client.getStatusCodeReply();

--- a/src/main/java/redis/clients/jedis/PipelineBase.java
+++ b/src/main/java/redis/clients/jedis/PipelineBase.java
@@ -1190,12 +1190,22 @@ abstract class PipelineBase extends Queable implements BinaryRedisPipeline, Redi
     return getResponse(BuilderFactory.DOUBLE);
   }
 
+  @Deprecated
   public Response<String> psetex(String key, int milliseconds, String value) {
+    return psetex(key, (long) milliseconds, value);
+  }
+
+  @Deprecated
+  public Response<String> psetex(byte[] key, int milliseconds, byte[] value) {
+    return psetex(key, (long) milliseconds, value);
+  }
+
+  public Response<String> psetex(String key, long milliseconds, String value) {
     getClient(key).psetex(key, milliseconds, value);
     return getResponse(BuilderFactory.STRING);
   }
 
-  public Response<String> psetex(byte[] key, int milliseconds, byte[] value) {
+  public Response<String> psetex(byte[] key, long milliseconds, byte[] value) {
     getClient(key).psetex(key, milliseconds, value);
     return getResponse(BuilderFactory.STRING);
   }

--- a/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
@@ -511,6 +511,18 @@ public class AllKindOfValuesCommandsTest extends JedisCommandTestBase {
   }
 
   @Test
+  public void psetex() {
+    long pttl = jedis.pttl("foo");
+    assertEquals(-2, pttl);
+
+    String status = jedis.psetex("foo", 200000000000L, "bar");
+    assertTrue(Keyword.OK.name().equalsIgnoreCase(status));
+
+    pttl = jedis.pttl("foo");
+    assertTrue(pttl > 100000000000L);
+  }
+
+  @Test
   public void scan() {
     jedis.set("b", "b");
     jedis.set("a", "a");


### PR DESCRIPTION
Deprecates psetex(String, int, String) in favour of psetex(String, long, String). Note that test failures are due to #896. This change is in the same vein as #576.