### PR TITLE
Release all resources from disconnect regardless of IOException

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -169,6 +169,12 @@ public class Connection implements Closeable {
       } catch (IOException ex) {
         broken = true;
         throw new JedisConnectionException(ex);
+      } finally {
+        closeIOResourceQuietly(inputStream);
+        if (!socket.isClosed()) {
+          closeIOResourceQuietly(outputStream);
+          closeIOResourceQuietly(socket);
+        }
       }
     }
   }
@@ -271,5 +277,16 @@ public class Connection implements Closeable {
       }
     }
     return responses;
+  }
+
+  private void closeIOResourceQuietly(Closeable resource) {
+    // It's same thing as Apache Commons - IOUtils.closeQuietly()
+    if (resource != null) {
+      try {
+        resource.close();
+      } catch (IOException e) {
+        // pass
+      }
+    }
   }
 }

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -162,18 +162,18 @@ public class Connection implements Closeable {
   public void disconnect() {
     if (isConnected()) {
       try {
-        inputStream.close();
+        outputStream.close();
         if (!socket.isClosed()) {
-          outputStream.close();
+          inputStream.close();
           socket.close();
         }
       } catch (IOException ex) {
         broken = true;
         throw new JedisConnectionException(ex);
       } finally {
-        IOUtils.closeQuietly(inputStream);
+        IOUtils.closeQuietly(outputStream);
         if (!socket.isClosed()) {
-          IOUtils.closeQuietly(outputStream);
+          IOUtils.closeQuietly(inputStream);
           IOUtils.closeQuietly(socket);
         }
       }

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -11,6 +11,7 @@ import java.util.List;
 import redis.clients.jedis.Protocol.Command;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.util.IOUtils;
 import redis.clients.util.RedisInputStream;
 import redis.clients.util.RedisOutputStream;
 import redis.clients.util.SafeEncoder;
@@ -170,10 +171,10 @@ public class Connection implements Closeable {
         broken = true;
         throw new JedisConnectionException(ex);
       } finally {
-        closeIOResourceQuietly(inputStream);
+        IOUtils.closeQuietly(inputStream);
         if (!socket.isClosed()) {
-          closeIOResourceQuietly(outputStream);
-          closeIOResourceQuietly(socket);
+          IOUtils.closeQuietly(outputStream);
+          IOUtils.closeQuietly(socket);
         }
       }
     }
@@ -277,16 +278,5 @@ public class Connection implements Closeable {
       }
     }
     return responses;
-  }
-
-  private void closeIOResourceQuietly(Closeable resource) {
-    // It's same thing as Apache Commons - IOUtils.closeQuietly()
-    if (resource != null) {
-      try {
-        resource.close();
-      } catch (IOException e) {
-        // pass
-      }
-    }
   }
 }

--- a/src/main/java/redis/clients/util/IOUtils.java
+++ b/src/main/java/redis/clients/util/IOUtils.java
@@ -1,0 +1,32 @@
+package redis.clients.util;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.Socket;
+
+public class IOUtils {
+  private IOUtils() {}
+
+  public static void closeQuietly(Closeable resource) {
+    // It's same thing as Apache Commons - IOUtils.closeQuietly()
+    if (resource != null) {
+      try {
+        resource.close();
+      } catch (IOException e) {
+        // pass
+      }
+    }
+  }
+
+  public static void closeQuietly(Socket resource) {
+    // It's same thing as Apache Commons - IOUtils.closeQuietly()
+    if (resource != null) {
+      try {
+        resource.close();
+      } catch (IOException e) {
+        // pass
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Sorry I'm too late on applying #847. (Thanks @allanwax!)

When IOException occurs on disconnect, it forces to close others with finally statement.
IMO it would be safe to use first IOException on disconnect to report JedisConnectionException.
I'm not 100% sure it's the best way, so any opinions are greatly appreciated.

Please review and comment. Thanks!