### PR TITLE
Pool IO buffers

### DIFF
--- a/src/main/java/redis/clients/util/BufferPool.java
+++ b/src/main/java/redis/clients/util/BufferPool.java
@@ -1,0 +1,79 @@
+package redis.clients.util;
+
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+
+public class BufferPool {
+  private static final class BufferFactory extends BasePooledObjectFactory<byte[]> {
+    static final BufferFactory INSTANCE = new BufferFactory();
+
+    @Override
+    public byte[] create() {
+      return new byte[pooled_buffer_size];
+    }
+
+    @Override
+    public PooledObject<byte[]> wrap(byte[] obj) {
+      return new DefaultPooledObject<byte[]>(obj);
+    }
+
+    @Override
+    public boolean validateObject(PooledObject<byte[]> p) {
+      return p.getObject().length == pooled_buffer_size;
+    }
+  }
+
+  private BufferPool() {
+  }
+
+  /**
+   * @param newSize. Set to a negative value to disable buffer pooling
+   */
+  public static void setPooledBufferSize(final int newSize) {
+    if (pooled_buffer_size != newSize) {
+      buffer_pool.clear();
+      pooled_buffer_size = newSize;
+    }
+  }
+
+  public static int getPooledBufferSize() {
+    return pooled_buffer_size;
+  }
+
+  /**
+   * Application-wide setting
+   */
+  private static int pooled_buffer_size = IOUtils.DEFAULT_BUFFER_SIZE;
+  private static GenericObjectPool<byte[]> buffer_pool = new GenericObjectPool<byte[]>(
+      BufferFactory.INSTANCE);
+
+  static {
+    buffer_pool.setMinIdle(0);
+    buffer_pool.setMaxWaitMillis(0L);
+    buffer_pool.setTestOnBorrow(true); // pooled_buffer_size may have changed in between
+    buffer_pool.setTestOnReturn(false);
+    buffer_pool.setTestOnCreate(false);
+    buffer_pool.setTestWhileIdle(false);
+  }
+
+  public static byte[] obtainBuffer(int size) {
+    if (size == pooled_buffer_size) {
+      try {
+        return buffer_pool.borrowObject();
+      } catch (Exception e) {
+      }
+    }
+    return new byte[size];
+  }
+
+  public static void returnBuffer(byte[] buf) {
+    if (buf.length == pooled_buffer_size) {
+      try {
+        buffer_pool.returnObject(buf);
+      } catch (Exception e) {
+      }
+    }
+  }
+}

--- a/src/main/java/redis/clients/util/IOUtils.java
+++ b/src/main/java/redis/clients/util/IOUtils.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.net.Socket;
 
 public class IOUtils {
+  public static final int DEFAULT_BUFFER_SIZE = 8192;
+
   private IOUtils() {
   }
 

--- a/src/main/java/redis/clients/util/RedisOutputStream.java
+++ b/src/main/java/redis/clients/util/RedisOutputStream.java
@@ -15,7 +15,7 @@ public final class RedisOutputStream extends FilterOutputStream {
   protected int count;
 
   public RedisOutputStream(final OutputStream out) {
-    this(out, 8192);
+    this(out, IOUtils.DEFAULT_BUFFER_SIZE);
   }
 
   public RedisOutputStream(final OutputStream out, final int size) {
@@ -23,7 +23,7 @@ public final class RedisOutputStream extends FilterOutputStream {
     if (size <= 0) {
       throw new IllegalArgumentException("Buffer size <= 0");
     }
-    buf = new byte[size];
+    buf = BufferPool.obtainBuffer(size);
   }
 
   private void flushBuffer() throws IOException {
@@ -212,5 +212,11 @@ public final class RedisOutputStream extends FilterOutputStream {
   public void flush() throws IOException {
     flushBuffer();
     out.flush();
+  }
+
+  @Override
+  protected void finalize() throws Throwable {
+    BufferPool.returnBuffer(buf);
+    super.finalize();
   }
 }

--- a/src/test/java/redis/clients/jedis/tests/ProtocolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ProtocolTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import org.junit.Test;
 
 import redis.clients.jedis.Protocol;
+import redis.clients.util.IOUtils;
 import redis.clients.util.RedisInputStream;
 import redis.clients.util.RedisOutputStream;
 import redis.clients.util.SafeEncoder;
@@ -50,7 +51,7 @@ public class ProtocolTest extends JedisTestBase {
       }
     });
 
-    ros.write(new byte[8191]);
+    ros.write(new byte[IOUtils.DEFAULT_BUFFER_SIZE - 1]);
 
     try {
       ros.write((byte) '*');


### PR DESCRIPTION
This is a simple implementation that enables pooling the byte buffers used in Jedis IO filtered stream classes. It is non intrusive and easy to disable, yet should improve memory allocation pressure on large applications.

*to use* : nothing special to do by default. If you use a custom buffer size, call `BufferPool.setPooledBufferSize` with this buffer size.
*to completely disable* : call `BufferPool.setPooledBufferSize(-1)`