### PR TITLE
Fix: slot key is missed from *scan in JedisCluster

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -1366,7 +1366,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
       public ScanResult<Entry<String, String>> execute(Jedis connection) {
         return connection.hscan(key, cursor);
       }
-    }.run(null);
+    }.run(key);
   }
 
   @Override
@@ -1376,7 +1376,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
       public ScanResult<String> execute(Jedis connection) {
         return connection.sscan(key, cursor);
       }
-    }.run(null);
+    }.run(key);
   }
 
   @Override
@@ -1386,7 +1386,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
       public ScanResult<Tuple> execute(Jedis connection) {
         return connection.zscan(key, cursor);
       }
-    }.run(null);
+    }.run(key);
   }
 
   @Override


### PR DESCRIPTION
Maybe we really need to think about #829 ASAP.