### PR TITLE
Attempt to read RESP Errors message

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -104,8 +104,6 @@ public class Connection implements Closeable {
        * before close connection. We try to read it to provide reason of failure.
        */
       try {
-        // Set soTimeout 100ms to avoid long blocking
-        socket.setSoTimeout(100);
         String errorMessage = Protocol.readErrorLineIfPossible(inputStream);
         if (errorMessage != null && errorMessage.length() > 0) {
           ex = new JedisConnectionException(errorMessage, ex.getCause());

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -99,15 +99,23 @@ public class Connection implements Closeable {
       Protocol.sendCommand(outputStream, cmd, args);
       return this;
     } catch (JedisConnectionException ex) {
+      /*
+       * When client send request which formed by invalid protocol, Redis send back error message
+       * before close connection. We try to read it to provide reason of failure.
+       */
       try {
-        // Try to read single line for error message from Redis
-        String errorMessage = Protocol.readLine(inputStream);
+        // Set soTimeout 100ms to avoid long blocking
+        socket.setSoTimeout(100);
+        String errorMessage = Protocol.readErrorLineIfPossible(inputStream);
         if (errorMessage != null && errorMessage.length() > 0) {
-          // if possible replace exception
           ex = new JedisConnectionException(errorMessage, ex.getCause());
         }
       } catch (Exception e) {
-        // Ignore
+        /*
+         * Catch any IOException or JedisConnectionException occurred from InputStream#read and just
+         * ignore. This approach is safe because reading error message is optional and connection
+         * will eventually be closed.
+         */
       }
       // Any other exceptions related to connection?
       broken = true;

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -117,6 +117,15 @@ public final class Protocol {
     throw new JedisDataException(message);
   }
 
+  public static String readErrorLineIfPossible(RedisInputStream is) {
+    final byte b = is.readByte();
+    // if buffer contains other type of response, just ignore.
+    if (b != MINUS_BYTE) {
+      return null;
+    }
+    return is.readLine();
+  }
+
   private static String[] parseTargetHostAndSlot(String clusterRedirectResponse) {
     String[] response = new String[3];
     String[] messageInfo = clusterRedirectResponse.split(" ");
@@ -194,10 +203,6 @@ public final class Protocol {
 
   public static Object read(final RedisInputStream is) {
     return process(is);
-  }
-
-  public static String readLine(RedisInputStream inputStream) {
-    return inputStream.readLine();
   }
 
   public static final byte[] toByteArray(final boolean value) {

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -196,6 +196,10 @@ public final class Protocol {
     return process(is);
   }
 
+  public static String readLine(RedisInputStream inputStream) {
+    return inputStream.readLine();
+  }
+
   public static final byte[] toByteArray(final boolean value) {
     return value ? BYTES_TRUE : BYTES_FALSE;
   }

--- a/src/test/java/redis/clients/jedis/tests/ConnectionTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ConnectionTest.java
@@ -53,11 +53,6 @@ public class ConnectionTest extends Assert {
 
   @Test
   public void getErrorAfterConnectionReset() throws Exception {
-    brokenReason(new byte[1024 * 1024 + 1][0], "ERR Protocol error: invalid multibulk length");
-    brokenReason(new byte[1][512 * 1024 * 1024 + 1], "ERR Protocol error: invalid bulk length");
-  }
-
-  private void brokenReason(byte[][] params, String expectedMessage) throws Exception {
     class TestConnection extends Connection {
       public TestConnection() {
         super("localhost", 6379);
@@ -72,10 +67,10 @@ public class ConnectionTest extends Assert {
     TestConnection conn = new TestConnection();
 
     try {
-      conn.sendCommand(Command.HMSET, params);
+      conn.sendCommand(Command.HMSET, new byte[1024 * 1024 + 1][0]);
       fail("Should throw exception");
     } catch (JedisConnectionException jce) {
-      assertEquals(expectedMessage, jce.getMessage());
+      assertEquals("ERR Protocol error: invalid multibulk length", jce.getMessage());
     }
   }
 }


### PR DESCRIPTION
Following #981.

Attempt to read RESP Errors message from input stream when IOException occurs during `sendCommand`.
I need some reviews about introducing `Protocol.readLine(inputStream)` method.
I made it at `Protocol` class for consistency of read/write operation but there is a chance of unintended usage of it. Another option is directly using like `inputStream.readLine()` at `Connection.sendCommand` method.

Exception message in stack trace
* AS-IS
```
redis.clients.jedis.exceptions.JedisConnectionException: java.net.SocketException: Broken pipe
	at redis.clients.jedis.Connection.sendCommand(Connection.java:107)
Caused by: java.net.SocketException: Broken pipe
	at java.net.SocketOutputStream.socketWrite0(Native Method)

```

* TO-BE
```
redis.clients.jedis.exceptions.JedisConnectionException: -ERR Protocol error: invalid multibulk length
	at redis.clients.jedis.Connection.sendCommand(Connection.java:107)
Caused by: java.net.SocketException: Broken pipe
	at java.net.SocketOutputStream.socketWrite0(Native Method)
```