### PR TITLE
Add `addObject` method to pre-populate a JedisPool with idle objects

### DIFF
--- a/src/main/java/redis/clients/util/Pool.java
+++ b/src/main/java/redis/clients/util/Pool.java
@@ -117,4 +117,14 @@ public abstract class Pool<T> implements Closeable {
 
     return this.internalPool.getNumWaiters();
   }
+
+  public void addObjects(int count) {
+    try {
+      for (int i = 0; i < count ; i++) {
+        this.internalPool.addObject();
+      }
+    } catch (Exception e) {
+      throw new JedisException("Error trying to add idle objects", e);
+    }
+  }
 }

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
@@ -18,6 +18,7 @@ import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.Transaction;
 import redis.clients.jedis.exceptions.InvalidURIException;
 import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisException;
 
 public class JedisPoolTest extends Assert {
   private static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
@@ -345,4 +346,14 @@ public class JedisPoolTest extends Assert {
 
     pool.destroy();
   }
+
+  @Test
+  public void testAddObject() {
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
+    pool.addObjects(1);
+    assertEquals(pool.getNumIdle(), 1);
+    pool.destroy();
+
+  }
+
 }


### PR DESCRIPTION
This PR arose because a discussion here: https://groups.google.com/forum/#!topic/jedis_redis/tgpZ-ze8_Cw