### PR TITLE
Deprecate BasicCommands from JedisCluster since it has no meaning

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -1158,6 +1158,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(key);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String ping() {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1168,6 +1172,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String quit() {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1178,6 +1186,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String flushDB() {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1188,6 +1200,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public Long dbSize() {
     return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
@@ -1198,6 +1214,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String select(final int index) {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1208,6 +1228,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String flushAll() {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1218,6 +1242,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String auth(final String password) {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1228,6 +1256,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String save() {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1238,6 +1270,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String bgsave() {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1248,6 +1284,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String bgrewriteaof() {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1258,6 +1298,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public Long lastsave() {
     return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
@@ -1268,6 +1312,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String shutdown() {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1278,6 +1326,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String info() {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1288,6 +1340,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String info(final String section) {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1298,6 +1354,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String slaveof(final String host, final int port) {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1308,6 +1368,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String slaveofNoOne() {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1318,6 +1382,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public int getDB() {
     return new JedisClusterCommand<Integer>(connectionHandler, timeout, maxRedirections) {
@@ -1328,6 +1396,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String debug(final DebugParams params) {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1338,6 +1410,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(null);
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public String configResetStat() {
     return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
@@ -1352,6 +1428,10 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     return connectionHandler.getNodes();
   }
 
+  /**
+   * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
+   */
+  @Deprecated
   @Override
   public Long waitReplicas(int replicas, long timeout) {
     // TODO Auto-generated method stub


### PR DESCRIPTION
It'll be removed when we merge cluster-revised branch to master.
So I wanna mark it to @Deprecated to let users know.