### PR TITLE
Pool.close() should call destory() to shutdown derived classes properly

### DIFF
--- a/src/main/java/redis/clients/util/Pool.java
+++ b/src/main/java/redis/clients/util/Pool.java
@@ -20,7 +20,7 @@ public abstract class Pool<T> implements Closeable {
 
   @Override
   public void close() {
-    closeInternalPool();
+    destroy();
   }
 
   public boolean isClosed() {


### PR DESCRIPTION
Closes #1017

Before then, MasterListener threads aren't terminated although JedisSentinelPool.close() is called.
I was submitted PR #1018 but it also introduced random test failures, so I discard tests and re-submit.

In addition, I changed MasterListener thread to daemon to avoid MasterListener thread preventing  process to be not terminated. I also fix socket leak from MasterListener.

Please review and comment again. Thanks!