### PR TITLE
Remove deprecated PSETEX with int parameter

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -1088,11 +1088,6 @@ public class BinaryClient extends Connection {
     sendCommand(PTTL, key);
   }
 
-  @Deprecated
-  public void psetex(final byte[] key, final int milliseconds, final byte[] value) {
-    psetex(key, (long) milliseconds, value);
-  }
-
   public void psetex(final byte[] key, final long milliseconds, final byte[] value) {
     sendCommand(PSETEX, key, toByteArray(milliseconds), value);
   }

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -3090,11 +3090,6 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     return client.getIntegerReply();
   }
 
-  @Deprecated
-  public String psetex(final byte[] key, final int milliseconds, final byte[] value) {
-    return psetex(key, (long) milliseconds, value);
-  }
-
   public String psetex(final byte[] key, final long milliseconds, final byte[] value) {
     checkIsInMulti();
     client.psetex(key, milliseconds, value);

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -789,11 +789,6 @@ public class Client extends BinaryClient implements Commands {
     incrByFloat(SafeEncoder.encode(key), increment);
   }
 
-  @Deprecated
-  public void psetex(final String key, final int milliseconds, final String value) {
-    psetex(key, (long) milliseconds, value);
-  }
-
   public void psetex(final String key, final long milliseconds, final String value) {
     psetex(SafeEncoder.encode(key), milliseconds, SafeEncoder.encode(value));
   }

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -2900,11 +2900,6 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     return client.getIntegerReply();
   }
 
-  @Deprecated
-  public String psetex(final String key, final int milliseconds, final String value) {
-    return psetex(key, (long) milliseconds, value);
-  }
-
   public String psetex(final String key, final long milliseconds, final String value) {
     checkIsInMulti();
     client.psetex(key, milliseconds, value);

--- a/src/main/java/redis/clients/jedis/PipelineBase.java
+++ b/src/main/java/redis/clients/jedis/PipelineBase.java
@@ -1190,16 +1190,6 @@ abstract class PipelineBase extends Queable implements BinaryRedisPipeline, Redi
     return getResponse(BuilderFactory.DOUBLE);
   }
 
-  @Deprecated
-  public Response<String> psetex(String key, int milliseconds, String value) {
-    return psetex(key, (long) milliseconds, value);
-  }
-
-  @Deprecated
-  public Response<String> psetex(byte[] key, int milliseconds, byte[] value) {
-    return psetex(key, (long) milliseconds, value);
-  }
-
   public Response<String> psetex(String key, long milliseconds, String value) {
     getClient(key).psetex(key, milliseconds, value);
     return getResponse(BuilderFactory.STRING);


### PR DESCRIPTION
Removes deprecated psetex(String, int, String). This is the follow-up to #898.