### PR TITLE
Simplifies disconnect() since the only thing we should close is socket

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -162,20 +162,13 @@ public class Connection implements Closeable {
   public void disconnect() {
     if (isConnected()) {
       try {
-        outputStream.close();
-        if (!socket.isClosed()) {
-          inputStream.close();
-          socket.close();
-        }
+        outputStream.flush();
+        socket.close();
       } catch (IOException ex) {
         broken = true;
         throw new JedisConnectionException(ex);
       } finally {
-        IOUtils.closeQuietly(outputStream);
-        if (!socket.isClosed()) {
-          IOUtils.closeQuietly(inputStream);
-          IOUtils.closeQuietly(socket);
-        }
+        IOUtils.closeQuietly(socket);
       }
     }
   }

--- a/src/main/java/redis/clients/util/IOUtils.java
+++ b/src/main/java/redis/clients/util/IOUtils.java
@@ -1,32 +1,19 @@
 package redis.clients.util;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.Socket;
 
 public class IOUtils {
   private IOUtils() {}
 
-  public static void closeQuietly(Closeable resource) {
+  public static void closeQuietly(Socket sock) {
     // It's same thing as Apache Commons - IOUtils.closeQuietly()
-    if (resource != null) {
+    if (sock != null) {
       try {
-        resource.close();
+        sock.close();
       } catch (IOException e) {
-        // pass
+        // ignored
       }
     }
   }
-
-  public static void closeQuietly(Socket resource) {
-    // It's same thing as Apache Commons - IOUtils.closeQuietly()
-    if (resource != null) {
-      try {
-        resource.close();
-      } catch (IOException e) {
-        // pass
-      }
-    }
-  }
-
 }


### PR DESCRIPTION
Related to #946

outputStream.close() can throw IOException and we're happy to propagate it to users, we still need try-catch-finally statement.