### PR TITLE
validate the password in JedisFactory constructor

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisFactory.java
@@ -26,7 +26,11 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
     this.hostAndPort.set(new HostAndPort(host, port));
     this.connectionTimeout = connectionTimeout;
     this.soTimeout = soTimeout;
-    this.password = password;
+    if(password != null && ! password.trim().isEmpty()){
+      this.password = password;
+    }else{
+      this.password = null;
+    }
     this.database = database;
     this.clientName = clientName;
   }


### PR DESCRIPTION
When we use Jedis in our daily development, we like to integrate Jedis into Spring Framework. And we usually config it in spring xml configuration file,just like following:

<bean id = "jedisPool" class="redis.clients.jedis.JedisPool">
        <constructor-arg index="0" ref="poolConfig"/>
        <constructor-arg index="1" value="${redis.host}"/>
        <constructor-arg index="2" value="${redis.port}" type="int"/>
        <constructor-arg index="3" value="${redis.timeout}" type="int"/>
        <constructor-arg index="4" value="${redis.pass}"/>
</bean>

this xml file is in project and may not change.
in our dev environment ,we may configure the prameters like following in one properties file:

redis.host=127.0.0.1
redis.port=6379
redis.pass=			//attention: the pass is blank character or null !
redis.maxIdle=10

but when we switch to online product environment ,the properties file may like this:

redis.host=127.0.0.1
redis.port=6379
redis.pass=password123  //attention: the pass is password123
redis.maxIdle=10

if the spring xml file contains 
<constructor-arg index="4" value="${redis.pass}"/>
 but the properties file's "redis.pass" parameter is blank character or null, the Jedis will throw Exception.

The purpose of this change is to be compatible if there is a password or not.