### PR TITLE
fix bug: getIntegerMultiBulkReply() doesn't handle broken status

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -230,7 +230,7 @@ public class Connection implements Closeable {
   @SuppressWarnings("unchecked")
   public List<Long> getIntegerMultiBulkReply() {
     flush();
-    return (List<Long>) Protocol.read(inputStream);
+    return (List<Long>) readProtocolWithCheckingBroken();
   }
 
   public Object getOne() {

--- a/src/test/java/redis/clients/jedis/tests/ShardedJedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ShardedJedisTest.java
@@ -12,6 +12,7 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.ShardedJedis;
+import redis.clients.jedis.tests.utils.ClientKillerUtil;
 import redis.clients.util.Hashing;
 import redis.clients.util.Sharded;
 
@@ -51,15 +52,7 @@ public class ShardedJedisTest extends Assert {
     Jedis deadClient = it.next();
     deadClient.clientSetname("DEAD");
 
-    for (String clientInfo : deadClient.clientList().split("\n")) {
-      if (clientInfo.contains("DEAD")) {
-        // Ugly, but cmon, it's a test.
-        String[] hostAndPort = clientInfo.split(" ")[1].split("=")[1].split(":");
-        // It would be better if we kill the client by Id as it's safer but jedis doesn't implement
-        // the command yet.
-        deadClient.clientKill(hostAndPort[0] + ":" + hostAndPort[1]);
-      }
-    }
+    ClientKillerUtil.killClient(deadClient, "DEAD");
 
     assertEquals(true, deadClient.isConnected());
     assertEquals(false, deadClient.getClient().getSocket().isClosed());

--- a/src/test/java/redis/clients/jedis/tests/commands/ScriptingCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ScriptingCommandsTest.java
@@ -10,7 +10,10 @@ import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import redis.clients.jedis.BinaryJedis;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.tests.utils.ClientKillerUtil;
 import redis.clients.util.SafeEncoder;
 
 public class ScriptingCommandsTest extends JedisCommandTestBase {
@@ -197,6 +200,27 @@ public class ScriptingCommandsTest extends JedisCommandTestBase {
     assertEquals(2, results.size());
     assertNull(results.get(0));
     assertNull(results.get(1));
+  }
+
+  @Test
+  public void scriptExistsWithBrokenConnection() {
+    Jedis deadClient = new Jedis(jedis.getClient().getHost(), jedis.getClient().getPort());
+    deadClient.auth("foobared");
+
+    deadClient.clientSetname("DEAD");
+
+    ClientKillerUtil.killClient(deadClient, "DEAD");
+
+    // sure, script doesn't exist, but it's just for checking connection
+    try {
+      deadClient.scriptExists("abcdefg");
+    } catch (JedisConnectionException e) {
+      // ignore it
+    }
+
+    assertEquals(true, deadClient.getClient().isBroken());
+
+    deadClient.close();
   }
 
   private <T> Matcher<Iterable<? super T>> listWithItem(T expected) {

--- a/src/test/java/redis/clients/jedis/tests/utils/ClientKillerUtil.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/ClientKillerUtil.java
@@ -1,0 +1,17 @@
+package redis.clients.jedis.tests.utils;
+
+import redis.clients.jedis.Jedis;
+
+public class ClientKillerUtil {
+  public static void killClient(Jedis jedis, String clientName) {
+    for (String clientInfo : jedis.clientList().split("\n")) {
+      if (clientInfo.contains("name=" + clientName)) {
+        // Ugly, but cmon, it's a test.
+        String[] hostAndPort = clientInfo.split(" ")[1].split("=")[1].split(":");
+        // It would be better if we kill the client by Id as it's safer but jedis doesn't implement
+        // the command yet.
+        jedis.clientKill(hostAndPort[0] + ":" + hostAndPort[1]);
+      }
+    }
+  }
+}


### PR DESCRIPTION
When users call scriptExists() but occurs JedisConnectionException, Jedis.close() doesn't work properly.