### PR TITLE
Continue renewSlotCache if exception is encountered

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -72,6 +72,8 @@ public abstract class JedisClusterConnectionHandler {
         jedis = jp.getResource();
         cache.discoverClusterSlots(jedis);
         break;
+      } catch (JedisConnectionException e) {
+        // try next nodes
       } finally {
         if (jedis != null) {
           jedis.close();


### PR DESCRIPTION
If it encounters a JedisMovedDataException, JedisClusterCommand.runWithRetries will trigger renewSlotCache. However, renewSlotCache's behavior isn't currently like initializeSlotsCache and will fail out if it happens to connect to a node that is inaccessible. 

I encountered this problem while testing out cluster node failures under load.