### PR TITLE
Add missing methods to interfaces and implementations to 2.7 (and 2.8)

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -92,6 +92,16 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   }
 
   @Override
+  public String set(final String key, final String value, final String nxxx) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+      @Override
+      public String execute(Jedis connection) {
+        return connection.set(key, value, nxxx);
+      }
+    }.run(key);
+  }
+
+  @Override
   public String get(final String key) {
     return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
       @Override
@@ -182,6 +192,16 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   }
 
   @Override
+  public Long pttl(final String key) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+      @Override
+      public Long execute(Jedis connection) {
+        return connection.pttl(key);
+      }
+    }.run(key);
+  }
+
+  @Override
   public Boolean setbit(final String key, final long offset, final boolean value) {
     return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
       @Override
@@ -257,6 +277,16 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
       @Override
       public String execute(Jedis connection) {
         return connection.setex(key, seconds, value);
+      }
+    }.run(key);
+  }
+
+  @Override
+  public String psetex(final String key, final long milliseconds, final String value) {
+    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+      @Override
+      public String execute(Jedis connection) {
+        return connection.psetex(key, milliseconds, value);
       }
     }.run(key);
   }
@@ -1190,6 +1220,26 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
     }.run(key);
   }
 
+  @Override
+  public Long bitpos(final String key, final boolean value) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+      @Override
+      public Long execute(Jedis connection) {
+        return connection.bitpos(key, value);
+      }
+    }.run(key);
+  }
+
+  @Override
+  public Long bitpos(final String key, final boolean value, final BitPosParams params) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+      @Override
+      public Long execute(Jedis connection) {
+        return connection.bitpos(key, value, params);
+      }
+    }.run(key);
+  }
+
   /**
    * Deprecated, BasicCommands is not fit to JedisCluster, so it'll be removed
    */
@@ -1531,6 +1581,17 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   }
 
   @Override
+  public ScanResult<Entry<String, String>> hscan(final String key, final String cursor, final ScanParams params) {
+    return new JedisClusterCommand<ScanResult<Entry<String, String>>>(connectionHandler,
+        maxRedirections) {
+      @Override
+      public ScanResult<Entry<String, String>> execute(Jedis connection) {
+        return connection.hscan(key, cursor, params);
+      }
+    }.run(key);
+  }
+
+  @Override
   public ScanResult<String> sscan(final String key, final String cursor) {
     return new JedisClusterCommand<ScanResult<String>>(connectionHandler, maxRedirections) {
       @Override
@@ -1541,11 +1602,31 @@ public class JedisCluster implements JedisCommands, BasicCommands, Closeable {
   }
 
   @Override
+  public ScanResult<String> sscan(final String key, final String cursor, final ScanParams params) {
+    return new JedisClusterCommand<ScanResult<String>>(connectionHandler, maxRedirections) {
+      @Override
+      public ScanResult<String> execute(Jedis connection) {
+        return connection.sscan(key, cursor, params);
+      }
+    }.run(key);
+  }
+
+  @Override
   public ScanResult<Tuple> zscan(final String key, final String cursor) {
     return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxRedirections) {
       @Override
       public ScanResult<Tuple> execute(Jedis connection) {
         return connection.zscan(key, cursor);
+      }
+    }.run(key);
+  }
+
+  @Override
+  public ScanResult<Tuple> zscan(final String key, final String cursor, final ScanParams params) {
+    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxRedirections) {
+      @Override
+      public ScanResult<Tuple> execute(Jedis connection) {
+        return connection.zscan(key, cursor, params);
       }
     }.run(key);
   }

