### PR TITLE
Add constructors in JedisCluster for just one node

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -8,6 +8,7 @@ import redis.clients.jedis.commands.JedisClusterScriptingCommands;
 import redis.clients.jedis.commands.MultiKeyJedisClusterCommands;
 import redis.clients.util.KeyMergeUtil;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -23,6 +24,36 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
     SOFT, HARD
   }
 
+  public JedisCluster(HostAndPort node) {
+	this(Collections.singleton(node), DEFAULT_TIMEOUT);
+  }
+
+  public JedisCluster(HostAndPort node, int timeout) {
+    this(Collections.singleton(node), timeout, DEFAULT_MAX_REDIRECTIONS);
+  }
+
+  public JedisCluster(HostAndPort node, int timeout, int maxRedirections) {
+    this(Collections.singleton(node), timeout, maxRedirections, new GenericObjectPoolConfig());
+  }
+
+  public JedisCluster(HostAndPort node, final GenericObjectPoolConfig poolConfig) {
+    this(Collections.singleton(node), DEFAULT_TIMEOUT, DEFAULT_MAX_REDIRECTIONS, poolConfig);
+  }
+
+  public JedisCluster(HostAndPort node, int timeout, final GenericObjectPoolConfig poolConfig) {
+    this(Collections.singleton(node), timeout, DEFAULT_MAX_REDIRECTIONS, poolConfig);
+  }
+
+  public JedisCluster(HostAndPort node, int timeout, int maxRedirections,
+      final GenericObjectPoolConfig poolConfig) {
+    this(Collections.singleton(node), timeout, maxRedirections, poolConfig);
+  }
+
+  public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout,
+      int maxRedirections, final GenericObjectPoolConfig poolConfig) {
+    super(Collections.singleton(node), connectionTimeout, soTimeout, maxRedirections, poolConfig);
+  }
+  
   public JedisCluster(Set<HostAndPort> nodes) {
     this(nodes, DEFAULT_TIMEOUT);
   }

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -127,8 +127,11 @@ public class JedisClusterTest extends Assert {
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
     JedisCluster jc = new JedisCluster(jedisClusterNode);
     assertEquals(3, jc.getClusterNodes().size());
+    
+    JedisCluster jc2 = new JedisCluster(new HostAndPort("127.0.0.1", 7379));
+    assertEquals(3, jc2.getClusterNodes().size());
   }
-
+  
   @Test
   public void testCalculateConnectionPerSlot() {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
@@ -136,6 +139,12 @@ public class JedisClusterTest extends Assert {
     JedisCluster jc = new JedisCluster(jedisClusterNode);
     jc.set("foo", "bar");
     jc.set("test", "test");
+    assertEquals("bar", node3.get("foo"));
+    assertEquals("test", node2.get("test"));
+    
+    JedisCluster jc2 = new JedisCluster(new HostAndPort("127.0.0.1", 7379));
+    jc2.set("foo", "bar");
+    jc2.set("test", "test");
     assertEquals("bar", node3.get("foo"));
     assertEquals("test", node2.get("test"));
   }


### PR DESCRIPTION
As there is nodes auto discovering in JedisCluster, I believe to be useful a constructor who receives only one node. Something like this:
```
JedisCluster cluster = new JedisCluster(new HostAndPort("10.10.10.10", 7777));
```

Best regards!