### PR TITLE
Fixes binary compatibility between 2.6.3 and 2.7.x

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -83,7 +83,7 @@ public class Connection implements Closeable {
     }
   }
 
-  protected Connection sendCommand(final ProtocolCommand cmd, final String... args) {
+  protected Connection sendCommand(final Command cmd, final String... args) {
     final byte[][] bargs = new byte[args.length][];
     for (int i = 0; i < args.length; i++) {
       bargs[i] = SafeEncoder.encode(args[i]);
@@ -91,11 +91,11 @@ public class Connection implements Closeable {
     return sendCommand(cmd, bargs);
   }
 
-  protected Connection sendCommand(final ProtocolCommand cmd) {
+  protected Connection sendCommand(final Command cmd) {
     return sendCommand(cmd, EMPTY_ARGS);
   }
 
-  protected Connection sendCommand(final ProtocolCommand cmd, final byte[]... args) {
+  protected Connection sendCommand(final Command cmd, final byte[]... args) {
     try {
       connect();
       Protocol.sendCommand(outputStream, cmd, args);

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -73,9 +73,9 @@ public final class Protocol {
     // this prevent the class from instantiation
   }
 
-  public static void sendCommand(final RedisOutputStream os, final ProtocolCommand command,
+  public static void sendCommand(final RedisOutputStream os, final Command command,
       final byte[]... args) {
-    sendCommand(os, command.getRaw(), args);
+    sendCommand(os, command.raw, args);
   }
 
   private static void sendCommand(final RedisOutputStream os, final byte[] command,
@@ -221,10 +221,10 @@ public final class Protocol {
     return SafeEncoder.encode(String.valueOf(value));
   }
 
-  public static enum Command implements ProtocolCommand {
+  public static enum Command {
     PING, SET, GET, QUIT, EXISTS, DEL, TYPE, FLUSHDB, KEYS, RANDOMKEY, RENAME, RENAMENX, RENAMEX, DBSIZE, EXPIRE, EXPIREAT, TTL, SELECT, MOVE, FLUSHALL, GETSET, MGET, SETNX, SETEX, MSET, MSETNX, DECRBY, DECR, INCRBY, INCR, APPEND, SUBSTR, HSET, HGET, HSETNX, HMSET, HMGET, HINCRBY, HEXISTS, HDEL, HLEN, HKEYS, HVALS, HGETALL, RPUSH, LPUSH, LLEN, LRANGE, LTRIM, LINDEX, LSET, LREM, LPOP, RPOP, RPOPLPUSH, SADD, SMEMBERS, SREM, SPOP, SMOVE, SCARD, SISMEMBER, SINTER, SINTERSTORE, SUNION, SUNIONSTORE, SDIFF, SDIFFSTORE, SRANDMEMBER, ZADD, ZRANGE, ZREM, ZINCRBY, ZRANK, ZREVRANK, ZREVRANGE, ZCARD, ZSCORE, MULTI, DISCARD, EXEC, WATCH, UNWATCH, SORT, BLPOP, BRPOP, AUTH, SUBSCRIBE, PUBLISH, UNSUBSCRIBE, PSUBSCRIBE, PUNSUBSCRIBE, PUBSUB, ZCOUNT, ZRANGEBYSCORE, ZREVRANGEBYSCORE, ZREMRANGEBYRANK, ZREMRANGEBYSCORE, ZUNIONSTORE, ZINTERSTORE, ZLEXCOUNT, ZRANGEBYLEX, ZREVRANGEBYLEX, ZREMRANGEBYLEX, SAVE, BGSAVE, BGREWRITEAOF, LASTSAVE, SHUTDOWN, INFO, MONITOR, SLAVEOF, CONFIG, STRLEN, SYNC, LPUSHX, PERSIST, RPUSHX, ECHO, LINSERT, DEBUG, BRPOPLPUSH, SETBIT, GETBIT, BITPOS, SETRANGE, GETRANGE, EVAL, EVALSHA, SCRIPT, SLOWLOG, OBJECT, BITCOUNT, BITOP, SENTINEL, DUMP, RESTORE, PEXPIRE, PEXPIREAT, PTTL, INCRBYFLOAT, PSETEX, CLIENT, TIME, MIGRATE, HINCRBYFLOAT, SCAN, HSCAN, SSCAN, ZSCAN, WAIT, CLUSTER, ASKING, PFADD, PFCOUNT, PFMERGE;
 
-    private final byte[] raw;
+    public final byte[] raw;
 
     Command() {
       raw = SafeEncoder.encode(this.name());

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -230,10 +230,6 @@ public final class Protocol {
       raw = SafeEncoder.encode(this.name());
     }
 
-    @Override
-    public byte[] getRaw() {
-      return raw;
-    }
   }
 
   public static enum Keyword {

--- a/src/main/java/redis/clients/jedis/ProtocolCommand.java
+++ b/src/main/java/redis/clients/jedis/ProtocolCommand.java
@@ -1,7 +1,0 @@
-package redis.clients.jedis;
-
-public interface ProtocolCommand {
-
-  public byte[] getRaw();
-
-}

--- a/src/test/java/redis/clients/jedis/tests/ConnectionTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ConnectionTest.java
@@ -4,10 +4,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.Protocol.Command;
-import redis.clients.jedis.ProtocolCommand;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
 public class ConnectionTest extends Assert {
@@ -59,7 +57,7 @@ public class ConnectionTest extends Assert {
       }
 
       @Override
-      protected Connection sendCommand(ProtocolCommand cmd, byte[]... args) {
+      protected Connection sendCommand(Command cmd, byte[]... args) {
         return super.sendCommand(cmd, args);
       }
     }


### PR DESCRIPTION
This PR fixes issues presented in #1043 where sprint data redis stopped working due to binary compatibility issues. 

@HeartSaVioR @xetorthio this is the last PR needed to release 2.7.3. Plz review and comment