### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expression…

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -762,7 +762,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     checkIsInMultiOrPipeline();
     client.incrByFloat(key, integer);
     String dval = client.getBulkReply();
-    return (dval != null ? new Double(dval) : null);
+    return dval != null ? new Double(dval) : null;
   }
 
   /**
@@ -961,7 +961,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     checkIsInMultiOrPipeline();
     client.hincrByFloat(key, field, value);
     final String dval = client.getBulkReply();
-    return (dval != null ? new Double(dval) : null);
+    return dval != null ? new Double(dval) : null;
   }
 
   /**
@@ -1790,7 +1790,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     checkIsInMultiOrPipeline();
     client.zscore(key, member);
     final String score = client.getBulkReply();
-    return (score != null ? new Double(score) : null);
+    return score != null ? new Double(score) : null;
   }
 
   public Transaction multi() {
@@ -3551,7 +3551,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     checkIsInMultiOrPipeline();
     client.geodist(key, member1, member2);
     String dval = client.getBulkReply();
-    return (dval != null ? new Double(dval) : null);
+    return dval != null ? new Double(dval) : null;
   }
 
   @Override
@@ -3559,7 +3559,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     checkIsInMultiOrPipeline();
     client.geodist(key, member1, member2, unit);
     String dval = client.getBulkReply();
-    return (dval != null ? new Double(dval) : null);
+    return dval != null ? new Double(dval) : null;
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -37,7 +37,7 @@ public class BuilderFactory {
   public static final Builder<byte[]> BYTE_ARRAY = new Builder<byte[]>() {
     @Override
     public byte[] build(Object data) {
-      return ((byte[]) data); // deleted == 1
+      return (byte[]) data; // deleted == 1
     }
 
     public String toString() {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -603,7 +603,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     checkIsInMultiOrPipeline();
     client.incrByFloat(key, value);
     String dval = client.getBulkReply();
-    return (dval != null ? new Double(dval) : null);
+    return dval != null ? new Double(dval) : null;
   }
 
   /**
@@ -802,7 +802,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     checkIsInMultiOrPipeline();
     client.hincrByFloat(key, field, value);
     final String dval = client.getBulkReply();
-    return (dval != null ? new Double(dval) : null);
+    return dval != null ? new Double(dval) : null;
   }
 
   /**
@@ -1648,7 +1648,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     checkIsInMultiOrPipeline();
     client.zscore(key, member);
     final String score = client.getBulkReply();
-    return (score != null ? new Double(score) : null);
+    return score != null ? new Double(score) : null;
   }
 
   @Override
@@ -3507,7 +3507,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     checkIsInMultiOrPipeline();
     client.geodist(key, member1, member2);
     String dval = client.getBulkReply();
-    return (dval != null ? new Double(dval) : null);
+    return dval != null ? new Double(dval) : null;
   }
 
   @Override
@@ -3515,7 +3515,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     checkIsInMultiOrPipeline();
     client.geodist(key, member1, member2, unit);
     String dval = client.getBulkReply();
-    return (dval != null ? new Double(dval) : null);
+    return dval != null ? new Double(dval) : null;
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -216,7 +216,7 @@ public class JedisPool extends JedisPoolAbstract {
       final int connectionTimeout, final int soTimeout, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     super(poolConfig, new JedisFactory(uri, connectionTimeout, soTimeout, null,
-        (uri.getScheme() !=null && uri.getScheme().equals("rediss")), sslSocketFactory,
+        uri.getScheme() !=null && uri.getScheme().equals("rediss"), sslSocketFactory,
         sslParameters, hostnameVerifier));
   }
 

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -169,7 +169,7 @@ public final class Protocol {
     final byte[] read = new byte[len];
     int offset = 0;
     while (offset < len) {
-      final int size = is.read(read, offset, (len - offset));
+      final int size = is.read(read, offset, len - offset);
       if (size == -1) throw new JedisConnectionException(
           "It seems like server has closed the connection.");
       offset += size;

--- a/src/main/java/redis/clients/util/JedisClusterCRC16.java
+++ b/src/main/java/redis/clients/util/JedisClusterCRC16.java
@@ -75,7 +75,7 @@ public class JedisClusterCRC16 {
     int crc = 0x0000;
 
     for (int i = s; i < e; i++) {
-      crc = ((crc << 8) ^ LOOKUP_TABLE[((crc >>> 8) ^ (bytes[i] & 0xFF)) & 0xFF]);
+      crc = (crc << 8) ^ LOOKUP_TABLE[((crc >>> 8) ^ (bytes[i] & 0xFF)) & 0xFF];
     }
     return crc & 0xFFFF;
   }

--- a/src/main/java/redis/clients/util/RedisInputStream.java
+++ b/src/main/java/redis/clients/util/RedisInputStream.java
@@ -173,7 +173,7 @@ public class RedisInputStream extends FilterInputStream {
       }
     }
 
-    return (isNeg ? -value : value);
+    return isNeg ? -value : value;
   }
 
   public int read(byte[] b, int off, int len) throws JedisConnectionException {

--- a/src/main/java/redis/clients/util/RedisOutputStream.java
+++ b/src/main/java/redis/clients/util/RedisOutputStream.java
@@ -133,17 +133,17 @@ public final class RedisOutputStream extends FilterOutputStream {
           flushBuffer();
         }
         int uc = Character.toCodePoint(c, str.charAt(i++));
-        buf[count++] = ((byte) (0xf0 | ((uc >> 18))));
-        buf[count++] = ((byte) (0x80 | ((uc >> 12) & 0x3f)));
-        buf[count++] = ((byte) (0x80 | ((uc >> 6) & 0x3f)));
-        buf[count++] = ((byte) (0x80 | (uc & 0x3f)));
+        buf[count++] = (byte) (0xf0 | (uc >> 18));
+        buf[count++] = (byte) (0x80 | ((uc >> 12) & 0x3f));
+        buf[count++] = (byte) (0x80 | ((uc >> 6) & 0x3f));
+        buf[count++] = (byte) (0x80 | (uc & 0x3f));
       } else {
         if (3 >= buf.length - count) {
           flushBuffer();
         }
-        buf[count++] = ((byte) (0xe0 | ((c >> 12))));
-        buf[count++] = ((byte) (0x80 | ((c >> 6) & 0x3f)));
-        buf[count++] = ((byte) (0x80 | (c & 0x3f)));
+        buf[count++] = (byte) (0xe0 | (c >> 12));
+        buf[count++] = (byte) (0x80 | ((c >> 6) & 0x3f));
+        buf[count++] = (byte) (0x80 | (c & 0x3f));
       }
     }
 

--- a/src/test/java/redis/clients/jedis/tests/benchmark/ProtocolBenchmark.java
+++ b/src/test/java/redis/clients/jedis/tests/benchmark/ProtocolBenchmark.java
@@ -20,7 +20,7 @@ public class ProtocolBenchmark {
     long total = 0;
     for (int at = 0; at != 10; ++at) {
       long elapsed = measureInputMulti();
-      long ops = ((1000 * 2 * TOTAL_OPERATIONS) / TimeUnit.NANOSECONDS.toMillis(elapsed));
+      long ops = (1000 * 2 * TOTAL_OPERATIONS) / TimeUnit.NANOSECONDS.toMillis(elapsed);
       if (at >= 5) {
         total += ops;
       }
@@ -30,7 +30,7 @@ public class ProtocolBenchmark {
     total = 0;
     for (int at = 0; at != 10; ++at) {
       long elapsed = measureInputStatus();
-      long ops = ((1000 * 2 * TOTAL_OPERATIONS) / TimeUnit.NANOSECONDS.toMillis(elapsed));
+      long ops = (1000 * 2 * TOTAL_OPERATIONS) / TimeUnit.NANOSECONDS.toMillis(elapsed);
       if (at >= 5) {
         total += ops;
       }
@@ -41,7 +41,7 @@ public class ProtocolBenchmark {
     total = 0;
     for (int at = 0; at != 10; ++at) {
       long elapsed = measureCommand();
-      long ops = ((1000 * 2 * TOTAL_OPERATIONS) / TimeUnit.NANOSECONDS.toMillis(elapsed));
+      long ops = (1000 * 2 * TOTAL_OPERATIONS) / TimeUnit.NANOSECONDS.toMillis(elapsed);
       if (at >= 5) {
         total += ops;
       }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

M-Ezzat
