### PR TITLE
Malicious code vulnerability - Public static method may expose internal representation by returning array

### DIFF
--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -207,7 +207,7 @@ public final class Protocol {
   }
 
   public static final byte[] toByteArray(final boolean value) {
-    return value ? BYTES_TRUE : BYTES_FALSE;
+    return value ? BYTES_TRUE.clone() : BYTES_FALSE.clone();
   }
 
   public static final byte[] toByteArray(final int value) {

--- a/src/test/java/redis/clients/jedis/tests/ProtocolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ProtocolTest.java
@@ -119,4 +119,18 @@ public class ProtocolTest extends JedisTestBase {
     List<String> response = (List<String>) Protocol.read(new RedisInputStream(is));
     assertNull(response);
   }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void toByteArrayBoolean() {
+    byte[] trueResult = Protocol.toByteArray(true);
+    assertArrayEquals(trueResult, Protocol.BYTES_TRUE);
+    assertNotEquals(trueResult, Protocol.BYTES_TRUE);
+
+    byte[] falseResult = Protocol.toByteArray(false);
+    assertArrayEquals(falseResult, Protocol.BYTES_FALSE);
+    assertNotEquals(falseResult, Protocol.BYTES_FALSE);
+  }
+
+
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of findbugs rule findbugs:MS_EXPOSE_REP - “Malicious code vulnerability - Public static method may expose internal representation by returning array”. 
You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/findbugs:MS_EXPOSE_REP