### PR TITLE
Follow up new behavior of rename from test

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
@@ -211,21 +211,12 @@ public class AllKindOfValuesCommandsTest extends JedisCommandTestBase {
 
   @Test
   public void renameOldAndNewAreTheSame() {
-    try {
-      jedis.set("foo", "bar");
-      jedis.rename("foo", "foo");
-      fail("JedisDataException expected");
-    } catch (final JedisDataException e) {
-    }
+    jedis.set("foo", "bar");
+    jedis.rename("foo", "foo");
 
     // Binary
-    try {
-      jedis.set(bfoo, bbar);
-      jedis.rename(bfoo, bfoo);
-      fail("JedisDataException expected");
-    } catch (final JedisDataException e) {
-    }
-
+    jedis.set(bfoo, bbar);
+    jedis.rename(bfoo, bfoo);
   }
 
   @Test


### PR DESCRIPTION
* Fixes #896
* Renaming a key to itself is now essentially a noop