### PR TITLE
Set Jedis timeout longer while PipeliningTest

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
@@ -27,7 +27,7 @@ public class PipeliningTest extends Assert {
 
   @Before
   public void setUp() throws Exception {
-    jedis = new Jedis(hnp.getHost(), hnp.getPort(), 500);
+    jedis = new Jedis(hnp.getHost(), hnp.getPort(), 2000);
     jedis.connect();
     jedis.auth("foobared");
     jedis.flushAll();


### PR DESCRIPTION
It was too short (0.5 sec), and it periodically triggers build failure on Travis CI, JDK8.