### PR TITLE
Could not return the resource to the pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,18 @@ pidfile /tmp/sentinel3.pid
 logfile /tmp/sentinel3.log
 endef
 
+define REDIS_SENTINEL4
+port 26382
+daemonize yes
+sentinel monitor mymaster 127.0.0.1 6381 1
+sentinel auth-pass mymaster foobared
+sentinel down-after-milliseconds mymaster 2000
+sentinel parallel-syncs mymaster 1
+sentinel failover-timeout mymaster 120000
+pidfile /tmp/sentinel4.pid
+logfile /tmp/sentinel4.log
+endef
+
 # CLUSTER REDIS NODES
 define REDIS_CLUSTER_NODE1_CONF
 daemonize yes
@@ -199,6 +211,7 @@ export REDIS7_CONF
 export REDIS_SENTINEL1
 export REDIS_SENTINEL2
 export REDIS_SENTINEL3
+export REDIS_SENTINEL4
 export REDIS_CLUSTER_NODE1_CONF
 export REDIS_CLUSTER_NODE2_CONF
 export REDIS_CLUSTER_NODE3_CONF
@@ -219,6 +232,8 @@ start: cleanup
 	echo "$$REDIS_SENTINEL2" > /tmp/sentinel2.conf && redis-server /tmp/sentinel2.conf --sentinel
 	@sleep 0.5
 	echo "$$REDIS_SENTINEL3" > /tmp/sentinel3.conf && redis-server /tmp/sentinel3.conf --sentinel
+	@sleep 0.5
+	echo "$$REDIS_SENTINEL4" > /tmp/sentinel4.conf && redis-server /tmp/sentinel4.conf --sentinel
 	echo "$$REDIS_CLUSTER_NODE1_CONF" | redis-server -
 	echo "$$REDIS_CLUSTER_NODE2_CONF" | redis-server -
 	echo "$$REDIS_CLUSTER_NODE3_CONF" | redis-server -
@@ -241,6 +256,7 @@ stop:
 	kill `cat /tmp/sentinel1.pid`
 	kill `cat /tmp/sentinel2.pid`
 	kill `cat /tmp/sentinel3.pid`
+	kill `cat /tmp/sentinel4.pid`
 	kill `cat /tmp/redis_cluster_node1.pid` || true
 	kill `cat /tmp/redis_cluster_node2.pid` || true
 	kill `cat /tmp/redis_cluster_node3.pid` || true

--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -104,6 +104,26 @@ public class BuilderFactory {
 
     };
     
