### PR TITLE
Support for ssl/tls using defaults or user specified SSLSocketFactory, SSLParameters, and HostnameVerifier.

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -20,6 +20,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+
 import redis.clients.jedis.Protocol.Command;
 import redis.clients.jedis.Protocol.Keyword;
 import redis.clients.jedis.params.geo.GeoRadiusParam;
@@ -64,6 +68,16 @@ public class BinaryClient extends Connection {
 
   public BinaryClient(final String host, final int port) {
     super(host, port);
+  }
+
+  public BinaryClient(final String host, final int port, final boolean ssl) {
+    super(host, port, ssl);
+  }
+
+  public BinaryClient(final String host, final int port, final boolean ssl,
+      final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    super(host, port, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
   }
 
   private byte[][] joinParameters(byte[] first, byte[][] rest) {

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -15,6 +15,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+
 import redis.clients.jedis.BinaryClient.LIST_POSITION;
 import redis.clients.jedis.commands.*;
 import redis.clients.jedis.exceptions.InvalidURIException;
@@ -51,8 +55,32 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     client = new Client(host, port);
   }
 
+  public BinaryJedis(final String host, final int port, final boolean ssl) {
+    client = new Client(host, port, ssl);
+  }
+
+  public BinaryJedis(final String host, final int port, final boolean ssl,
+      final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    client = new Client(host, port, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
+  }
+
   public BinaryJedis(final String host, final int port, final int timeout) {
     client = new Client(host, port);
+    client.setConnectionTimeout(timeout);
+    client.setSoTimeout(timeout);
+  }
+
+  public BinaryJedis(final String host, final int port, final int timeout, final boolean ssl) {
+    client = new Client(host, port, ssl);
+    client.setConnectionTimeout(timeout);
+    client.setSoTimeout(timeout);
+  }
+
+  public BinaryJedis(final String host, final int port, final int timeout, final boolean ssl,
+      final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    client = new Client(host, port, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
     client.setConnectionTimeout(timeout);
     client.setSoTimeout(timeout);
   }
@@ -64,8 +92,25 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     client.setSoTimeout(soTimeout);
   }
 
+  public BinaryJedis(final String host, final int port, final int connectionTimeout,
+      final int soTimeout, final boolean ssl) {
+    client = new Client(host, port, ssl);
+    client.setConnectionTimeout(connectionTimeout);
+    client.setSoTimeout(soTimeout);
+  }
+
+  public BinaryJedis(final String host, final int port, final int connectionTimeout,
+      final int soTimeout, final boolean ssl, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+    client = new Client(host, port, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
+    client.setConnectionTimeout(connectionTimeout);
+    client.setSoTimeout(soTimeout);
+  }
+
   public BinaryJedis(final JedisShardInfo shardInfo) {
-    client = new Client(shardInfo.getHost(), shardInfo.getPort());
+    client = new Client(shardInfo.getHost(), shardInfo.getPort(), shardInfo.getSsl(),
+        shardInfo.getSslSocketFactory(), shardInfo.getSslParameters(),
+        shardInfo.getHostnameVerifier());
     client.setConnectionTimeout(shardInfo.getConnectionTimeout());
     client.setSoTimeout(shardInfo.getSoTimeout());
     client.setPassword(shardInfo.getPassword());
@@ -76,8 +121,20 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     initializeClientFromURI(uri);
   }
 
+  public BinaryJedis(URI uri, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+    initializeClientFromURI(uri, sslSocketFactory, sslParameters, hostnameVerifier);
+  }
+
   public BinaryJedis(final URI uri, final int timeout) {
     initializeClientFromURI(uri);
+    client.setConnectionTimeout(timeout);
+    client.setSoTimeout(timeout);
+  }
+
+  public BinaryJedis(final URI uri, final int timeout, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+    initializeClientFromURI(uri, sslSocketFactory, sslParameters, hostnameVerifier);
     client.setConnectionTimeout(timeout);
     client.setSoTimeout(timeout);
   }
@@ -88,13 +145,45 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     client.setSoTimeout(soTimeout);
   }
 
+  public BinaryJedis(final URI uri, final int connectionTimeout, final int soTimeout,
+      final SSLSocketFactory sslSocketFactory,final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    initializeClientFromURI(uri, sslSocketFactory, sslParameters, hostnameVerifier);
+    client.setConnectionTimeout(connectionTimeout);
+    client.setSoTimeout(soTimeout);
+  }
+
   private void initializeClientFromURI(URI uri) {
     if (!JedisURIHelper.isValid(uri)) {
       throw new InvalidURIException(String.format(
         "Cannot open Redis connection due invalid URI. %s", uri.toString()));
     }
 
-    client = new Client(uri.getHost(), uri.getPort());
+    client = new Client(uri.getHost(), uri.getPort(), uri.getScheme().equals("rediss"));
+
+    String password = JedisURIHelper.getPassword(uri);
+    if (password != null) {
+      client.auth(password);
+      client.getStatusCodeReply();
+    }
+
+    int dbIndex = JedisURIHelper.getDBIndex(uri);
+    if (dbIndex > 0) {
+      client.select(dbIndex);
+      client.getStatusCodeReply();
+      client.setDb(dbIndex);
+    }
+  }
+
+  private void initializeClientFromURI(URI uri, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+    if (!JedisURIHelper.isValid(uri)) {
+      throw new InvalidURIException(String.format(
+        "Cannot open Redis connection due invalid URI. %s", uri.toString()));
+    }
+
+    client = new Client(uri.getHost(), uri.getPort(), uri.getScheme().equals("rediss"),
+      sslSocketFactory, sslParameters, hostnameVerifier);
 
     String password = JedisURIHelper.getPassword(uri);
     if (password != null) {

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -9,6 +9,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+
 import redis.clients.jedis.JedisCluster.Reset;
 import redis.clients.jedis.commands.Commands;
 import redis.clients.jedis.params.geo.GeoRadiusParam;
@@ -29,6 +33,16 @@ public class Client extends BinaryClient implements Commands {
 
   public Client(final String host, final int port) {
     super(host, port);
+  }
+
+  public Client(final String host, final int port, final boolean ssl) {
+    super(host, port, ssl);
+  }
+
+  public Client(final String host, final int port, final boolean ssl,
+      final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    super(host, port, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -8,6 +8,11 @@ import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
 import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
@@ -28,6 +33,10 @@ public class Connection implements Closeable {
   private int connectionTimeout = Protocol.DEFAULT_TIMEOUT;
   private int soTimeout = Protocol.DEFAULT_TIMEOUT;
   private boolean broken = false;
+  private boolean ssl;
+  private SSLSocketFactory sslSocketFactory;
+  private SSLParameters sslParameters;
+  private HostnameVerifier hostnameVerifier;
 
   public Connection() {
   }
@@ -39,6 +48,23 @@ public class Connection implements Closeable {
   public Connection(final String host, final int port) {
     this.host = host;
     this.port = port;
+  }
+
+  public Connection(final String host, final int port, final boolean ssl) {
+    this.host = host;
+    this.port = port;
+    this.ssl = ssl;
+  }
+
+  public Connection(final String host, final int port, final boolean ssl,
+      SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
+      HostnameVerifier hostnameVerifier) {
+    this.host = host;
+    this.port = port;
+    this.ssl = ssl;
+    this.sslSocketFactory = sslSocketFactory;
+    this.sslParameters = sslParameters;
+    this.hostnameVerifier = hostnameVerifier;
   }
 
   public Socket getSocket() {
@@ -155,6 +181,23 @@ public class Connection implements Closeable {
 
         socket.connect(new InetSocketAddress(host, port), connectionTimeout);
         socket.setSoTimeout(soTimeout);
+
+        if (ssl) {
+          if (null == sslSocketFactory) {
+            sslSocketFactory = (SSLSocketFactory)SSLSocketFactory.getDefault();
+          }
+          socket = (SSLSocket) sslSocketFactory.createSocket(socket, host, port, true);
+          if (null != sslParameters) {
+            ((SSLSocket) socket).setSSLParameters(sslParameters);
+          }
+          if ((null != hostnameVerifier) &&
+              (!hostnameVerifier.verify(host, ((SSLSocket) socket).getSession()))) {
+            String message = String.format(
+                "The connection to '%s' failed ssl/tls hostname verification.", host);
+            throw new JedisConnectionException(message);
+          }
+        }
+
         outputStream = new RedisOutputStream(socket.getOutputStream());
         inputStream = new RedisInputStream(socket.getInputStream());
       } catch (IOException ex) {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -11,6 +11,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+
 import redis.clients.jedis.BinaryClient.LIST_POSITION;
 import redis.clients.jedis.JedisCluster.Reset;
 import redis.clients.jedis.commands.*;
@@ -38,12 +42,44 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     super(host, port);
   }
 
+  public Jedis(final String host, final int port, final boolean ssl) {
+    super(host, port, ssl);
+  }
+
+  public Jedis(final String host, final int port, final boolean ssl,
+      final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    super(host, port, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
+  }
+
   public Jedis(final String host, final int port, final int timeout) {
     super(host, port, timeout);
   }
 
+  public Jedis(final String host, final int port, final int timeout, final boolean ssl) {
+    super(host, port, timeout, ssl);
+  }
+
+  public Jedis(final String host, final int port, final int timeout, final boolean ssl,
+      final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    super(host, port, timeout, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
+  }
+
   public Jedis(final String host, final int port, final int connectionTimeout, final int soTimeout) {
     super(host, port, connectionTimeout, soTimeout);
+  }
+
+  public Jedis(final String host, final int port, final int connectionTimeout, final int soTimeout,
+      final boolean ssl) {
+    super(host, port, connectionTimeout, soTimeout, ssl);
+  }
+
+  public Jedis(final String host, final int port, final int connectionTimeout, final int soTimeout,
+      final boolean ssl, final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    super(host, port, connectionTimeout, soTimeout, ssl, sslSocketFactory, sslParameters,
+        hostnameVerifier);
   }
 
   public Jedis(JedisShardInfo shardInfo) {
@@ -54,12 +90,28 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     super(uri);
   }
 
+  public Jedis(URI uri, final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    super(uri, sslSocketFactory, sslParameters, hostnameVerifier);
+  }
+
   public Jedis(final URI uri, final int timeout) {
     super(uri, timeout);
   }
 
+  public Jedis(final URI uri, final int timeout, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+    super(uri, timeout, sslSocketFactory, sslParameters, hostnameVerifier);
+  }
+
   public Jedis(final URI uri, final int connectionTimeout, final int soTimeout) {
     super(uri, connectionTimeout, soTimeout);
+  }
+
+  public Jedis(final URI uri, final int connectionTimeout, final int soTimeout,
+      final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    super(uri, connectionTimeout, soTimeout, sslSocketFactory, sslParameters, hostnameVerifier);
   }
 
   /**

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -7,6 +7,10 @@ import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
 import redis.clients.util.ClusterNodeInformation;
@@ -105,7 +109,37 @@ public class JedisClusterInfoCache {
       if (nodes.containsKey(nodeKey)) return;
 
       JedisPool nodePool = new JedisPool(poolConfig, node.getHost(), node.getPort(),
-          connectionTimeout, soTimeout, null, 0, null);
+          connectionTimeout, soTimeout, null, 0, null, false, null, null, null);
+      nodes.put(nodeKey, nodePool);
+    } finally {
+      w.unlock();
+    }
+  }
+
+  public void setNodeIfNotExist(HostAndPort node, boolean ssl) {
+    w.lock();
+    try {
+      String nodeKey = getNodeKey(node);
+      if (nodes.containsKey(nodeKey)) return;
+
+      JedisPool nodePool = new JedisPool(poolConfig, node.getHost(), node.getPort(),
+          connectionTimeout, soTimeout, null, 0, null, ssl, null, null, null);
+      nodes.put(nodeKey, nodePool);
+    } finally {
+      w.unlock();
+    }
+  }
+
+  public void setNodeIfNotExist(HostAndPort node, boolean ssl, SSLSocketFactory sslSocketFactory,
+      SSLParameters sslParameters, HostnameVerifier hostnameVerifier) {
+    w.lock();
+    try {
+      String nodeKey = getNodeKey(node);
+      if (nodes.containsKey(nodeKey)) return;
+
+      JedisPool nodePool = new JedisPool(poolConfig, node.getHost(), node.getPort(),
+          connectionTimeout, soTimeout, null, 0, null, ssl, sslSocketFactory, sslParameters,
+          hostnameVerifier);
       nodes.put(nodeKey, nodePool);
     } finally {
       w.unlock();

--- a/src/main/java/redis/clients/jedis/JedisFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisFactory.java
@@ -3,6 +3,10 @@ package redis.clients.jedis;
 import java.net.URI;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.PooledObjectFactory;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
@@ -21,19 +25,30 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
   private final String password;
   private final int database;
   private final String clientName;
+  private final boolean ssl;
+  private final SSLSocketFactory sslSocketFactory;
+  private SSLParameters sslParameters;
+  private HostnameVerifier hostnameVerifier;
 
   public JedisFactory(final String host, final int port, final int connectionTimeout,
-      final int soTimeout, final String password, final int database, final String clientName) {
+      final int soTimeout, final String password, final int database, final String clientName,
+      final boolean ssl, final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
     this.hostAndPort.set(new HostAndPort(host, port));
     this.connectionTimeout = connectionTimeout;
     this.soTimeout = soTimeout;
     this.password = password;
     this.database = database;
     this.clientName = clientName;
+    this.ssl = ssl;
+    this.sslSocketFactory = sslSocketFactory;
+    this.sslParameters = sslParameters;
+    this.hostnameVerifier = hostnameVerifier;
   }
 
   public JedisFactory(final URI uri, final int connectionTimeout, final int soTimeout,
-      final String clientName) {
+      final String clientName, final boolean ssl, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     if (!JedisURIHelper.isValid(uri)) {
       throw new InvalidURIException(String.format(
         "Cannot open Redis connection due invalid URI. %s", uri.toString()));
@@ -45,6 +60,10 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
     this.password = JedisURIHelper.getPassword(uri);
     this.database = JedisURIHelper.getDBIndex(uri);
     this.clientName = clientName;
+    this.ssl = ssl;
+    this.sslSocketFactory = sslSocketFactory;
+    this.sslParameters = sslParameters;
+    this.hostnameVerifier = hostnameVerifier;
   }
 
   public void setHostAndPort(final HostAndPort hostAndPort) {
@@ -81,7 +100,7 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
   public PooledObject<Jedis> makeObject() throws Exception {
     final HostAndPort hostAndPort = this.hostAndPort.get();
     final Jedis jedis = new Jedis(hostAndPort.getHost(), hostAndPort.getPort(), connectionTimeout,
-        soTimeout);
+        soTimeout, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
 
     try {
       jedis.connect();

--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -2,6 +2,10 @@ package redis.clients.jedis;
 
 import java.net.URI;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
@@ -31,13 +35,34 @@ public class JedisPool extends JedisPoolAbstract {
       int port = uri.getPort();
       String password = JedisURIHelper.getPassword(uri);
       int database = JedisURIHelper.getDBIndex(uri);
+      boolean ssl = uri.getScheme().equals("rediss");
       this.internalPool = new GenericObjectPool<Jedis>(new JedisFactory(h, port,
-          Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, password, database, null),
+          Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, password, database, null,
+            ssl, null, null, null), new GenericObjectPoolConfig());
+    } else {
+      this.internalPool = new GenericObjectPool<Jedis>(new JedisFactory(host,
+          Protocol.DEFAULT_PORT, Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, null,
+          Protocol.DEFAULT_DATABASE, null, false, null, null, null), new GenericObjectPoolConfig());
+    }
+  }
+
+  public JedisPool(final String host, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+    URI uri = URI.create(host);
+    if (JedisURIHelper.isValid(uri)) {
+      String h = uri.getHost();
+      int port = uri.getPort();
+      String password = JedisURIHelper.getPassword(uri);
+      int database = JedisURIHelper.getDBIndex(uri);
+      boolean ssl = uri.getScheme().equals("rediss");
+      this.internalPool = new GenericObjectPool<Jedis>(new JedisFactory(h, port,
+          Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, password, database, null, ssl,
+            sslSocketFactory, sslParameters, hostnameVerifier),
           new GenericObjectPoolConfig());
     } else {
       this.internalPool = new GenericObjectPool<Jedis>(new JedisFactory(host,
           Protocol.DEFAULT_PORT, Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, null,
-          Protocol.DEFAULT_DATABASE, null), new GenericObjectPoolConfig());
+          Protocol.DEFAULT_DATABASE, null, false, null, null, null), new GenericObjectPoolConfig());
     }
   }
 
@@ -45,8 +70,20 @@ public class JedisPool extends JedisPoolAbstract {
     this(new GenericObjectPoolConfig(), uri, Protocol.DEFAULT_TIMEOUT);
   }
 
+  public JedisPool(final URI uri, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+    this(new GenericObjectPoolConfig(), uri, Protocol.DEFAULT_TIMEOUT, sslSocketFactory,
+        sslParameters, hostnameVerifier);
+  }
+
   public JedisPool(final URI uri, final int timeout) {
     this(new GenericObjectPoolConfig(), uri, timeout);
+  }
+
+  public JedisPool(final URI uri, final int timeout, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+    this(new GenericObjectPoolConfig(), uri, timeout, sslSocketFactory, sslParameters,
+        hostnameVerifier);
   }
 
   public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
@@ -54,13 +91,51 @@ public class JedisPool extends JedisPoolAbstract {
     this(poolConfig, host, port, timeout, password, Protocol.DEFAULT_DATABASE, null);
   }
 
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
+      int timeout, final String password, final boolean ssl) {
+    this(poolConfig, host, port, timeout, password, Protocol.DEFAULT_DATABASE, null, ssl);
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
+      int timeout, final String password, final boolean ssl,
+      final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    this(poolConfig, host, port, timeout, password, Protocol.DEFAULT_DATABASE, null, ssl,
+        sslSocketFactory, sslParameters, hostnameVerifier);
+  }
+
   public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port) {
     this(poolConfig, host, port, Protocol.DEFAULT_TIMEOUT, null, Protocol.DEFAULT_DATABASE, null);
   }
 
   public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port,
+      final boolean ssl) {
+    this(poolConfig, host, port, Protocol.DEFAULT_TIMEOUT, null, Protocol.DEFAULT_DATABASE, null,
+        ssl);
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port,
+      final boolean ssl, final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    this(poolConfig, host, port, Protocol.DEFAULT_TIMEOUT, null, Protocol.DEFAULT_DATABASE, null,
+        ssl, sslSocketFactory, sslParameters, hostnameVerifier);
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port,
       final int timeout) {
     this(poolConfig, host, port, timeout, null, Protocol.DEFAULT_DATABASE, null);
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port,
+      final int timeout, final boolean ssl) {
+    this(poolConfig, host, port, timeout, null, Protocol.DEFAULT_DATABASE, null, ssl);
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port,
+      final int timeout, final boolean ssl, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+    this(poolConfig, host, port, timeout, null, Protocol.DEFAULT_DATABASE, null, ssl,
+        sslSocketFactory, sslParameters, hostnameVerifier);
   }
 
   public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
@@ -69,28 +144,80 @@ public class JedisPool extends JedisPoolAbstract {
   }
 
   public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
+      int timeout, final String password, final int database, final boolean ssl) {
+    this(poolConfig, host, port, timeout, password, database, null, ssl);
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
+      int timeout, final String password, final int database, final boolean ssl,
+      final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    this(poolConfig, host, port, timeout, password, database, null, ssl, sslSocketFactory,
+        sslParameters, hostnameVerifier);
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
       int timeout, final String password, final int database, final String clientName) {
-    this(poolConfig, host, port, timeout, timeout, password, database, clientName);
+    this(poolConfig, host, port, timeout, timeout, password, database, clientName, false,
+        null, null, null);
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
+      int timeout, final String password, final int database, final String clientName,
+      final boolean ssl) {
+    this(poolConfig, host, port, timeout, timeout, password, database, clientName, ssl,
+        null, null, null);
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
+      int timeout, final String password, final int database, final String clientName,
+      final boolean ssl, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+    this(poolConfig, host, port, timeout, timeout, password, database, clientName, ssl,
+        sslSocketFactory, sslParameters, hostnameVerifier);
   }
 
   public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
       final int connectionTimeout, final int soTimeout, final String password, final int database,
-      final String clientName) {
+      final String clientName, final boolean ssl, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     super(poolConfig, new JedisFactory(host, port, connectionTimeout, soTimeout, password,
-        database, clientName));
+        database, clientName, ssl, sslSocketFactory, sslParameters, hostnameVerifier));
   }
 
   public JedisPool(final GenericObjectPoolConfig poolConfig, final URI uri) {
     this(poolConfig, uri, Protocol.DEFAULT_TIMEOUT);
   }
 
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final URI uri,
+      final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    this(poolConfig, uri, Protocol.DEFAULT_TIMEOUT, sslSocketFactory, sslParameters,
+        hostnameVerifier);
+  }
+
   public JedisPool(final GenericObjectPoolConfig poolConfig, final URI uri, final int timeout) {
     this(poolConfig, uri, timeout, timeout);
   }
 
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final URI uri, final int timeout,
+      final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier) {
+    this(poolConfig, uri, timeout, timeout, sslSocketFactory, sslParameters, hostnameVerifier);
+  }
+
   public JedisPool(final GenericObjectPoolConfig poolConfig, final URI uri,
       final int connectionTimeout, final int soTimeout) {
-    super(poolConfig, new JedisFactory(uri, connectionTimeout, soTimeout, null));
+    super(poolConfig, new JedisFactory(uri, connectionTimeout, soTimeout, null, false,
+        null, null, null));
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final URI uri,
+      final int connectionTimeout, final int soTimeout, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+    super(poolConfig, new JedisFactory(uri, connectionTimeout, soTimeout, null,
+        (uri.getScheme() !=null && uri.getScheme().equals("rediss")), sslSocketFactory,
+        sslParameters, hostnameVerifier));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -112,7 +112,7 @@ public class JedisSentinelPool extends JedisPoolAbstract {
       currentHostMaster = master;
       if (factory == null) {
         factory = new JedisFactory(master.getHost(), master.getPort(), connectionTimeout,
-            soTimeout, password, database, clientName);
+            soTimeout, password, database, clientName, false, null, null, null);
         initPool(poolConfig, factory);
       } else {
         factory.setHostAndPort(currentHostMaster);

--- a/src/main/java/redis/clients/jedis/JedisShardInfo.java
+++ b/src/main/java/redis/clients/jedis/JedisShardInfo.java
@@ -2,6 +2,10 @@ package redis.clients.jedis;
 
 import java.net.URI;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+
 import redis.clients.jedis.exceptions.InvalidURIException;
 import redis.clients.util.JedisURIHelper;
 import redis.clients.util.ShardInfo;
@@ -21,6 +25,10 @@ public class JedisShardInfo extends ShardInfo<Jedis> {
   private String name = null;
   // Default Redis DB
   private int db = 0;
+  private boolean ssl;
+  private SSLSocketFactory sslSocketFactory;
+  private SSLParameters sslParameters;
+  private HostnameVerifier hostnameVerifier;
 
   public String getHost() {
     return host;
@@ -38,6 +46,26 @@ public class JedisShardInfo extends ShardInfo<Jedis> {
       this.port = uri.getPort();
       this.password = JedisURIHelper.getPassword(uri);
       this.db = JedisURIHelper.getDBIndex(uri);
+      this.ssl = uri.getScheme().equals("rediss");
+    } else {
+      this.host = host;
+      this.port = Protocol.DEFAULT_PORT;
+    }
+  }
+
+  public JedisShardInfo(String host, SSLSocketFactory sslSocketFactory,
+      SSLParameters sslParameters, HostnameVerifier hostnameVerifier) {
+    super(Sharded.DEFAULT_WEIGHT);
+    URI uri = URI.create(host);
+    if (JedisURIHelper.isValid(uri)) {
+      this.host = uri.getHost();
+      this.port = uri.getPort();
+      this.password = JedisURIHelper.getPassword(uri);
+      this.db = JedisURIHelper.getDBIndex(uri);
+      this.ssl = uri.getScheme().equals("rediss");
+      this.sslSocketFactory = sslSocketFactory;
+      this.sslParameters = sslParameters;
+      this.hostnameVerifier = hostnameVerifier;
     } else {
       this.host = host;
       this.port = Protocol.DEFAULT_PORT;
@@ -52,17 +80,65 @@ public class JedisShardInfo extends ShardInfo<Jedis> {
     this(host, port, 2000);
   }
 
+  public JedisShardInfo(String host, int port, boolean ssl) {
+    this(host, port, 2000, 2000, Sharded.DEFAULT_WEIGHT, ssl);
+  }
+
+  public JedisShardInfo(String host, int port, boolean ssl, SSLSocketFactory sslSocketFactory,
+      SSLParameters sslParameters, HostnameVerifier hostnameVerifier) {
+    this(host, port, 2000, 2000, Sharded.DEFAULT_WEIGHT, ssl, sslSocketFactory, sslParameters,
+        hostnameVerifier);
+  }
+
   public JedisShardInfo(String host, int port, String name) {
     this(host, port, 2000, name);
+  }
+
+  public JedisShardInfo(String host, int port, String name, boolean ssl) {
+    this(host, port, 2000, name, ssl);
+  }
+
+  public JedisShardInfo(String host, int port, String name, boolean ssl, SSLSocketFactory sslSocketFactory,
+      SSLParameters sslParameters, HostnameVerifier hostnameVerifier) {
+    this(host, port, 2000, name, ssl, sslSocketFactory, sslParameters,
+        hostnameVerifier);
   }
 
   public JedisShardInfo(String host, int port, int timeout) {
     this(host, port, timeout, timeout, Sharded.DEFAULT_WEIGHT);
   }
 
+  public JedisShardInfo(String host, int port, int timeout, boolean ssl) {
+    this(host, port, timeout, timeout, Sharded.DEFAULT_WEIGHT, ssl);
+  }
+
+  public JedisShardInfo(String host, int port, int timeout, boolean ssl,
+      SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
+      HostnameVerifier hostnameVerifier) {
+    this(host, port, timeout, timeout, Sharded.DEFAULT_WEIGHT, ssl, sslSocketFactory,
+        sslParameters, hostnameVerifier);
+  }
+
   public JedisShardInfo(String host, int port, int timeout, String name) {
     this(host, port, timeout, timeout, Sharded.DEFAULT_WEIGHT);
     this.name = name;
+  }
+
+  public JedisShardInfo(String host, int port, int timeout, String name, boolean ssl) {
+    this(host, port, timeout, timeout, Sharded.DEFAULT_WEIGHT);
+    this.name = name;
+    this.ssl = ssl;
+  }
+
+  public JedisShardInfo(String host, int port, int timeout, String name, boolean ssl,
+      SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
+      HostnameVerifier hostnameVerifier) {
+    this(host, port, timeout, timeout, Sharded.DEFAULT_WEIGHT);
+    this.name = name;
+    this.ssl = ssl;
+    this.sslSocketFactory = sslSocketFactory;
+    this.sslParameters = sslParameters;
+    this.hostnameVerifier = hostnameVerifier;
   }
 
   public JedisShardInfo(String host, int port, int connectionTimeout, int soTimeout, int weight) {
@@ -73,6 +149,30 @@ public class JedisShardInfo extends ShardInfo<Jedis> {
     this.soTimeout = soTimeout;
   }
 
+  public JedisShardInfo(String host, int port, int connectionTimeout, int soTimeout, int weight,
+      boolean ssl) {
+    super(weight);
+    this.host = host;
+    this.port = port;
+    this.connectionTimeout = connectionTimeout;
+    this.soTimeout = soTimeout;
+    this.ssl = ssl;
+  }
+
+  public JedisShardInfo(String host, int port, int connectionTimeout, int soTimeout, int weight,
+      boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
+      HostnameVerifier hostnameVerifier) {
+    super(weight);
+    this.host = host;
+    this.port = port;
+    this.connectionTimeout = connectionTimeout;
+    this.soTimeout = soTimeout;
+    this.ssl = ssl;
+    this.sslSocketFactory = sslSocketFactory;
+    this.sslParameters = sslParameters;
+    this.hostnameVerifier = hostnameVerifier;
+  }
+
   public JedisShardInfo(String host, String name, int port, int timeout, int weight) {
     super(weight);
     this.host = host;
@@ -80,6 +180,32 @@ public class JedisShardInfo extends ShardInfo<Jedis> {
     this.port = port;
     this.connectionTimeout = timeout;
     this.soTimeout = timeout;
+  }
+
+  public JedisShardInfo(String host, String name, int port, int timeout, int weight,
+      boolean ssl) {
+    super(weight);
+    this.host = host;
+    this.name = name;
+    this.port = port;
+    this.connectionTimeout = timeout;
+    this.soTimeout = timeout;
+    this.ssl = ssl;
+  }
+
+  public JedisShardInfo(String host, String name, int port, int timeout, int weight,
+      boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
+      HostnameVerifier hostnameVerifier) {
+    super(weight);
+    this.host = host;
+    this.name = name;
+    this.port = port;
+    this.connectionTimeout = timeout;
+    this.soTimeout = timeout;
+    this.ssl = ssl;
+    this.sslSocketFactory = sslSocketFactory;
+    this.sslParameters = sslParameters;
+    this.hostnameVerifier = hostnameVerifier;
   }
 
   public JedisShardInfo(URI uri) {
@@ -93,6 +219,25 @@ public class JedisShardInfo extends ShardInfo<Jedis> {
     this.port = uri.getPort();
     this.password = JedisURIHelper.getPassword(uri);
     this.db = JedisURIHelper.getDBIndex(uri);
+    this.ssl = uri.getScheme().equals("rediss");
+  }
+
+  public JedisShardInfo(URI uri, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
+      HostnameVerifier hostnameVerifier) {
+    super(Sharded.DEFAULT_WEIGHT);
+    if (!JedisURIHelper.isValid(uri)) {
+      throw new InvalidURIException(String.format(
+        "Cannot open Redis connection due invalid URI. %s", uri.toString()));
+    }
+
+    this.host = uri.getHost();
+    this.port = uri.getPort();
+    this.password = JedisURIHelper.getPassword(uri);
+    this.db = JedisURIHelper.getDBIndex(uri);
+    this.ssl = uri.getScheme().equals("rediss");
+    this.sslSocketFactory = sslSocketFactory;
+    this.sslParameters = sslParameters;
+    this.hostnameVerifier = hostnameVerifier;
   }
 
   public String getPassword() {
@@ -126,6 +271,22 @@ public class JedisShardInfo extends ShardInfo<Jedis> {
 
   public int getDb() {
     return db;
+  }
+
+  public boolean getSsl() {
+      return ssl;
+  }
+
+  public SSLSocketFactory getSslSocketFactory() {
+    return sslSocketFactory;
+  }
+
+  public SSLParameters getSslParameters() {
+    return sslParameters;
+  }
+
+  public HostnameVerifier getHostnameVerifier() {
+    return hostnameVerifier;
   }
 
   @Override


### PR DESCRIPTION
This pull request provides support for SSL/TLS with the option to specify an SSLSocketFactory, SSLParameters, and HostnameVerifier.

I am essentially resuscitating the content from the pull request submitted by RedisLabs (https://github.com/xetorthio/jedis/pull/611/files). The majority of the credit for these changes belongs to them. For my part, I added the ability for the user to explicitly set an SSLSocketFactory, SSLParameters, and HostnameVerifier which should alleviate any concerns about missing or sub-optimal hostname verification when using either Java 6 or 7.

I have tested this with the Azure's Redis cache service.