### PR TITLE
squid:S2162, squid:S1488 - equals methods should be symmetric and wor…

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -164,9 +164,7 @@ public class BuilderFactory {
       if (null == data) {
         return null;
       }
-      List<byte[]> l = (List<byte[]>) data;
-
-      return l;
+      return (List<byte[]>) data;
     }
 
     public String toString() {

--- a/src/main/java/redis/clients/jedis/GeoCoordinate.java
+++ b/src/main/java/redis/clients/jedis/GeoCoordinate.java
@@ -20,7 +20,7 @@ public class GeoCoordinate {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof GeoCoordinate)) return false;
+    if (this.getClass() != o.getClass()) return false;
 
     GeoCoordinate that = (GeoCoordinate) o;
 

--- a/src/main/java/redis/clients/jedis/HostAndPort.java
+++ b/src/main/java/redis/clients/jedis/HostAndPort.java
@@ -25,7 +25,7 @@ public static final String LOCALHOST_STR = "localhost";
 
   @Override
   public boolean equals(Object obj) {
-    if (obj instanceof HostAndPort) {
+    if (this.getClass() == obj.getClass()) {
       HostAndPort hp = (HostAndPort) obj;
 
       String thisHost = convertHost(host);

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -875,8 +875,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
   public List<String> hvals(final String key) {
     checkIsInMultiOrPipeline();
     client.hvals(key);
-    final List<String> lresult = client.getMultiBulkReply();
-    return lresult;
+    return client.getMultiBulkReply();
   }
 
   /**

--- a/src/main/java/redis/clients/util/Hashing.java
+++ b/src/main/java/redis/clients/util/Hashing.java
@@ -25,9 +25,8 @@ public interface Hashing {
       md5.reset();
       md5.update(key);
       byte[] bKey = md5.digest();
-      long res = ((long) (bKey[3] & 0xFF) << 24) | ((long) (bKey[2] & 0xFF) << 16)
-          | ((long) (bKey[1] & 0xFF) << 8) | (long) (bKey[0] & 0xFF);
-      return res;
+      return ((long) (bKey[3] & 0xFF) << 24) | ((long) (bKey[2] & 0xFF) << 16)
+              | ((long) (bKey[1] & 0xFF) << 8) | (long) (bKey[0] & 0xFF);
     }
   };
 

--- a/src/test/java/redis/clients/jedis/tests/utils/JedisSentinelTestUtil.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/JedisSentinelTestUtil.java
@@ -34,9 +34,8 @@ public class JedisSentinelTestUtil {
     }, "*");
 
     String[] chunks = newmaster.get().split(" ");
-    HostAndPort newMaster = new HostAndPort(chunks[3], Integer.parseInt(chunks[4]));
 
-    return newMaster;
+    return new HostAndPort(chunks[3], Integer.parseInt(chunks[4]));
   }
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S2162 - "equals" methods should be symmetric and work for subclasses
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1939
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1488

Please let me know if you have any questions.

M-Ezzat