+    public static final Builder<Map<String, String>> PUBSUB_NUMSUB_MAP = new Builder<Map<String, String>>() {
+	@SuppressWarnings("unchecked")
+	public Map<String, String> build(Object data) {
+	    final List<Object> flatHash = (List<Object>) data;
+	    final Map<String, String> hash = new HashMap<String, String>();
+	    final Iterator<Object> iterator = flatHash.iterator();
+	    while (iterator.hasNext()) {
+		hash.put(SafeEncoder.encode((byte[]) iterator.next()),
+			String.valueOf((Long) iterator.next()));
+	    }
+
+	    return hash;
+	}
+
+	public String toString() {
+	    return "PUBSUB_NUMSUB_MAP<String, String>";
+	}
+
+    };
+    
     public static final Builder<Set<String>> STRING_SET = new Builder<Set<String>>() {
 	@SuppressWarnings("unchecked")
 	public Set<String> build(Object data) {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3511,7 +3511,7 @@ public class Jedis extends BinaryJedis implements JedisCommands,
     public Map<String, String> pubsubNumSub(String... channels) {
 	checkIsInMulti();
 	client.pubsubNumSub(channels);
-	return BuilderFactory.STRING_MAP
+	return BuilderFactory.PUBSUB_NUMSUB_MAP
 		.build(client.getBinaryMultiBulkReply());
     }
 

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -65,6 +65,9 @@ public class JedisSentinelPool extends Pool<Jedis> {
     public JedisSentinelPool(String masterName, Set<String> sentinels,
 	    final GenericObjectPoolConfig poolConfig, int timeout,
 	    final String password, final int database) {
+    // Proper master failover detection dependes on testOnBorrow, so force it here
+    poolConfig.setTestOnBorrow(true);
+
 	this.poolConfig = poolConfig;
 	this.timeout = timeout;
 	this.password = password;

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -74,6 +74,7 @@ public class JedisSentinelPool extends Pool<Jedis> {
 	initPool(master);
     }
 
+    private volatile JedisFactory factory;
     private volatile HostAndPort currentHostMaster;
 
     public void destroy() {
@@ -91,10 +92,15 @@ public class JedisSentinelPool extends Pool<Jedis> {
     private void initPool(HostAndPort master) {
 	if (!master.equals(currentHostMaster)) {
 	    currentHostMaster = master;
+	    if (factory == null) {
+	        factory = new JedisFactory(master.getHost(), master.getPort(),
+	                                   timeout, password, database);
+	        initPool(poolConfig, factory);
+	    } else {
+	        factory.setHostAndPort(currentHostMaster);
+	    }
+
 	    log.info("Created JedisPool to master at " + master);
-	    initPool(poolConfig,
-		    new JedisFactory(master.getHost(), master.getPort(),
-			    timeout, password, database));
 	}
     }
 

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -65,8 +65,10 @@ public class JedisSentinelPool extends Pool<Jedis> {
     public JedisSentinelPool(String masterName, Set<String> sentinels,
 	    final GenericObjectPoolConfig poolConfig, int timeout,
 	    final String password, final int database) {
-    // Proper master failover detection dependes on testOnBorrow, so force it here
-    poolConfig.setTestOnBorrow(true);
+    // Proper master failover detection dependes on testOnBorrow or testOnReturn, so force it here
+    if (!poolConfig.getTestOnBorrow() && !poolConfig.getTestOnReturn()) {
+        poolConfig.setTestOnBorrow(true);
+    }
 
 	this.poolConfig = poolConfig;
 	this.timeout = timeout;

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -126,20 +126,24 @@ public class JedisSentinelPool extends Pool<Jedis> {
 
 		log.fine("Connecting to Sentinel " + hap);
 
+		Jedis jedis = null;
 		try {
-		    Jedis jedis = new Jedis(hap.getHost(), hap.getPort());
+		    jedis = new Jedis(hap.getHost(), hap.getPort());
 
 		    if (master == null) {
 			master = toHostAndPort(jedis
 				.sentinelGetMasterAddrByName(masterName));
 			log.fine("Found Redis master at " + master);
-			jedis.disconnect();
 			break outer;
 		    }
 		} catch (JedisConnectionException e) {
 		    log.warning("Cannot connect to sentinel running @ " + hap
 			    + ". Trying next one.");
-		}
+		} finally {
+		    if (jedis != null) {
+	        jedis.close();
+		    }
+		}		
 	    }
 
 	    try {

--- a/src/test/java/redis/clients/jedis/tests/HostAndPortUtil.java
+++ b/src/test/java/redis/clients/jedis/tests/HostAndPortUtil.java
@@ -23,6 +23,7 @@ public class HostAndPortUtil {
 	sentinelHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT));
 	sentinelHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 1));
 	sentinelHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 2));
+	sentinelHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 3));
 
 	clusterHostAndPortList.add(new HostAndPort("localhost", 7379));
 	clusterHostAndPortList.add(new HostAndPort("localhost", 7380));

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelTest.java
@@ -85,16 +85,16 @@ public class JedisSentinelTest extends JedisTestBase {
     public void sentinelFailover() throws InterruptedException {
 	Jedis j = new Jedis(sentinelForFailover.getHost(),
 		sentinelForFailover.getPort());
+	Jedis j2 = new Jedis(sentinelForFailover.getHost(),
+	                    sentinelForFailover.getPort());
 
 	try {
 	    List<String> masterHostAndPort = j
 		    .sentinelGetMasterAddrByName(FAILOVER_MASTER_NAME);
 	    HostAndPort currentMaster = new HostAndPort(masterHostAndPort.get(0), 
 		    Integer.parseInt(masterHostAndPort.get(1)));
-	    String result = j.sentinelFailover(FAILOVER_MASTER_NAME);
-	    assertEquals("OK", result);
 
-	    JedisSentinelTestUtil.waitForNewPromotedMaster(j);
+	    JedisSentinelTestUtil.waitForNewPromotedMaster(FAILOVER_MASTER_NAME, j, j2);
 
 	    masterHostAndPort = j
 		    .sentinelGetMasterAddrByName(FAILOVER_MASTER_NAME);

--- a/src/test/java/redis/clients/jedis/tests/utils/JedisSentinelTestUtil.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/JedisSentinelTestUtil.java
@@ -8,7 +8,8 @@ import redis.clients.jedis.JedisPubSub;
 import redis.clients.jedis.tests.utils.FailoverAbortedException;
 
 public class JedisSentinelTestUtil {
-    public static HostAndPort waitForNewPromotedMaster(Jedis sentinelJedis) 
+    public static HostAndPort waitForNewPromotedMaster(final String masterName, 
+        final Jedis sentinelJedis, final Jedis commandJedis) 
 	    throws InterruptedException {
 	
 	final AtomicReference<String> newmaster = new AtomicReference<String>(
@@ -47,6 +48,7 @@ public class JedisSentinelTestUtil {
 
 	    @Override
 	    public void onPSubscribe(String pattern, int subscribedChannels) {
+        commandJedis.sentinelFailover(masterName);
 	    }
 	}, "*");
 


### PR DESCRIPTION
redis.clients.jedis.exceptions.JedisException: Could not return the resource to the pool
	at redis.clients.util.Pool.returnResourceObject(Pool.java:54)
	at redis.clients.jedis.ShardedJedisPool.returnResource(ShardedJedisPool.java:53)
	at redis.clients.jedis.ShardedJedisPool.returnResource(ShardedJedisPool.java:14)
	at com.my.datacenter.cache.conn.impl.ShardControlImpl.freeConnection(ShardControlImpl.java:77)
	at com.my.datacenter.cache.conn.impl.ShardControlImpl.addHash(ShardControlImpl.java:480)
	at com.my.datacenter.cache.handle.impl.CTFOCacheTableImpl.PaddHash(CTFOCacheTableImpl.java:587)
	at com.my.datacenter.cache.handle.impl.CTFOCacheTableImpl.addHash(CTFOCacheTableImpl.java:574)
	at com.my.rtuserver.output.service.DatacenterClientThread.execute(DatacenterClientThread.java:192)
	at com.my.rtuserver.output.service.DatacenterClientThread.run(DatacenterClientThread.java:50)
	at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
	at java.lang.Thread.run(Thread.java:662)
Caused by: java.lang.IllegalStateException: Returned object not currently part of this pool
	at org.apache.commons.pool2.impl.GenericObjectPool.returnObject(GenericObjectPool.java:537)
	at redis.clients.util.Pool.returnResourceObject(Pool.java:52)
	... 11 more 
my program worked on jedis 2.4.2 and 2.5.2 to encounter error above.
    I found  this problem on github about issue #560 and #554,but i don't find which jedis version to fix it?  i should download which verison  if i want to slove it. 