### PR TITLE
Configure connection timeout in JedisPool and JedisSentinelPool

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -32,11 +32,12 @@ public class JedisPool extends JedisPoolAbstract {
       String password = JedisURIHelper.getPassword(uri);
       int database = JedisURIHelper.getDBIndex(uri);
       this.internalPool = new GenericObjectPool<Jedis>(new JedisFactory(h, port,
-          Protocol.DEFAULT_TIMEOUT, password, database, null), new GenericObjectPoolConfig());
+          Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, password, database, null),
+          new GenericObjectPoolConfig());
     } else {
       this.internalPool = new GenericObjectPool<Jedis>(new JedisFactory(host,
-          Protocol.DEFAULT_PORT, Protocol.DEFAULT_TIMEOUT, null, Protocol.DEFAULT_DATABASE, null),
-          new GenericObjectPoolConfig());
+          Protocol.DEFAULT_PORT, Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, null,
+          Protocol.DEFAULT_DATABASE, null), new GenericObjectPoolConfig());
     }
   }
 
@@ -69,7 +70,14 @@ public class JedisPool extends JedisPoolAbstract {
 
   public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
       int timeout, final String password, final int database, final String clientName) {
-    super(poolConfig, new JedisFactory(host, port, timeout, password, database, clientName));
+    this(poolConfig, host, port, timeout, timeout, password, database, clientName);
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
+      final int connectionTimeout, final int soTimeout, final String password, final int database,
+      final String clientName) {
+    super(poolConfig, new JedisFactory(host, port, connectionTimeout, soTimeout, password,
+        database, clientName));
   }
 
   public JedisPool(final GenericObjectPoolConfig poolConfig, final URI uri) {
@@ -77,7 +85,12 @@ public class JedisPool extends JedisPoolAbstract {
   }
 
   public JedisPool(final GenericObjectPoolConfig poolConfig, final URI uri, final int timeout) {
-    super(poolConfig, new JedisFactory(uri, timeout, null));
+    this(poolConfig, uri, timeout, timeout);
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final URI uri,
+      final int connectionTimeout, final int soTimeout) {
+    super(poolConfig, new JedisFactory(uri, connectionTimeout, soTimeout, null));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -17,7 +17,8 @@ public class JedisSentinelPool extends JedisPoolAbstract {
 
   protected GenericObjectPoolConfig poolConfig;
 
-  protected int timeout = Protocol.DEFAULT_TIMEOUT;
+  protected int connectionTimeout = Protocol.DEFAULT_TIMEOUT;
+  protected int soTimeout = Protocol.DEFAULT_TIMEOUT;
 
   protected String password;
 
@@ -26,7 +27,7 @@ public class JedisSentinelPool extends JedisPoolAbstract {
   protected Set<MasterListener> masterListeners = new HashSet<MasterListener>();
 
   protected Logger log = Logger.getLogger(getClass().getName());
-  
+
   private volatile JedisFactory factory;
   private volatile HostAndPort currentHostMaster;
 
@@ -63,9 +64,15 @@ public class JedisSentinelPool extends JedisPoolAbstract {
   public JedisSentinelPool(String masterName, Set<String> sentinels,
       final GenericObjectPoolConfig poolConfig, int timeout, final String password,
       final int database) {
+    this(masterName, sentinels, poolConfig, timeout, timeout, password, database);
+  }
 
+  public JedisSentinelPool(String masterName, Set<String> sentinels,
+      final GenericObjectPoolConfig poolConfig, final int connectionTimeout, final int soTimeout,
+      final String password, final int database) {
     this.poolConfig = poolConfig;
-    this.timeout = timeout;
+    this.connectionTimeout = connectionTimeout;
+    this.soTimeout = soTimeout;
     this.password = password;
     this.database = database;
 
@@ -89,7 +96,8 @@ public class JedisSentinelPool extends JedisPoolAbstract {
     if (!master.equals(currentHostMaster)) {
       currentHostMaster = master;
       if (factory == null) {
-        factory = new JedisFactory(master.getHost(), master.getPort(), timeout, password, database);
+        factory = new JedisFactory(master.getHost(), master.getPort(), connectionTimeout,
+            soTimeout, password, database, null);
         initPool(poolConfig, factory);
       } else {
         factory.setHostAndPort(currentHostMaster);
@@ -287,7 +295,7 @@ public class JedisSentinelPool extends JedisPoolAbstract {
         // This isn't good, the Jedis object is not thread safe
         j.disconnect();
       } catch (Exception e) {
-        log.log(Level.SEVERE,"Caught exception while shutting down: ",e);
+        log.log(Level.SEVERE, "Caught exception while shutting down: ", e);
       }
     }
   }


### PR DESCRIPTION
I have separated timeout (`timeout` variable) to connection timeout (`connectionTimeout` variable) and read timeout (`soTimeout` variable) because in some cases need to specify short connection timeout and long read timeout.