### PR TITLE
Fix logic of refreshing slot table when MOVED redirection occurred.

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -1,5 +1,8 @@
 package redis.clients.jedis;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -50,7 +53,7 @@ public abstract class JedisClusterConnectionHandler {
   }
 
   public void renewSlotCache() {
-    for (JedisPool jp : cache.getNodes().values()) {
+    for (JedisPool jp : getShuffledNodesPool()) {
       Jedis jedis = null;
       try {
         jedis = jp.getResource();
@@ -66,4 +69,18 @@ public abstract class JedisClusterConnectionHandler {
     }
   }
 
+  public void renewSlotCache(Jedis jedis) {
+    try {
+      cache.discoverClusterSlots(jedis);
+    } catch (JedisConnectionException e) {
+      renewSlotCache();
+    }
+  }
+
+  protected List<JedisPool> getShuffledNodesPool() {
+    List<JedisPool> pools = new ArrayList<JedisPool>();
+    pools.addAll(cache.getNodes().values());
+    Collections.shuffle(pools);
+    return pools;
+  }
 }

--- a/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
@@ -64,12 +64,4 @@ public class JedisSlotBasedConnectionHandler extends JedisClusterConnectionHandl
       return getConnection();
     }
   }
-
-  private List<JedisPool> getShuffledNodesPool() {
-    List<JedisPool> pools = new ArrayList<JedisPool>();
-    pools.addAll(cache.getNodes().values());
-    Collections.shuffle(pools);
-    return pools;
-  }
-
 }


### PR DESCRIPTION
Currently, When refresh slot map table, Jedis select node(host:port) from beginning of map.  
But Redis cluster's configuration does not propagate at the same time.

So, we should use node which send MOVED redirection at first.
And if fail, we choose randomly.

Please review. :D
thanks.