### PR TITLE
Deprecate Pool.returnResourceObject()

### DIFF
--- a/src/main/java/redis/clients/util/Pool.java
+++ b/src/main/java/redis/clients/util/Pool.java
@@ -51,6 +51,11 @@ public abstract class Pool<T> implements Closeable {
     }
   }
 
+  /**
+   * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
+   *             using @see {@link redis.clients.jedis.Jedis#close()}
+   */
+  @Deprecated
   public void returnResourceObject(final T resource) {
     if (resource == null) {
       return;


### PR DESCRIPTION
We missed this from #912 and #913.
I'll make another PR to change visibility to protected.