--- a/src/main/java/redis/clients/jedis/JedisCommands.java
+++ b/src/main/java/redis/clients/jedis/JedisCommands.java
@@ -12,6 +12,8 @@ public interface JedisCommands {
 
   String set(String key, String value, String nxxx, String expx, long time);
 
+  String set(final String key, final String value, final String nxxx);
+
   String get(String key);
 
   Boolean exists(String key);
@@ -30,6 +32,8 @@ public interface JedisCommands {
 
   Long ttl(String key);
 
+  Long pttl(final String key);
+
   Boolean setbit(String key, long offset, boolean value);
 
   Boolean setbit(String key, long offset, String value);
@@ -45,6 +49,8 @@ public interface JedisCommands {
   Long setnx(String key, String value);
 
   String setex(String key, int seconds, String value);
+
+  String psetex(final String key, final long milliseconds, final String value);
 
   Long decrBy(String key, long integer);
 
@@ -242,6 +248,10 @@ public interface JedisCommands {
 
   Long bitcount(final String key, long start, long end);
 
+  Long bitpos(final String key, final boolean value);
+
+  Long bitpos(final String key, final boolean value, final BitPosParams params);
+
   @Deprecated
   /**
    * This method is deprecated due to bug (scan cursor should be unsigned long)
@@ -268,9 +278,15 @@ public interface JedisCommands {
 
   ScanResult<Map.Entry<String, String>> hscan(final String key, final String cursor);
 
+  ScanResult<Map.Entry<String, String>> hscan(final String key, final String cursor, final ScanParams params);
+
   ScanResult<String> sscan(final String key, final String cursor);
 
+  ScanResult<String> sscan(final String key, final String cursor, final ScanParams params);
+
   ScanResult<Tuple> zscan(final String key, final String cursor);
+
+  ScanResult<Tuple> zscan(final String key, final String cursor, final ScanParams params);
 
   Long pfadd(final String key, final String... elements);
 

--- a/src/main/java/redis/clients/jedis/MultiKeyCommands.java
+++ b/src/main/java/redis/clients/jedis/MultiKeyCommands.java
@@ -80,6 +80,8 @@ public interface MultiKeyCommands {
 
   ScanResult<String> scan(final String cursor);
 
+  ScanResult<String> scan(final String cursor, final ScanParams params);
+
   String pfmerge(final String destkey, final String... sourcekeys);
 
   long pfcount(final String... keys);

--- a/src/main/java/redis/clients/jedis/ShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedis.java
@@ -44,6 +44,12 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands, C
     return j.set(key, value, nxxx, expx, time);
   }
 
+  @Override
+  public String set(String key, String value, String nxxx) {
+    Jedis j = getShard(key);
+    return j.set(key, value, nxxx);
+  }
+
   public String get(String key) {
     Jedis j = getShard(key);
     return j.get(key);
@@ -89,6 +95,12 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands, C
     return j.ttl(key);
   }
 
+  @Override
+  public Long pttl(String key) {
+    Jedis j = getShard(key);
+    return j.pttl(key);
+  }
+
   public Boolean setbit(String key, long offset, boolean value) {
     Jedis j = getShard(key);
     return j.setbit(key, offset, value);
@@ -127,6 +139,12 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands, C
   public String setex(String key, int seconds, String value) {
     Jedis j = getShard(key);
     return j.setex(key, seconds, value);
+  }
+
+  @Override
+  public String psetex(String key, long milliseconds, String value) {
+    Jedis j = getShard(key);
+    return j.psetex(key, milliseconds, value);
   }
 
   public List<String> blpop(String arg) {
@@ -600,6 +618,18 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands, C
     return j.bitcount(key, start, end);
   }
 
+  @Override
+  public Long bitpos(String key, boolean value) {
+    Jedis j = getShard(key);
+    return j.bitpos(key, value);
+  }
+
+  @Override
+  public Long bitpos(String key, boolean value, BitPosParams params) {
+    Jedis j = getShard(key);
+    return j.bitpos(key, value, params);
+  }
+
   @Deprecated
   /**
    * This method is deprecated due to bug (scan cursor should be unsigned long)
@@ -638,14 +668,32 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands, C
     return j.hscan(key, cursor);
   }
 
+  @Override
+  public ScanResult<Entry<String, String>> hscan(String key, String cursor, ScanParams params) {
+    Jedis j = getShard(key);
+    return j.hscan(key, cursor, params);
+  }
+
   public ScanResult<String> sscan(String key, final String cursor) {
     Jedis j = getShard(key);
     return j.sscan(key, cursor);
   }
 
+  @Override
+  public ScanResult<String> sscan(String key, String cursor, ScanParams params) {
+    Jedis j = getShard(key);
+    return j.sscan(key, cursor, params);
+  }
+
   public ScanResult<Tuple> zscan(String key, final String cursor) {
     Jedis j = getShard(key);
     return j.zscan(key, cursor);
+  }
+
+  @Override
+  public ScanResult<Tuple> zscan(String key, String cursor, ScanParams params) {
+    Jedis j = getShard(key);
+    return j.zscan(key, cursor, params);
   }
 
   @Override


### PR DESCRIPTION
Taking a look at #1077 , I found that there're some methods which are missed from interfaces.

This PR adds missing methods to interfaces, and also adds implementations if needed.

Btw, I don't add @Override annotation to methods, which could take some time to finish.
If we think we should add this annotation to feel safe, I'm happy to. :)

Please review and comment. Thanks!