### PR TITLE
Pool.close() should call destory() to shutdown derived classes properly

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -291,6 +291,8 @@ public class JedisSentinelPool extends JedisPoolAbstract {
           } else {
             log.fine("Unsubscribing from Sentinel at " + host + ":" + port);
           }
+        } finally {
+          j.close();
         }
       }
     }
@@ -301,7 +303,7 @@ public class JedisSentinelPool extends JedisPoolAbstract {
         running.set(false);
         // This isn't good, the Jedis object is not thread safe
         if (j != null) {
-          j.getClient().getSocket().close();
+          j.disconnect();
         }
       } catch (Exception e) {
         log.log(Level.SEVERE, "Caught exception while shutting down: ", e);

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -301,7 +301,7 @@ public class JedisSentinelPool extends JedisPoolAbstract {
         running.set(false);
         // This isn't good, the Jedis object is not thread safe
         if (j != null) {
-          j.disconnect();
+          j.getClient().getSocket().close();
         }
       } catch (Exception e) {
         log.log(Level.SEVERE, "Caught exception while shutting down: ", e);

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -228,6 +228,7 @@ public class JedisSentinelPool extends JedisPoolAbstract {
     }
 
     public MasterListener(String masterName, String host, int port) {
+      super(String.format("MasterListener-%s-[%s:%d]", masterName, host, port));
       this.masterName = masterName;
       this.host = host;
       this.port = port;

--- a/src/main/java/redis/clients/util/Pool.java
+++ b/src/main/java/redis/clients/util/Pool.java
@@ -20,7 +20,7 @@ public abstract class Pool<T> implements Closeable {
 
   @Override
   public void close() {
-    closeInternalPool();
+    destroy();
   }
 
   public boolean isClosed() {

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
@@ -82,12 +82,14 @@ public class JedisSentinelPoolTest extends JedisTestBase {
         // Not cleaner, but easy way
         if (t.getName().startsWith("MasterListener")) {
           masterListenerAlive = true;
-        }
-
-        if (!masterListenerAlive) {
           break;
         }
       }
+
+      if (!masterListenerAlive) {
+        break;
+      }
+
     }
 
     assertFalse("MasterListener thread is still alive!", masterListenerAlive);

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
@@ -71,8 +71,8 @@ public class JedisSentinelPoolTest extends JedisTestBase {
 
     // sleep enough time to let shutdown work!
     boolean masterListenerAlive = true;
-    // sleep maximum 2 sec
-    for (int i = 0 ; i < 10 ; i++) {
+    // sleep maximum 10 sec
+    for (int i = 0 ; i < 50 ; i++) {
       masterListenerAlive = false;
 
       Thread.sleep(200);

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
@@ -62,11 +62,15 @@ public class JedisSentinelPoolTest extends JedisTestBase {
     jedis.set("foo", "bar");
     assertEquals("bar", jedis.get("foo"));
     jedis.close();
+
+    // sleep enough time to let MasterListener initialized!
+    Thread.sleep(100);
+
     pool.close();
     assertTrue(pool.isClosed());
 
     // sleep enough time to let shutdown work!
-    Thread.sleep(1 * 1000);
+    Thread.sleep(500);
 
     Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
     for (Thread t : threadSet) {

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
@@ -1,12 +1,8 @@
 package redis.clients.jedis.tests;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.junit.Before;
 import org.junit.Test;
-
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisSentinelPool;
@@ -14,6 +10,9 @@ import redis.clients.jedis.Transaction;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.tests.utils.JedisSentinelTestUtil;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class JedisSentinelPoolTest extends JedisTestBase {
   private static final String MASTER_NAME = "mymaster";
@@ -65,6 +64,9 @@ public class JedisSentinelPoolTest extends JedisTestBase {
     jedis.close();
     pool.close();
     assertTrue(pool.isClosed());
+
+    // sleep enough time to let shutdown work!
+    Thread.sleep(1 * 1000);
 
     Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
     for (Thread t : threadSet) {

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
@@ -70,13 +70,28 @@ public class JedisSentinelPoolTest extends JedisTestBase {
     assertTrue(pool.isClosed());
 
     // sleep enough time to let shutdown work!
-    Thread.sleep(500);
+    boolean masterListenerAlive = true;
+    // sleep maximum 2 sec
+    for (int i = 0 ; i < 10 ; i++) {
+      masterListenerAlive = false;
 
-    Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
-    for (Thread t : threadSet) {
-      // Not cleaner, but easy way
-      assertFalse("MasterListener thread is still alive!", t.getName().startsWith("MasterListener"));
+      Thread.sleep(200);
+
+      Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
+      for (Thread t : threadSet) {
+        // Not cleaner, but easy way
+        if (t.getName().startsWith("MasterListener")) {
+          masterListenerAlive = true;
+        }
+
+        if (!masterListenerAlive) {
+          break;
+        }
+      }
     }
+
+    assertFalse("MasterListener thread is still alive!", masterListenerAlive);
+
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelPoolTest.java
@@ -71,8 +71,8 @@ public class JedisSentinelPoolTest extends JedisTestBase {
 
     // sleep enough time to let shutdown work!
     boolean masterListenerAlive = true;
-    // sleep maximum 10 sec
-    for (int i = 0 ; i < 50 ; i++) {
+    // sleep maximum 20 sec
+    for (int i = 0 ; i < 100 ; i++) {
       masterListenerAlive = false;
 
       Thread.sleep(200);


### PR DESCRIPTION
Closes #1017 

Before then, MasterListener threads aren't terminated although JedisSentinelPool.close() is called.

You can confirm that modified JedisSentinelPoolTest.checkCloseableConnections() fails on current master and succeeds on PR.

Please review and comment. Thanks!