### PR TITLE
add spop with count command available in 3.0

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -344,6 +344,10 @@ public class BinaryClient extends Connection {
     sendCommand(SPOP, key);
   }
 
+  public void spop(final byte[] key, final long count) {
+    sendCommand(SPOP, key, toByteArray(count));
+  }
+
   public void smove(final byte[] srckey, final byte[] dstkey, final byte[] member) {
     sendCommand(SMOVE, srckey, dstkey, member);
   }

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -1245,6 +1245,13 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     return client.getBinaryBulkReply();
   }
 
+  public Set<byte[]> spop(final byte[] key, final long count) {
+    checkIsInMulti();
+    client.spop(key, count);
+    final List<byte[]> members = client.getBinaryMultiBulkReply();
+    return new HashSet<byte[]>(members);
+  }
+
   /**
    * Move the specified member from the set at srckey to the set at dstkey. This operation is
    * atomic, in every given moment the element will appear to be in the source or destination set

--- a/src/main/java/redis/clients/jedis/BinaryJedisCommands.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCommands.java
@@ -121,6 +121,8 @@ public interface BinaryJedisCommands {
 
   byte[] spop(byte[] key);
 
+  Set<byte[]> spop(byte[] key, long count);
+
   Long scard(byte[] key);
 
   Boolean sismember(byte[] key, byte[] member);

--- a/src/main/java/redis/clients/jedis/BinaryRedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/BinaryRedisPipeline.java
@@ -124,6 +124,8 @@ public interface BinaryRedisPipeline {
 
   Response<byte[]> spop(byte[] key);
 
+  Response<Set<byte[]>> spop(byte[] key, long count);
+
   Response<byte[]> srandmember(byte[] key);
 
   Response<Long> srem(byte[] key, byte[]... member);

--- a/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
@@ -313,6 +313,11 @@ public class BinaryShardedJedis extends Sharded<Jedis, JedisShardInfo> implement
     return j.spop(key);
   }
 
+  public Set<byte[]> spop(byte[] key, long count) {
+    Jedis j = getShard(key);
+    return j.spop(key, count);
+  }
+
   public Long scard(byte[] key) {
     Jedis j = getShard(key);
     return j.scard(key);

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -259,6 +259,10 @@ public class Client extends BinaryClient implements Commands {
     spop(SafeEncoder.encode(key));
   }
 
+  public void spop(final String key, final long count) {
+    spop(SafeEncoder.encode(key), count);
+  }
+
   public void smove(final String srckey, final String dstkey, final String member) {
     smove(SafeEncoder.encode(srckey), SafeEncoder.encode(dstkey), SafeEncoder.encode(member));
   }

--- a/src/main/java/redis/clients/jedis/Commands.java
+++ b/src/main/java/redis/clients/jedis/Commands.java
@@ -125,6 +125,8 @@ public interface Commands {
 
   public void spop(final String key);
 
+  public void spop(final String key, final long count);
+
   public void smove(final String srckey, final String dstkey, final String member);
 
   public void scard(final String key);

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -1092,6 +1092,16 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     return client.getBulkReply();
   }
 
+  public Set<String> spop(final String key, final long count) {
+    checkIsInMulti();
+    client.spop(key, count);
+    final List<String> members = client.getMultiBulkReply();
+    if (members == null) {
+      return null;
+    }
+    return new HashSet<String>(members);
+  }
+
   /**
    * Move the specifided member from the set at srckey to the set at dstkey. This operation is
    * atomic, in every given moment the element will appear to be in the source or destination set

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -588,6 +588,16 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   }
 
   @Override
+  public Set<String> spop(final String key, final long count) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+      @Override
+      public Set<String> execute(Jedis connection) {
+        return connection.spop(key, count);
+      }
+    }.run(key);
+  }
+
+  @Override
   public Long scard(final String key) {
     return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
       @Override

--- a/src/main/java/redis/clients/jedis/JedisCommands.java
+++ b/src/main/java/redis/clients/jedis/JedisCommands.java
@@ -112,6 +112,8 @@ public interface JedisCommands {
 
   String spop(String key);
 
+  Set<String> spop(String key, long count);
+
   Long scard(String key);
 
   Boolean sismember(String key, String member);

--- a/src/main/java/redis/clients/jedis/PipelineBase.java
+++ b/src/main/java/redis/clients/jedis/PipelineBase.java
@@ -585,9 +585,19 @@ abstract class PipelineBase extends Queable implements BinaryRedisPipeline, Redi
     return getResponse(BuilderFactory.STRING);
   }
 
+  public Response<Set<String>> spop(String key, long count) {
+    getClient(key).spop(key,count);
+    return getResponse(BuilderFactory.STRING_SET);
+  }
+
   public Response<byte[]> spop(byte[] key) {
     getClient(key).spop(key);
     return getResponse(BuilderFactory.BYTE_ARRAY);
+  }
+
+  public Response<Set<byte[]>> spop(byte[] key, long count) {
+    getClient(key).spop(key, count);
+    return getResponse(BuilderFactory.BYTE_ARRAY_ZSET);
   }
 
   public Response<String> srandmember(String key) {

--- a/src/main/java/redis/clients/jedis/RedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/RedisPipeline.java
@@ -122,6 +122,8 @@ public interface RedisPipeline {
 
   Response<String> spop(String key);
 
+  Response<Set<String>> spop(String key, long count);
+
   Response<String> srandmember(String key);
 
   Response<Long> srem(String key, String... member);

--- a/src/main/java/redis/clients/jedis/ShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedis.java
@@ -347,6 +347,11 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands, C
     return j.spop(key);
   }
 
+  public Set<String> spop(String key, long count) {
+    Jedis j = getShard(key);
+    return j.spop(key, count);
+  }
+
   public Long scard(String key) {
     Jedis j = getShard(key);
     return j.scard(key);

--- a/src/test/java/redis/clients/jedis/tests/commands/SetCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/SetCommandsTest.java
@@ -133,6 +133,41 @@ public class SetCommandsTest extends JedisCommandTestBase {
   }
 
   @Test
+  public void spopWithCount() {
+    jedis.sadd("foo", "a");
+    jedis.sadd("foo", "b");
+
+    Set<String> expected = new HashSet<String>();
+    expected.add("a");
+    expected.add("b");
+
+    Set<String> members = jedis.spop("foo",2);
+
+    assertEquals(2, members.size());
+    assertEquals(members, expected);
+
+    members = jedis.spop("foo",2);
+    assertTrue(members.isEmpty());
+
+    // Binary
+    jedis.sadd(bfoo, ba);
+    jedis.sadd(bfoo, bb);
+
+    Set<byte[]> bexpected = new HashSet<byte[]>();
+    bexpected.add(bb);
+    bexpected.add(ba);
+
+    Set<byte[]> bmembers = jedis.spop(bfoo, 2);
+
+    assertEquals(2, bmembers.size());
+    assertEquals(bexpected, bmembers);
+
+    bmembers = jedis.spop(bfoo,2);
+    assertTrue(bmembers.isEmpty());
+
+  }
+
+  @Test
   public void smove() {
     jedis.sadd("foo", "a");
     jedis.sadd("foo", "b");


### PR DESCRIPTION
hello, 

redis 3.0 adds support for `spop` with a count, this PR adds the same for jedis

http://redis.io/commands/SPOP

thanks