### PR TITLE
fix version of Maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
       </plugin>
 			<plugin>
 			  <artifactId>maven-jar-plugin</artifactId>
+			  <version>2.6</version>
 			  <configuration>
 			    <archive>  
 			      <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>


### PR DESCRIPTION
Thanks for your releasing a good product. Recently I started to learn Redis and found jedis, so I'm trying to use jedis with joy.

I found a warning when I execute `mvn` command. [Latest Travis-CI build](https://travis-ci.org/xetorthio/jedis/jobs/58138294#L462) also has same one:

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for redis.clients:jedis:jar:3.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 136, column 12
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

We can remove this warning by fixing version of `maven-jar-plugin`. This MR will fix it and remove that warning from Maven.