### PR TITLE
modified for Redis single node support.

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -100,13 +100,13 @@ public class JedisPool extends JedisPoolAbstract {
     return jedis;
   }
 
-  protected void returnBrokenResource(final Jedis resource) {
+  public void returnBrokenResource(final Jedis resource) {
     if (resource != null) {
       returnBrokenResourceObject(resource);
     }
   }
 
-  protected void returnResource(final Jedis resource) {
+  public void returnResource(final Jedis resource) {
     if (resource != null) {
       try {
         resource.resetState();


### PR DESCRIPTION
The issue is, Using protected access specifier we can't return the jedis resources from our custom redis cache util class in single node jedis pool creation. So, I have changes this from protected to public for both cluster and single node jedis pool creation supportability.