### PR TITLE
Change visibility of Pool.returnResourceObject() to protected

### DIFF
--- a/src/main/java/redis/clients/util/Pool.java
+++ b/src/main/java/redis/clients/util/Pool.java
@@ -51,7 +51,7 @@ public abstract class Pool<T> implements Closeable {
     }
   }
 
-  public void returnResourceObject(final T resource) {
+  protected void returnResourceObject(final T resource) {
     if (resource == null) {
       return;
     }


### PR DESCRIPTION
It's just OK to hide since it was already intended to internal use.