### PR TITLE
deprecating returnBrokenResource

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -88,6 +88,10 @@ public class JedisPool extends Pool<Jedis> {
     return jedis;
   }
 
+  /**
+   * Deprecated, this method will be removed. returnResource method must be used for return all resources(broken or not)
+   */
+  @Deprecated
   public void returnBrokenResource(final Jedis resource) {
     if (resource != null) {
       returnBrokenResourceObject(resource);


### PR DESCRIPTION
We will use only returnResource and the broken logic will be in it.

This is related to #909 in order to simplify the return resource to pool logic.

@HeartSaVioR @marcosnils 