### PR TITLE
Fix race condition in RedisClusterCommand

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -123,9 +123,17 @@ public abstract class JedisClusterCommand<T> {
         throw jce;
       }
 
+      // release current connection before recursion
+      releaseConnection(connection);
+      connection = null;
+
       // retry with random connection
       return runWithRetries(key, redirections - 1, true, asking);
     } catch (JedisRedirectionException jre) {
+      // release current connection before recursion or renewing
+      releaseConnection(connection);
+      connection = null;
+
       if (jre instanceof JedisAskDataException) {
         asking = true;
         askConnection.set(this.connectionHandler.getConnectionFromNode(jre.getTargetNode()));
@@ -146,7 +154,6 @@ public abstract class JedisClusterCommand<T> {
   private void releaseConnection(Jedis connection) {
     if (connection != null) {
       connection.close();
-      connection = null;
     }
   }
 


### PR DESCRIPTION
This is fix for below problem that happened in my environment.

1-a. borrow `connection A` from `pool A`.
1-b. execute on `connection A` throws JedisConnectionException.
1-c. make recursive call with tryRandomNode.
2-a. borrow `connection B` from `pool B`.
2-b. execute on `connection B` throws JedisRedirectionException because `pool B` is not slot owner.
2-c. make recursive call for `MOVED` handling.
3-a. try to borrow `connection C` from `pool A`.  But we still holds `connection A`. It's never returned to pool before `connection C` is borrowed. for instance pool's maxTotal is 1, `connection C` couldn't borrow.

If release a connection before make recursive call, this problem is gone.