### PR TITLE
Disable JMX of GenericObjectPoolConfig for speed

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -39,6 +39,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int timeout, int maxRedirections,
       final GenericObjectPoolConfig poolConfig) {
+    poolConfig.setJmxEnabled(false);
     this.connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
         timeout);
     this.maxRedirections = maxRedirections;
@@ -46,6 +47,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout,
       int soTimeout, int maxRedirections, final GenericObjectPoolConfig poolConfig) {
+    poolConfig.setJmxEnabled(false);
     this.connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
         connectionTimeout, soTimeout);
     this.maxRedirections = maxRedirections;


### PR DESCRIPTION
When running 32 threads and every thread has a JedisCluster(), the
program will spend more than 30 seconds to init 32 JedisCluster()
instances.
The reason is in commons-pool-2.4 :

    GenericObjectPool() --> BaseGenericObjectPool() --> jmxRegister()

the jmxRegister() will spend a lot of time to register MBean because
it always use the same Instance name and have to loop many turns.

Because users can't affort minutes to init multi-instances of
JedisCluster(), I suggest to defaultly disable JMX in JedisCluster().