### PR TITLE
close the jedis pool of the fail node

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -88,6 +88,24 @@ public class JedisClusterInfoCache {
         setNodeIfNotExist(targetNode);
         assignSlotsToNode(slotNums, targetNode);
       }
+      
+      //close the jedis pool of the fail node
+      String localNodes = jedis.clusterNodes();
+      for (String nodeInfo: localNodes.split("\n")) {
+          if(nodeInfo.contains("fail")){
+              ClusterNodeInformation clusterNodeInfo = nodeInfoParser.parse(
+                      nodeInfo, new HostAndPort(jedis.getClient().getHost(),
+                              jedis.getClient().getPort()));
+
+              HostAndPort failNode = clusterNodeInfo.getNode();
+              String nodeKey = getNodeKey(failNode);
+              JedisPool jedisPool=nodes.get(nodeKey);
+              if(jedisPool!=null){
+                  jedisPool.close();
+                  nodes.remove(nodeKey);                    
+              }
+          }
+      }
     } finally {
       w.unlock();
     }


### PR DESCRIPTION
There is a bug on the condition that: 
       redis cluster contains three masters and three slaves,if jedis client invoke JedisCluster with the default GenericObjectPoolConfig,this means the jedispool would block to wait idleObjects when exceed the default eight concurrences.At that time one master down and its slave replace it to master,but the blocking threads are waiting for the down master notify,but cannot wait for notify.so those threads will block util the down master live out the new master.
       what i do is when discoverClusterSlots,please close the jedis pool of the fail node,so those blocking threads can release.
