### PR TITLE
Deprecates JedisPool returnResource and returnBrokenResource

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -337,20 +337,22 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   }
 
   /**
-   * @deprecated use BinaryJedis.pexpire(byte[], long) or Jedis.pexpire(String,long)
-   * Set a timeout on the specified key. After the timeout the key will be automatically deleted by
-   * the server. A key with an associated timeout is said to be volatile in Redis terminology.
-   * <p>
-   * Voltile keys are stored on disk like the other keys, the timeout is persistent too like all the
-   * other aspects of the dataset. Saving a dataset containing expires and stopping the server does
-   * not stop the flow of time as Redis stores on disk the time when the key will no longer be
-   * available as Unix time, and not the remaining milliseconds.
-   * <p>
-   * Since Redis 2.1.3 you can update the value of the timeout of a key already having an expire
-   * set. It is also possible to undo the expire at all turning the key into a normal key using the
-   * {@link #persist(byte[]) PERSIST} command.
-   * <p>
-   * Time complexity: O(1)
+   * @deprecated use BinaryJedis.pexpire(byte[], long) or Jedis.pexpire(String,long) Set a timeout
+   *             on the specified key. After the timeout the key will be automatically deleted by
+   *             the server. A key with an associated timeout is said to be volatile in Redis
+   *             terminology.
+   *             <p>
+   *             Voltile keys are stored on disk like the other keys, the timeout is persistent too
+   *             like all the other aspects of the dataset. Saving a dataset containing expires and
+   *             stopping the server does not stop the flow of time as Redis stores on disk the time
+   *             when the key will no longer be available as Unix time, and not the remaining
+   *             milliseconds.
+   *             <p>
+   *             Since Redis 2.1.3 you can update the value of the timeout of a key already having
+   *             an expire set. It is also possible to undo the expire at all turning the key into a
+   *             normal key using the {@link #persist(byte[]) PERSIST} command.
+   *             <p>
+   *             Time complexity: O(1)
    * @see <ahref="http://redis.io/commands/pexpire">PEXPIRE Command</a>
    * @param key
    * @param milliseconds

--- a/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
@@ -82,6 +82,7 @@ public class BinaryShardedJedis extends Sharded<Jedis, JedisShardInfo> implement
     Jedis j = getShard(key);
     return j.pexpire(key, milliseconds);
   }
+
   @Deprecated
   public Long pexpire(String key, final long milliseconds) {
     Jedis j = getShard(key);

--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -88,12 +88,22 @@ public class JedisPool extends Pool<Jedis> {
     return jedis;
   }
 
+  /**
+   * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
+   *             using @see {@link redis.clients.jedis.Jedis#close()}
+   */
+  @Deprecated
   public void returnBrokenResource(final Jedis resource) {
     if (resource != null) {
       returnBrokenResourceObject(resource);
     }
   }
 
+  /**
+   * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
+   *             using @see {@link redis.clients.jedis.Jedis#close()}
+   */
+  @Deprecated
   public void returnResource(final Jedis resource) {
     if (resource != null) {
       try {

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -194,12 +194,20 @@ public class JedisSentinelPool extends Pool<Jedis> {
     }
   }
 
+  /**
+   * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
+   *             using @see {@link redis.clients.jedis.Jedis#close()}
+   */
   public void returnBrokenResource(final Jedis resource) {
     if (resource != null) {
       returnBrokenResourceObject(resource);
     }
   }
 
+  /**
+   * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
+   *             using @see {@link redis.clients.jedis.Jedis#close()}
+   */
   public void returnResource(final Jedis resource) {
     if (resource != null) {
       resource.resetState();

--- a/src/main/java/redis/clients/jedis/ShardedJedisPool.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedisPool.java
@@ -40,7 +40,7 @@ public class ShardedJedisPool extends Pool<ShardedJedis> {
 
   /**
    * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
-   *             using @see {@link redis.clients.jedis.Jedis#close()}
+   *             using @see {@link redis.clients.jedis.ShardedJedis#close()}
    */
   @Override
   public void returnBrokenResource(final ShardedJedis resource) {
@@ -51,7 +51,7 @@ public class ShardedJedisPool extends Pool<ShardedJedis> {
 
   /**
    * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
-   *             using @see {@link redis.clients.jedis.Jedis#close()}
+   *             using @see {@link redis.clients.jedis.ShardedJedis#close()}
    */
   @Override
   public void returnResource(final ShardedJedis resource) {

--- a/src/main/java/redis/clients/jedis/ShardedJedisPool.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedisPool.java
@@ -38,6 +38,10 @@ public class ShardedJedisPool extends Pool<ShardedJedis> {
     return jedis;
   }
 
+  /**
+   * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
+   *             using @see {@link redis.clients.jedis.Jedis#close()}
+   */
   @Override
   public void returnBrokenResource(final ShardedJedis resource) {
     if (resource != null) {
@@ -45,6 +49,10 @@ public class ShardedJedisPool extends Pool<ShardedJedis> {
     }
   }
 
+  /**
+   * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
+   *             using @see {@link redis.clients.jedis.Jedis#close()}
+   */
   @Override
   public void returnResource(final ShardedJedis resource) {
     if (resource != null) {


### PR DESCRIPTION
Per #909 as we're planning not to support these methods in the future to avoid confusions.