### PR TITLE
Sets timeout correctly for JedisCluster. Fixes #602.

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -12,14 +12,13 @@ import redis.clients.jedis.BinaryClient.LIST_POSITION;
 
 public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   public static final short HASHSLOTS = 16384;
-  private static final int DEFAULT_TIMEOUT = 1;
+  private static final int DEFAULT_TIMEOUT = 2000;
   private static final int DEFAULT_MAX_REDIRECTIONS = 5;
 
   public static enum Reset {
     SOFT, HARD
   }
 
-  private int timeout;
   private int maxRedirections;
 
   private JedisClusterConnectionHandler connectionHandler;
@@ -46,8 +45,8 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   public JedisCluster(Set<HostAndPort> jedisClusterNode, int timeout, int maxRedirections,
       final GenericObjectPoolConfig poolConfig) {
-    this.connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig);
-    this.timeout = timeout;
+    this.connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
+        timeout);
     this.maxRedirections = maxRedirections;
   }
 
@@ -68,7 +67,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String set(final String key, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.set(key, value);
@@ -79,7 +78,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Override
   public String set(final String key, final String value, final String nxxx, final String expx,
       final long time) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.set(key, value, nxxx, expx, time);
@@ -89,7 +88,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String get(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.get(key);
@@ -99,7 +98,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Boolean exists(final String key) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.exists(key);
@@ -109,7 +108,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long persist(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.persist(key);
@@ -119,7 +118,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String type(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.type(key);
@@ -129,7 +128,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long expire(final String key, final int seconds) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.expire(key, seconds);
@@ -139,7 +138,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long pexpire(final String key, final long milliseconds) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pexpire(key, milliseconds);
@@ -149,7 +148,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long expireAt(final String key, final long unixTime) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.expireAt(key, unixTime);
@@ -159,7 +158,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long pexpireAt(final String key, final long millisecondsTimestamp) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pexpireAt(key, millisecondsTimestamp);
@@ -169,7 +168,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long ttl(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.ttl(key);
@@ -179,7 +178,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Boolean setbit(final String key, final long offset, final boolean value) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.setbit(key, offset, value);
@@ -189,7 +188,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Boolean setbit(final String key, final long offset, final String value) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.setbit(key, offset, value);
@@ -199,7 +198,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Boolean getbit(final String key, final long offset) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.getbit(key, offset);
@@ -209,7 +208,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long setrange(final String key, final long offset, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.setrange(key, offset, value);
@@ -219,7 +218,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String getrange(final String key, final long startOffset, final long endOffset) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.getrange(key, startOffset, endOffset);
@@ -229,7 +228,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String getSet(final String key, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.getSet(key, value);
@@ -239,7 +238,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long setnx(final String key, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.setnx(key, value);
@@ -249,7 +248,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String setex(final String key, final int seconds, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.setex(key, seconds, value);
@@ -259,7 +258,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long decrBy(final String key, final long integer) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.decrBy(key, integer);
@@ -269,7 +268,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long decr(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.decr(key);
@@ -279,7 +278,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long incrBy(final String key, final long integer) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.incrBy(key, integer);
@@ -289,7 +288,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Double incrByFloat(final String key, final double value) {
-    return new JedisClusterCommand<Double>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
       @Override
       public Double execute(Jedis connection) {
         return connection.incrByFloat(key, value);
@@ -299,7 +298,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long incr(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.incr(key);
@@ -309,7 +308,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long append(final String key, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.append(key, value);
@@ -319,7 +318,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String substr(final String key, final int start, final int end) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.substr(key, start, end);
@@ -329,7 +328,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long hset(final String key, final String field, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hset(key, field, value);
@@ -339,7 +338,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String hget(final String key, final String field) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.hget(key, field);
@@ -349,7 +348,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long hsetnx(final String key, final String field, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hsetnx(key, field, value);
@@ -359,7 +358,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String hmset(final String key, final Map<String, String> hash) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.hmset(key, hash);
@@ -369,7 +368,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public List<String> hmget(final String key, final String... fields) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.hmget(key, fields);
@@ -379,7 +378,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long hincrBy(final String key, final String field, final long value) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hincrBy(key, field, value);
@@ -389,7 +388,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Boolean hexists(final String key, final String field) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.hexists(key, field);
@@ -399,7 +398,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long hdel(final String key, final String... field) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hdel(key, field);
@@ -409,7 +408,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long hlen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hlen(key);
@@ -419,7 +418,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<String> hkeys(final String key) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.hkeys(key);
@@ -429,7 +428,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public List<String> hvals(final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.hvals(key);
@@ -439,7 +438,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Map<String, String> hgetAll(final String key) {
-    return new JedisClusterCommand<Map<String, String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Map<String, String>>(connectionHandler, maxRedirections) {
       @Override
       public Map<String, String> execute(Jedis connection) {
         return connection.hgetAll(key);
@@ -449,7 +448,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long rpush(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.rpush(key, string);
@@ -459,7 +458,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long lpush(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lpush(key, string);
@@ -469,7 +468,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long llen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.llen(key);
@@ -479,7 +478,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public List<String> lrange(final String key, final long start, final long end) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.lrange(key, start, end);
@@ -489,7 +488,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String ltrim(final String key, final long start, final long end) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.ltrim(key, start, end);
@@ -499,7 +498,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String lindex(final String key, final long index) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.lindex(key, index);
@@ -509,7 +508,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String lset(final String key, final long index, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.lset(key, index, value);
@@ -519,7 +518,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long lrem(final String key, final long count, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lrem(key, count, value);
@@ -529,7 +528,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String lpop(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.lpop(key);
@@ -539,7 +538,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String rpop(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.rpop(key);
@@ -549,7 +548,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long sadd(final String key, final String... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sadd(key, member);
@@ -559,7 +558,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<String> smembers(final String key) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.smembers(key);
@@ -569,7 +568,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long srem(final String key, final String... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.srem(key, member);
@@ -579,7 +578,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String spop(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.spop(key);
@@ -589,7 +588,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long scard(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.scard(key);
@@ -599,7 +598,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Boolean sismember(final String key, final String member) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.sismember(key, member);
@@ -609,7 +608,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String srandmember(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.srandmember(key);
@@ -619,7 +618,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public List<String> srandmember(final String key, final int count) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.srandmember(key, count);
@@ -629,7 +628,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long strlen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.strlen(key);
@@ -639,7 +638,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long zadd(final String key, final double score, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zadd(key, score, member);
@@ -649,7 +648,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long zadd(final String key, final Map<String, Double> scoreMembers) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zadd(key, scoreMembers);
@@ -659,7 +658,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<String> zrange(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrange(key, start, end);
@@ -669,7 +668,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long zrem(final String key, final String... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zrem(key, member);
@@ -679,7 +678,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Double zincrby(final String key, final double score, final String member) {
-    return new JedisClusterCommand<Double>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
       @Override
       public Double execute(Jedis connection) {
         return connection.zincrby(key, score, member);
@@ -689,7 +688,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long zrank(final String key, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zrank(key, member);
@@ -699,7 +698,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long zrevrank(final String key, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zrevrank(key, member);
@@ -709,7 +708,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<String> zrevrange(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrange(key, start, end);
@@ -719,7 +718,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<Tuple> zrangeWithScores(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeWithScores(key, start, end);
@@ -729,7 +728,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<Tuple> zrevrangeWithScores(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeWithScores(key, start, end);
@@ -739,7 +738,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long zcard(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcard(key);
@@ -749,7 +748,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Double zscore(final String key, final String member) {
-    return new JedisClusterCommand<Double>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
       @Override
       public Double execute(Jedis connection) {
         return connection.zscore(key, member);
@@ -759,7 +758,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public List<String> sort(final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.sort(key);
@@ -769,7 +768,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public List<String> sort(final String key, final SortingParams sortingParameters) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.sort(key, sortingParameters);
@@ -779,7 +778,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long zcount(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcount(key, min, max);
@@ -789,7 +788,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long zcount(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcount(key, min, max);
@@ -799,7 +798,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<String> zrangeByScore(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max);
@@ -809,7 +808,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<String> zrangeByScore(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max);
@@ -819,7 +818,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final double max, final double min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min);
@@ -830,7 +829,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Override
   public Set<String> zrangeByScore(final String key, final double min, final double max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max, offset, count);
@@ -840,7 +839,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min);
@@ -851,7 +850,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Override
   public Set<String> zrangeByScore(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max, offset, count);
@@ -862,7 +861,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Override
   public Set<String> zrevrangeByScore(final String key, final double max, final double min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min, offset, count);
@@ -872,7 +871,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max);
@@ -882,7 +881,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final double max, final double min) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min);
@@ -893,7 +892,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final double min, final double max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max, offset, count);
@@ -904,7 +903,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Override
   public Set<String> zrevrangeByScore(final String key, final String max, final String min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min, offset, count);
@@ -914,7 +913,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max);
@@ -924,7 +923,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min);
@@ -935,7 +934,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max, offset, count);
@@ -946,7 +945,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final double max,
       final double min, final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min, offset, count);
@@ -957,7 +956,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final String max,
       final String min, final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min, offset, count);
@@ -967,7 +966,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long zremrangeByRank(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByRank(key, start, end);
@@ -977,7 +976,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long zremrangeByScore(final String key, final double start, final double end) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByScore(key, start, end);
@@ -987,7 +986,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long zremrangeByScore(final String key, final String start, final String end) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByScore(key, start, end);
@@ -997,7 +996,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long zlexcount(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zlexcount(key, min, max);
@@ -1007,7 +1006,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<String> zrangeByLex(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByLex(key, min, max);
@@ -1018,7 +1017,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Override
   public Set<String> zrangeByLex(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByLex(key, min, max, offset, count);
@@ -1028,7 +1027,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Set<String> zrevrangeByLex(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByLex(key, max, min);
@@ -1039,7 +1038,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Override
   public Set<String> zrevrangeByLex(final String key, final String max, final String min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByLex(key, max, min, offset, count);
@@ -1049,7 +1048,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long zremrangeByLex(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByLex(key, min, max);
@@ -1060,7 +1059,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Override
   public Long linsert(final String key, final LIST_POSITION where, final String pivot,
       final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.linsert(key, where, pivot, value);
@@ -1070,7 +1069,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long lpushx(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lpushx(key, string);
@@ -1080,7 +1079,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long rpushx(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.rpushx(key, string);
@@ -1094,7 +1093,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Override
   @Deprecated
   public List<String> blpop(final String arg) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.blpop(arg);
@@ -1108,7 +1107,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Override
   @Deprecated
   public List<String> brpop(final String arg) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.brpop(arg);
@@ -1118,7 +1117,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long del(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.del(key);
@@ -1128,7 +1127,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public String echo(final String string) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.echo(string);
@@ -1138,7 +1137,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long move(final String key, final int dbIndex) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.move(key, dbIndex);
@@ -1148,7 +1147,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long bitcount(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.bitcount(key);
@@ -1158,7 +1157,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long bitcount(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.bitcount(key, start, end);
@@ -1172,7 +1171,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String ping() {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.ping();
@@ -1186,7 +1185,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String quit() {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.quit();
@@ -1200,7 +1199,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String flushDB() {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.flushDB();
@@ -1214,7 +1213,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public Long dbSize() {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.dbSize();
@@ -1228,7 +1227,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String select(final int index) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.select(index);
@@ -1242,7 +1241,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String flushAll() {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.flushAll();
@@ -1256,7 +1255,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String auth(final String password) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.auth(password);
@@ -1270,7 +1269,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String save() {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.save();
@@ -1284,7 +1283,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String bgsave() {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.bgsave();
@@ -1298,7 +1297,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String bgrewriteaof() {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.bgrewriteaof();
@@ -1312,7 +1311,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public Long lastsave() {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lastsave();
@@ -1326,7 +1325,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String shutdown() {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.shutdown();
@@ -1340,7 +1339,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String info() {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.info();
@@ -1354,7 +1353,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String info(final String section) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.info(section);
@@ -1368,7 +1367,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String slaveof(final String host, final int port) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.slaveof(host, port);
@@ -1382,7 +1381,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String slaveofNoOne() {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.slaveofNoOne();
@@ -1396,7 +1395,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public int getDB() {
-    return new JedisClusterCommand<Integer>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Integer>(connectionHandler, maxRedirections) {
       @Override
       public Integer execute(Jedis connection) {
         return connection.getDB();
@@ -1410,7 +1409,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String debug(final DebugParams params) {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.debug(params);
@@ -1424,7 +1423,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   @Deprecated
   @Override
   public String configResetStat() {
-    return new JedisClusterCommand<String>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
       public String execute(Jedis connection) {
         return connection.configResetStat();
@@ -1448,7 +1447,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public ScanResult<Entry<String, String>> hscan(final String key, final String cursor) {
-    return new JedisClusterCommand<ScanResult<Entry<String, String>>>(connectionHandler, timeout,
+    return new JedisClusterCommand<ScanResult<Entry<String, String>>>(connectionHandler,
         maxRedirections) {
       @Override
       public ScanResult<Entry<String, String>> execute(Jedis connection) {
@@ -1459,7 +1458,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public ScanResult<String> sscan(final String key, final String cursor) {
-    return new JedisClusterCommand<ScanResult<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<ScanResult<String>>(connectionHandler, maxRedirections) {
       @Override
       public ScanResult<String> execute(Jedis connection) {
         return connection.sscan(key, cursor);
@@ -1469,7 +1468,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public ScanResult<Tuple> zscan(final String key, final String cursor) {
-    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxRedirections) {
       @Override
       public ScanResult<Tuple> execute(Jedis connection) {
         return connection.zscan(key, cursor);
@@ -1479,7 +1478,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public Long pfadd(final String key, final String... elements) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pfadd(key, elements);
@@ -1489,7 +1488,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public long pfcount(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pfcount(key);
@@ -1499,7 +1498,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public List<String> blpop(final int timeout, final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.blpop(timeout, key);
@@ -1509,7 +1508,7 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
 
   @Override
   public List<String> brpop(final int timeout, final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, timeout, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.brpop(timeout, key);

--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -11,14 +11,11 @@ import redis.clients.util.JedisClusterCRC16;
 public abstract class JedisClusterCommand<T> {
 
   private JedisClusterConnectionHandler connectionHandler;
-  private int commandTimeout;
   private int redirections;
   private ThreadLocal<Jedis> askConnection = new ThreadLocal<Jedis>();
 
-  public JedisClusterCommand(JedisClusterConnectionHandler connectionHandler, int timeout,
-      int maxRedirections) {
+  public JedisClusterCommand(JedisClusterConnectionHandler connectionHandler, int maxRedirections) {
     this.connectionHandler = connectionHandler;
-    this.commandTimeout = timeout;
     this.redirections = maxRedirections;
   }
 

--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -14,6 +14,8 @@ public abstract class JedisClusterConnectionHandler {
 
   abstract Jedis getConnection();
 
+  private int timeout;
+
   public void returnConnection(Jedis connection) {
     cache.getNode(getNodeKey(connection.getClient())).returnResource(connection);
   }
@@ -30,8 +32,8 @@ public abstract class JedisClusterConnectionHandler {
   }
 
   public JedisClusterConnectionHandler(Set<HostAndPort> nodes,
-      final GenericObjectPoolConfig poolConfig) {
-    this.cache = new JedisClusterInfoCache(poolConfig);
+      final GenericObjectPoolConfig poolConfig, int timeout) {
+    this.cache = new JedisClusterInfoCache(poolConfig, timeout);
     initializeSlotsCache(nodes, poolConfig);
   }
 

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -24,7 +24,10 @@ public class JedisClusterInfoCache {
   private final Lock w = rwl.writeLock();
   private final GenericObjectPoolConfig poolConfig;
 
-  public JedisClusterInfoCache(final GenericObjectPoolConfig poolConfig) {
+  private int timeout;
+
+  public JedisClusterInfoCache(final GenericObjectPoolConfig poolConfig, int timeout) {
+    this.timeout = timeout;
     this.poolConfig = poolConfig;
   }
 
@@ -94,7 +97,7 @@ public class JedisClusterInfoCache {
       String nodeKey = getNodeKey(node);
       if (nodes.containsKey(nodeKey)) return;
 
-      JedisPool nodePool = new JedisPool(poolConfig, node.getHost(), node.getPort());
+      JedisPool nodePool = new JedisPool(poolConfig, node.getHost(), node.getPort(), timeout);
       nodes.put(nodeKey, nodePool);
     } finally {
       w.unlock();

--- a/src/main/java/redis/clients/jedis/JedisPoolAbstract.java
+++ b/src/main/java/redis/clients/jedis/JedisPoolAbstract.java
@@ -6,24 +6,22 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import redis.clients.util.Pool;
 
 public class JedisPoolAbstract extends Pool<Jedis> {
-	
 
-	public JedisPoolAbstract() {
-		super();
-	}
+  public JedisPoolAbstract() {
+    super();
+  }
 
-	public JedisPoolAbstract(GenericObjectPoolConfig poolConfig,
-			PooledObjectFactory<Jedis> factory) {
-		super(poolConfig, factory);
-	}
+  public JedisPoolAbstract(GenericObjectPoolConfig poolConfig, PooledObjectFactory<Jedis> factory) {
+    super(poolConfig, factory);
+  }
 
-	@Override
-	protected void returnBrokenResource(Jedis resource) {
-		super.returnBrokenResource(resource);
-	}
-	
-	@Override
-	protected void returnResource(Jedis resource) {
-		super.returnResource(resource);
-	}
+  @Override
+  protected void returnBrokenResource(Jedis resource) {
+    super.returnBrokenResource(resource);
+  }
+
+  @Override
+  protected void returnResource(Jedis resource) {
+    super.returnResource(resource);
+  }
 }

--- a/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
@@ -12,8 +12,8 @@ import redis.clients.jedis.exceptions.JedisConnectionException;
 public class JedisSlotBasedConnectionHandler extends JedisClusterConnectionHandler {
 
   public JedisSlotBasedConnectionHandler(Set<HostAndPort> nodes,
-      final GenericObjectPoolConfig poolConfig) {
-    super(nodes, poolConfig);
+      final GenericObjectPoolConfig poolConfig, int timeout) {
+    super(nodes, poolConfig, timeout);
   }
 
   public Jedis getConnection() {

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -454,6 +454,22 @@ public class JedisClusterTest extends Assert {
   }
 
   @Test
+  public void testJedisClusterTimeout() {
+    Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
+    jedisClusterNode.add(new HostAndPort(nodeInfo1.getHost(), nodeInfo1.getPort()));
+
+    JedisCluster jc = new JedisCluster(jedisClusterNode, 4000);
+
+    for (JedisPool pool : jc.getClusterNodes().values()) {
+      Jedis jedis = pool.getResource();
+      assertEquals(jedis.getClient().getConnectionTimeout(), 4000);
+      assertEquals(jedis.getClient().getSoTimeout(), 4000);
+      jedis.close();
+    }
+
+  }
+
+  @Test
   public void testJedisClusterRunsWithMultithreaded() throws InterruptedException,
       ExecutionException {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
@@ -110,7 +110,7 @@ public class JedisSentinelPoolTest extends JedisTestBase {
         jedis2 = null;
       }
     } finally {
-    	jedis2.close();
+      jedis2.close();
 
       pool.destroy();
     }

--- a/src/test/java/redis/clients/jedis/tests/JedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisTest.java
@@ -143,12 +143,11 @@ public class JedisTest extends JedisCommandTestBase {
     bj.connect();
     bj.close();
   }
-  
+
   @Test
   public void checkDisconnectOnQuit() {
     jedis.quit();
     assertFalse(jedis.getClient().isConnected());
   }
-  
-  
+
 }


### PR DESCRIPTION
Removes unused JedisCluster timeout parameter and now it's passed
all the way up to the creation of the JedisPool.

@xetorthio, @HeartSaVioR  can you plz review?