### PR TITLE
Issue #1252: Fix creating a lot of new Jedis instances on unstable cluster, fix slots clearing without filling

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -1,9 +1,6 @@
 package redis.clients.jedis;
 
 import java.io.Closeable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,39 +46,15 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
   }
 
   public void renewSlotCache() {
-    for (JedisPool jp : getShuffledNodesPool()) {
-      Jedis jedis = null;
-      try {
-        jedis = jp.getResource();
-        cache.discoverClusterSlots(jedis);
-        break;
-      } catch (JedisConnectionException e) {
-        // try next nodes
-      } finally {
-        if (jedis != null) {
-          jedis.close();
-        }
-      }
-    }
+    cache.renewClusterSlots(null);
   }
 
   public void renewSlotCache(Jedis jedis) {
-    try {
-      cache.discoverClusterSlots(jedis);
-    } catch (JedisConnectionException e) {
-      renewSlotCache();
-    }
+    cache.renewClusterSlots(jedis);
   }
 
   @Override
   public void close() {
     cache.reset();
-  }
-
-  protected List<JedisPool> getShuffledNodesPool() {
-    List<JedisPool> pools = new ArrayList<JedisPool>();
-    pools.addAll(cache.getNodes().values());
-    Collections.shuffle(pools);
-    return pools;
   }
 }

--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -25,8 +25,7 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
   abstract Jedis getConnectionFromSlot(int slot);
 
   public Jedis getConnectionFromNode(HostAndPort node) {
-    cache.setNodeIfNotExist(node);
-    return cache.getNode(JedisClusterInfoCache.getNodeKey(node)).getResource();
+    return cache.setupNodeIfNotExist(node).getResource();
   }
   
   public Map<String, JedisPool> getNodes() {

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +14,8 @@ import javax.net.ssl.SSLSocketFactory;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.util.SafeEncoder;
 
 public class JedisClusterInfoCache {
@@ -77,44 +80,64 @@ public class JedisClusterInfoCache {
     }
   }
 
-  public void discoverClusterSlots(Jedis jedis) {
+  public void renewClusterSlots(Jedis jedis) {
     //If rediscovering is already in process - no need to start one more same rediscovering, just return
     if (!rediscovering) {
-      w.lock();
-      rediscovering = true;
-
       try {
-        List<Object> slots = jedis.clusterSlots();
+        w.lock();
+        rediscovering = true;
 
-        // We should clear slots after getting result about cluster slots, because if we got exception or timeout in
-        // getting new slots state, which is possible, because it's an external operation - we could got empty slots collection
-        // and ton of new Jedis instances for random nodes, see JedisSlotBasedConnectionHandler#getConnectionFromSlot
-        this.slots.clear();
-
-        for (Object slotInfoObj : slots) {
-          List<Object> slotInfo = (List<Object>) slotInfoObj;
-
-          if (slotInfo.size() <= MASTER_NODE_INDEX) {
-            continue;
+        if (jedis != null) {
+          try {
+            discoverClusterSlots(jedis);
+            return;
+          } catch (JedisException e) {
+            //try nodes from all pools
           }
+        }
 
-          List<Integer> slotNums = getAssignedSlotArray(slotInfo);
-
-          // hostInfos
-          List<Object> hostInfos = (List<Object>) slotInfo.get(MASTER_NODE_INDEX);
-          if (hostInfos.isEmpty()) {
-            continue;
+        for (JedisPool jp : getShuffledNodesPool()) {
+          try {
+            jedis = jp.getResource();
+            discoverClusterSlots(jedis);
+            return;
+          } catch (JedisConnectionException e) {
+            // try next nodes
+          } finally {
+            if (jedis != null) {
+              jedis.close();
+            }
           }
-
-          // at this time, we just use master, discard slave information
-          HostAndPort targetNode = generateHostAndPort(hostInfos);
-
-          assignSlotsToNode(slotNums, targetNode);
         }
       } finally {
         rediscovering = false;
         w.unlock();
       }
+    }
+  }
+
+  private void discoverClusterSlots(Jedis jedis) {
+    List<Object> slots = jedis.clusterSlots();
+    this.slots.clear();
+
+    for (Object slotInfoObj : slots) {
+      List<Object> slotInfo = (List<Object>) slotInfoObj;
+
+      if (slotInfo.size() <= MASTER_NODE_INDEX) {
+        continue;
+      }
+
+      List<Integer> slotNums = getAssignedSlotArray(slotInfo);
+
+      // hostInfos
+      List<Object> hostInfos = (List<Object>) slotInfo.get(MASTER_NODE_INDEX);
+      if (hostInfos.isEmpty()) {
+        continue;
+      }
+
+      // at this time, we just use master, discard slave information
+      HostAndPort targetNode = generateHostAndPort(hostInfos);
+      assignSlotsToNode(slotNums, targetNode);
     }
   }
 
@@ -222,6 +245,17 @@ public class JedisClusterInfoCache {
     }
   }
 
+  public List<JedisPool> getShuffledNodesPool() {
+    r.lock();
+    try {
+      List<JedisPool> pools = new ArrayList<JedisPool>(nodes.values());
+      Collections.shuffle(pools);
+      return pools;
+    } finally {
+      r.unlock();
+    }
+  }
+
   /**
    * Clear discovered nodes collections and gently release allocated resources
    */
@@ -264,5 +298,4 @@ public class JedisClusterInfoCache {
     }
     return slotNums;
   }
-
 }

--- a/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
@@ -61,7 +61,14 @@ public class JedisSlotBasedConnectionHandler extends JedisClusterConnectionHandl
       // assignment
       return connectionPool.getResource();
     } else {
-      return getConnection();
+      renewSlotCache(); //It's abnormal situation for cluster mode, that we have just nothing for slot, try to rediscover state
+      connectionPool = cache.getSlotPool(slot);
+      if (connectionPool != null) {
+        return connectionPool.getResource();
+      } else {
+        //no choice, fallback to new connection to random node
+        return getConnection();
+      }
     }
   }
 }

--- a/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
@@ -27,7 +27,7 @@ public class JedisSlotBasedConnectionHandler extends JedisClusterConnectionHandl
     // ping-pong)
     // or exception if all connections are invalid
 
-    List<JedisPool> pools = getShuffledNodesPool();
+    List<JedisPool> pools = cache.getShuffledNodesPool();
 
     for (JedisPool pool : pools) {
       Jedis jedis = null;


### PR DESCRIPTION
I started to investigate Issue #1252 and PING-PONG counts especially.

The most interesting things I found in stack traces on our runtime:
```
	at redis.clients.jedis.BinaryJedis.ping(BinaryJedis.java:106)
	at redis.clients.jedis.JedisSlotBasedConnectionHandler.getConnection(JedisSlotBasedConnectionHandler.java:41)
	at redis.clients.jedis.JedisSlotBasedConnectionHandler.getConnectionFromSlot(JedisSlotBasedConnectionHandler.java:64)
	at redis.clients.jedis.JedisClusterCommand.runWithRetries(JedisClusterCommand.java:115)
	at redis.clients.jedis.JedisClusterCommand.run(JedisClusterCommand.java:30)
	at redis.clients.jedis.JedisCluster.setex(JedisCluster.java:292)
```

Looks absolutely abnormal - we have nothing for slot and fallback to new Jedis to random node.

Here you can find my changes and fixes for place, that could cause this issue + some refactoring, remove of some duplicate map lookups/keys building.

System behavior before and after applying this changes:
![Before](http://s21.postimg.org/yv429wlzr/2016_04_06_23_01_13.png)
![After](http://s16.postimg.org/w4t1br4gl/2016_04_06_23_01_50.png)