### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -2442,7 +2442,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   private Set<Tuple> getBinaryTupledSet() {
     checkIsInMultiOrPipeline();
     List<byte[]> membersWithScores = client.getBinaryMultiBulkReply();
-    if (membersWithScores.size() == 0) {
+    if (membersWithScores.isEmpty()) {
       return Collections.emptySet();
     }
     Set<Tuple> set = new LinkedHashSet<Tuple>(membersWithScores.size() / 2, 1.0f);

--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -382,7 +382,7 @@ public class BuilderFactory {
       } else {
         List<Object> objectList = (List<Object>) data;
 
-        if (objectList.size() == 0) {
+        if (objectList.isEmpty()) {
           return new ArrayList<GeoRadiusResponse>();
         }
 

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -2249,7 +2249,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     if (membersWithScores == null) {
       return null;
     }
-    if (membersWithScores.size() == 0) {
+    if (membersWithScores.isEmpty()) {
       return Collections.emptySet();
     }
     Set<Tuple> set = new LinkedHashSet<Tuple>(membersWithScores.size() / 2, 1.0f);

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -82,7 +82,7 @@ public class JedisClusterInfoCache {
 
         // hostInfos
         List<Object> hostInfos = (List<Object>) slotInfo.get(2);
-        if (hostInfos.size() <= 0) {
+        if (hostInfos.isEmpty()) {
           continue;
         }
 

--- a/src/main/java/redis/clients/jedis/Queable.java
+++ b/src/main/java/redis/clients/jedis/Queable.java
@@ -25,7 +25,7 @@ public class Queable {
   }
 
   protected boolean hasPipelinedResponse() {
-    return pipelinedResponses.size() > 0;
+    return !pipelinedResponses.isEmpty();
   }
 
   protected int getPipelinedResponseLength() {

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelTest.java
@@ -61,7 +61,7 @@ public class JedisSentinelTest extends JedisTestBase {
       assertEquals(master, masterFromSentinel);
 
       List<Map<String, String>> slaves = j.sentinelSlaves(MASTER_NAME);
-      assertTrue(slaves.size() > 0);
+      assertTrue(!slaves.isEmpty());
       assertEquals(master.getPort(), Integer.parseInt(slaves.get(0).get("master-port")));
 
       // DO NOT RE-RUN TEST TOO FAST, RESET TAKES SOME TIME TO... RESET

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
@@ -137,7 +137,7 @@ public class ClusterCommandsTest extends JedisTestBase {
 
     List<Object> slots = node1.clusterSlots();
     assertNotNull(slots);
-    assertTrue(slots.size() > 0);
+    assertTrue(!slots.isEmpty());
 
     for (Object slotInfoObj : slots) {
       List<Object> slotInfo = (List<Object>) slotInfoObj;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155
- Collection.isEmpty() should be used to test for emptiness
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155
Please let me know if you have any questions.
M-Ezzat