### PR TITLE
fix zrevrangeByLex in BinaryJedisCluster

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -1188,7 +1188,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
     return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
-        return connection.zrangeByLex(key, max, min);
+        return connection.zrevrangeByLex(key, max, min);
       }
     }.runBinary(key);
   }


### PR DESCRIPTION
zvrangeByLex  should be zrevrangeByLex in BinaryJedisCluster ， here is a mistaken