### PR TITLE
add generation of OSGi metadata in the manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,28 @@
 		      <configFile>${project.basedir}/hbase-formatter.xml</configFile>
 	      </configuration>
       </plugin>
+			<plugin>
+			  <artifactId>maven-jar-plugin</artifactId>
+			  <configuration>
+			    <archive>  
+			      <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+			    </archive> 
+			  </configuration>
+			</plugin> 
+      		<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>2.5.3</version>		
+				<executions>
+				    <execution>
+				      <id>bundle-manifest</id>
+				      <phase>process-classes</phase>
+				      <goals>    
+				        <goal>manifest</goal>
+				      </goals>   
+				    </execution>
+				</executions>		
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
Added automatic generation of the OSGi metadata in the Manifest. Closes xetorthio/jedis/issues/443 and xetorthio/jedis/issues/501