### PR TITLE
Fix infinite loop from sentinel pool when failover occurred (for 2.7)

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -102,9 +102,10 @@ public class JedisPool extends Pool<Jedis> {
   }
 
   /**
-   * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
-   *             using @see {@link redis.clients.jedis.Jedis#close()}
+   * @deprecated starting from Jedis 3.0 this method will not be exposed.
+   * Resource cleanup should be done using @see {@link redis.clients.jedis.Jedis#close()}
    */
+  @Override
   @Deprecated
   public void returnBrokenResource(final Jedis resource) {
     if (resource != null) {
@@ -113,9 +114,10 @@ public class JedisPool extends Pool<Jedis> {
   }
 
   /**
-   * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
-   *             using @see {@link redis.clients.jedis.Jedis#close()}
+   * @deprecated starting from Jedis 3.0 this method will not be exposed.
+   * Resource cleanup should be done using @see {@link redis.clients.jedis.Jedis#close()}
    */
+  @Override
   @Deprecated
   public void returnResource(final Jedis resource) {
     if (resource != null) {

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -215,15 +215,17 @@ public class JedisSentinelPool extends Pool<Jedis> {
         // connected to the correct master
         return jedis;
       } else {
-        jedis.close();
+        returnBrokenResource(jedis);
       }
     }
   }
 
   /**
-   * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
-   *             using @see {@link redis.clients.jedis.Jedis#close()}
+   * @deprecated starting from Jedis 3.0 this method will not be exposed.
+   * Resource cleanup should be done using @see {@link redis.clients.jedis.Jedis#close()}
    */
+  @Override
+  @Deprecated
   public void returnBrokenResource(final Jedis resource) {
     if (resource != null) {
       returnBrokenResourceObject(resource);
@@ -231,9 +233,11 @@ public class JedisSentinelPool extends Pool<Jedis> {
   }
 
   /**
-   * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
-   *             using @see {@link redis.clients.jedis.Jedis#close()}
+   * @deprecated starting from Jedis 3.0 this method will not be exposed.
+   * Resource cleanup should be done using @see {@link redis.clients.jedis.Jedis#close()}
    */
+  @Override
+  @Deprecated
   public void returnResource(final Jedis resource) {
     if (resource != null) {
       resource.resetState();

--- a/src/main/java/redis/clients/jedis/ShardedJedisPool.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedisPool.java
@@ -39,10 +39,11 @@ public class ShardedJedisPool extends Pool<ShardedJedis> {
   }
 
   /**
-   * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
-   *             using @see {@link redis.clients.jedis.ShardedJedis#close()}
+   * @deprecated starting from Jedis 3.0 this method will not be exposed.
+   * Resource cleanup should be done using @see {@link redis.clients.jedis.Jedis#close()}
    */
   @Override
+  @Deprecated
   public void returnBrokenResource(final ShardedJedis resource) {
     if (resource != null) {
       returnBrokenResourceObject(resource);
@@ -50,10 +51,11 @@ public class ShardedJedisPool extends Pool<ShardedJedis> {
   }
 
   /**
-   * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
-   *             using @see {@link redis.clients.jedis.ShardedJedis#close()}
+   * @deprecated starting from Jedis 3.0 this method will not be exposed.
+   * Resource cleanup should be done using @see {@link redis.clients.jedis.Jedis#close()}
    */
   @Override
+  @Deprecated
   public void returnResource(final ShardedJedis resource) {
     if (resource != null) {
       resource.resetState();

--- a/src/main/java/redis/clients/util/Pool.java
+++ b/src/main/java/redis/clients/util/Pool.java
@@ -52,8 +52,8 @@ public abstract class Pool<T> implements Closeable {
   }
 
   /**
-   * @deprecated starting from Jedis 3.0 this method won't exist. Resouce cleanup should be done
-   *             using @see {@link redis.clients.jedis.Jedis#close()}
+   * @deprecated starting from Jedis 3.0 this method will not be exposed.
+   * Resource cleanup should be done using @see {@link redis.clients.jedis.Jedis#close()}
    */
   @Deprecated
   public void returnResourceObject(final T resource) {
@@ -67,12 +67,22 @@ public abstract class Pool<T> implements Closeable {
     }
   }
 
+  /**
+   * @deprecated starting from Jedis 3.0 this method will not be exposed.
+   * Resource cleanup should be done using @see {@link redis.clients.jedis.Jedis#close()}
+   */
+  @Deprecated
   public void returnBrokenResource(final T resource) {
     if (resource != null) {
       returnBrokenResourceObject(resource);
     }
   }
 
+  /**
+   * @deprecated starting from Jedis 3.0 this method will not be exposed.
+   * Resource cleanup should be done using @see {@link redis.clients.jedis.Jedis#close()}
+   */
+  @Deprecated
   public void returnResource(final T resource) {
     if (resource != null) {
       returnResourceObject(resource);


### PR DESCRIPTION
Fixes #1093 

* After failover, any borrowed instances connected to old master could be returned to pool
* Thread calling JedisSentinelPool.getResource() will run into infinite loop because old instances borrowed and returned repeatedly
* Fix JedisSentinelPool.getResource() to return instance as broken when instance is not connected to current master