### PR TITLE
Issue #1252: Random node + rediscovery on connection exception replaced with rediscovery at the end

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -26,7 +26,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   protected static final int DEFAULT_TIMEOUT = 2000;
   protected static final int DEFAULT_MAX_REDIRECTIONS = 5;
 
-  protected int maxRedirections;
+  protected int maxAttempts;
 
   protected JedisClusterConnectionHandler connectionHandler;
 
@@ -38,24 +38,24 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
     this(nodes, DEFAULT_TIMEOUT);
   }
 
-  public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int timeout, int maxRedirections,
+  public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int timeout, int maxAttempts,
       final GenericObjectPoolConfig poolConfig) {
     this.connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
         timeout);
-    this.maxRedirections = maxRedirections;
+    this.maxAttempts = maxAttempts;
   }
 
   public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout,
-      int soTimeout, int maxRedirections, final GenericObjectPoolConfig poolConfig) {
+                            int soTimeout, int maxAttempts, final GenericObjectPoolConfig poolConfig) {
     this.connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
         connectionTimeout, soTimeout);
-    this.maxRedirections = maxRedirections;
+    this.maxAttempts = maxAttempts;
   }
 
-  public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout, int maxRedirections, String password, GenericObjectPoolConfig poolConfig) {
+  public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout, int maxAttempts, String password, GenericObjectPoolConfig poolConfig) {
     this.connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
             connectionTimeout, soTimeout, password);
-    this.maxRedirections = maxRedirections;
+    this.maxAttempts = maxAttempts;
   }
 
   @Override
@@ -71,7 +71,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public String set(final byte[] key, final byte[] value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.set(key, value);
@@ -81,7 +81,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public String set(final byte[] key, final byte[] value, final SetParams params) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.set(key, value, params);
@@ -91,7 +91,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public byte[] get(final byte[] key) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.get(key);
@@ -101,7 +101,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long exists(final byte[]... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.exists(keys);
@@ -111,7 +111,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Boolean exists(final byte[] key) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.exists(key);
@@ -121,7 +121,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long persist(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.persist(key);
@@ -131,7 +131,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public String type(final byte[] key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.type(key);
@@ -141,7 +141,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long expire(final byte[] key, final int seconds) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.expire(key, seconds);
@@ -151,7 +151,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long pexpire(final byte[] key, final long milliseconds) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pexpire(key, milliseconds);
@@ -161,7 +161,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long expireAt(final byte[] key, final long unixTime) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.expireAt(key, unixTime);
@@ -171,7 +171,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long pexpireAt(final byte[] key, final long millisecondsTimestamp) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pexpire(key, millisecondsTimestamp);
@@ -181,7 +181,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long ttl(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.ttl(key);
@@ -191,7 +191,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Boolean setbit(final byte[] key, final long offset, final boolean value) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.setbit(key, offset, value);
@@ -201,7 +201,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Boolean setbit(final byte[] key, final long offset, final byte[] value) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.setbit(key, offset, value);
@@ -211,7 +211,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Boolean getbit(final byte[] key, final long offset) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.getbit(key, offset);
@@ -221,7 +221,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long setrange(final byte[] key, final long offset, final byte[] value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.setrange(key, offset, value);
@@ -231,7 +231,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public byte[] getrange(final byte[] key, final long startOffset, final long endOffset) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.getrange(key, startOffset, endOffset);
@@ -241,7 +241,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public byte[] getSet(final byte[] key, final byte[] value) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.getSet(key, value);
@@ -251,7 +251,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long setnx(final byte[] key, final byte[] value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.setnx(key, value);
@@ -261,7 +261,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public String setex(final byte[] key, final int seconds, final byte[] value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.setex(key, seconds, value);
@@ -271,7 +271,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long decrBy(final byte[] key, final long integer) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.decrBy(key, integer);
@@ -281,7 +281,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long decr(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.decr(key);
@@ -291,7 +291,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long incrBy(final byte[] key, final long integer) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.incrBy(key, integer);
@@ -301,7 +301,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Double incrByFloat(final byte[] key, final double value) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
       @Override
       public Double execute(Jedis connection) {
         return connection.incrByFloat(key, value);
@@ -311,7 +311,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long incr(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.incr(key);
@@ -321,7 +321,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long append(final byte[] key, final byte[] value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.append(key, value);
@@ -331,7 +331,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public byte[] substr(final byte[] key, final int start, final int end) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.substr(key, start, end);
@@ -341,7 +341,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long hset(final byte[] key, final byte[] field, final byte[] value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hset(key, field, value);
@@ -351,7 +351,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public byte[] hget(final byte[] key, final byte[] field) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.hget(key, field);
@@ -361,7 +361,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long hsetnx(final byte[] key, final byte[] field, final byte[] value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hsetnx(key, field, value);
@@ -371,7 +371,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public String hmset(final byte[] key, final Map<byte[], byte[]> hash) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.hmset(key, hash);
@@ -381,7 +381,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public List<byte[]> hmget(final byte[] key, final byte[]... fields) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public List<byte[]> execute(Jedis connection) {
         return connection.hmget(key, fields);
@@ -391,7 +391,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long hincrBy(final byte[] key, final byte[] field, final long value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hincrBy(key, field, value);
@@ -401,7 +401,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Double hincrByFloat(final byte[] key, final byte[] field, final double value) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
       @Override
       public Double execute(Jedis connection) {
         return connection.hincrByFloat(key, field, value);
@@ -411,7 +411,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Boolean hexists(final byte[] key, final byte[] field) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.hexists(key, field);
@@ -421,7 +421,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long hdel(final byte[] key, final byte[]... field) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hdel(key, field);
@@ -431,7 +431,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long hlen(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hlen(key);
@@ -441,7 +441,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<byte[]> hkeys(final byte[] key) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.hkeys(key);
@@ -451,7 +451,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Collection<byte[]> hvals(final byte[] key) {
-    return new JedisClusterCommand<Collection<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Collection<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Collection<byte[]> execute(Jedis connection) {
         return connection.hvals(key);
@@ -461,7 +461,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Map<byte[], byte[]> hgetAll(final byte[] key) {
-    return new JedisClusterCommand<Map<byte[], byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Map<byte[], byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Map<byte[], byte[]> execute(Jedis connection) {
         return connection.hgetAll(key);
@@ -471,7 +471,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long rpush(final byte[] key, final byte[]... args) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.rpush(key, args);
@@ -481,7 +481,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long lpush(final byte[] key, final byte[]... args) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lpush(key, args);
@@ -491,7 +491,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long llen(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.llen(key);
@@ -501,7 +501,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public List<byte[]> lrange(final byte[] key, final long start, final long end) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public List<byte[]> execute(Jedis connection) {
         return connection.lrange(key, start, end);
@@ -511,7 +511,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public String ltrim(final byte[] key, final long start, final long end) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.ltrim(key, start, end);
@@ -521,7 +521,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public byte[] lindex(final byte[] key, final long index) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.lindex(key, index);
@@ -531,7 +531,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public String lset(final byte[] key, final long index, final byte[] value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.lset(key, index, value);
@@ -541,7 +541,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long lrem(final byte[] key, final long count, final byte[] value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lrem(key, count, value);
@@ -551,7 +551,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public byte[] lpop(final byte[] key) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.lpop(key);
@@ -561,7 +561,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public byte[] rpop(final byte[] key) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.rpop(key);
@@ -571,7 +571,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long sadd(final byte[] key, final byte[]... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sadd(key, member);
@@ -581,7 +581,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<byte[]> smembers(final byte[] key) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.smembers(key);
@@ -591,7 +591,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long srem(final byte[] key, final byte[]... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.srem(key, member);
@@ -601,7 +601,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public byte[] spop(final byte[] key) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.spop(key);
@@ -611,7 +611,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<byte[]> spop(final byte[] key, final long count) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.spop(key, count);
@@ -621,7 +621,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long scard(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.scard(key);
@@ -631,7 +631,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Boolean sismember(final byte[] key, final byte[] member) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.sismember(key, member);
@@ -641,7 +641,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public byte[] srandmember(final byte[] key) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.srandmember(key);
@@ -651,7 +651,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long strlen(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.strlen(key);
@@ -661,7 +661,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long zadd(final byte[] key, final double score, final byte[] member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zadd(key, score, member);
@@ -672,7 +672,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Long zadd(final byte[] key, final double score, final byte[] member,
       final ZAddParams params) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zadd(key, score, member, params);
@@ -682,7 +682,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long zadd(final byte[] key, final Map<byte[], Double> scoreMembers) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zadd(key, scoreMembers);
@@ -692,7 +692,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long zadd(final byte[] key, final Map<byte[], Double> scoreMembers, final ZAddParams params) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zadd(key, scoreMembers, params);
@@ -702,7 +702,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<byte[]> zrange(final byte[] key, final long start, final long end) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.zrange(key, start, end);
@@ -712,7 +712,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long zrem(final byte[] key, final byte[]... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zrem(key, member);
@@ -722,7 +722,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Double zincrby(final byte[] key, final double score, final byte[] member) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
       @Override
       public Double execute(Jedis connection) {
         return connection.zincrby(key, score, member);
@@ -733,7 +733,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Double zincrby(final byte[] key, final double score, final byte[] member,
       final ZIncrByParams params) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
       @Override
       public Double execute(Jedis connection) {
         return connection.zincrby(key, score, member, params);
@@ -743,7 +743,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long zrank(final byte[] key, final byte[] member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zrank(key, member);
@@ -753,7 +753,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long zrevrank(final byte[] key, final byte[] member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zrevrank(key, member);
@@ -763,7 +763,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<byte[]> zrevrange(final byte[] key, final long start, final long end) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.zrevrange(key, start, end);
@@ -773,7 +773,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<Tuple> zrangeWithScores(final byte[] key, final long start, final long end) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeWithScores(key, start, end);
@@ -783,7 +783,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<Tuple> zrevrangeWithScores(final byte[] key, final long start, final long end) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeWithScores(key, start, end);
@@ -793,7 +793,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long zcard(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcard(key);
@@ -803,7 +803,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Double zscore(final byte[] key, final byte[] member) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
       @Override
       public Double execute(Jedis connection) {
         return connection.zscore(key, member);
@@ -813,7 +813,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public List<byte[]> sort(final byte[] key) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public List<byte[]> execute(Jedis connection) {
         return connection.sort(key);
@@ -823,7 +823,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public List<byte[]> sort(final byte[] key, final SortingParams sortingParameters) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public List<byte[]> execute(Jedis connection) {
         return connection.sort(key, sortingParameters);
@@ -833,7 +833,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long zcount(final byte[] key, final double min, final double max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcount(key, min, max);
@@ -843,7 +843,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long zcount(final byte[] key, final byte[] min, final byte[] max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcount(key, min, max);
@@ -853,7 +853,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final double min, final double max) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max);
@@ -863,7 +863,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final byte[] min, final byte[] max) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max);
@@ -873,7 +873,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final double max, final double min) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min);
@@ -884,7 +884,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final double min, final double max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max, offset, count);
@@ -894,7 +894,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final byte[] max, final byte[] min) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min);
@@ -905,7 +905,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final byte[] min, final byte[] max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max, offset, count);
@@ -916,7 +916,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final double max, final double min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min, offset, count);
@@ -926,7 +926,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final double min, final double max) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max);
@@ -936,7 +936,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final double max, final double min) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min);
@@ -947,7 +947,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final double min, final double max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max, offset, count);
@@ -958,7 +958,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final byte[] max, final byte[] min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min, offset, count);
@@ -968,7 +968,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final byte[] min, final byte[] max) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max);
@@ -978,7 +978,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final byte[] max, final byte[] min) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min);
@@ -989,7 +989,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final byte[] min, final byte[] max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max, offset, count);
@@ -1000,7 +1000,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final double max,
       final double min, final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min, offset, count);
@@ -1011,7 +1011,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final byte[] max,
       final byte[] min, final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min, offset, count);
@@ -1021,7 +1021,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long zremrangeByRank(final byte[] key, final long start, final long end) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByRank(key, start, end);
@@ -1031,7 +1031,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long zremrangeByScore(final byte[] key, final double start, final double end) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByScore(key, start, end);
@@ -1041,7 +1041,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long zremrangeByScore(final byte[] key, final byte[] start, final byte[] end) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByScore(key, start, end);
@@ -1052,7 +1052,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Long linsert(final byte[] key, final Client.LIST_POSITION where, final byte[] pivot,
       final byte[] value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.linsert(key, where, pivot, value);
@@ -1062,7 +1062,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long lpushx(final byte[] key, final byte[]... arg) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lpushx(key, arg);
@@ -1072,7 +1072,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long rpushx(final byte[] key, final byte[]... arg) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.rpushx(key, arg);
@@ -1082,7 +1082,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long del(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.del(key);
@@ -1093,7 +1093,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public byte[] echo(final byte[] arg) {
     // note that it'll be run from arbitary node
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.echo(arg);
@@ -1103,7 +1103,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long bitcount(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.bitcount(key);
@@ -1113,7 +1113,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long bitcount(final byte[] key, final long start, final long end) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.bitcount(key, start, end);
@@ -1123,7 +1123,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long pfadd(final byte[] key, final byte[]... elements) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pfadd(key, elements);
@@ -1133,7 +1133,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public long pfcount(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pfcount(key);
@@ -1143,7 +1143,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public List<byte[]> srandmember(final byte[] key, final int count) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public List<byte[]> execute(Jedis connection) {
         return connection.srandmember(key, count);
@@ -1153,7 +1153,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long zlexcount(final byte[] key, final byte[] min, final byte[] max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zlexcount(key, min, max);
@@ -1163,7 +1163,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<byte[]> zrangeByLex(final byte[] key, final byte[] min, final byte[] max) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.zrangeByLex(key, min, max);
@@ -1174,7 +1174,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Set<byte[]> zrangeByLex(final byte[] key, final byte[] min, final byte[] max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.zrangeByLex(key, min, max, offset, count);
@@ -1184,7 +1184,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<byte[]> zrevrangeByLex(final byte[] key, final byte[] max, final byte[] min) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.zrevrangeByLex(key, max, min);
@@ -1195,7 +1195,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Set<byte[]> zrevrangeByLex(final byte[] key, final byte[] max, final byte[] min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.zrevrangeByLex(key, max, min, offset, count);
@@ -1205,7 +1205,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long zremrangeByLex(final byte[] key, final byte[] min, final byte[] max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByLex(key, min, max);
@@ -1215,7 +1215,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Object eval(final byte[] script, final byte[] keyCount, final byte[]... params) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
       @Override
       public Object execute(Jedis connection) {
         return connection.eval(script, keyCount, params);
@@ -1225,7 +1225,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Object eval(final byte[] script, final int keyCount, final byte[]... params) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
       @Override
       public Object execute(Jedis connection) {
         return connection.eval(script, keyCount, params);
@@ -1235,7 +1235,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Object eval(final byte[] script, final List<byte[]> keys, final List<byte[]> args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
       @Override
       public Object execute(Jedis connection) {
         return connection.eval(script, keys, args);
@@ -1245,7 +1245,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Object eval(final byte[] script, byte[] key) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
       @Override
       public Object execute(Jedis connection) {
         return connection.eval(script);
@@ -1255,7 +1255,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Object evalsha(final byte[] script, byte[] key) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
       @Override
       public Object execute(Jedis connection) {
         return connection.evalsha(script);
@@ -1265,7 +1265,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Object evalsha(final byte[] sha1, final List<byte[]> keys, final List<byte[]> args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
       @Override
       public Object execute(Jedis connection) {
         return connection.evalsha(sha1, keys, args);
@@ -1275,7 +1275,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Object evalsha(final byte[] sha1, final int keyCount, final byte[]... params) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
       @Override
       public Object execute(Jedis connection) {
         return connection.evalsha(sha1, keyCount, params);
@@ -1285,7 +1285,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public List<Long> scriptExists(final byte[] key, final byte[][] sha1) {
-    return new JedisClusterCommand<List<Long>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts) {
       @Override
       public List<Long> execute(Jedis connection) {
         return connection.scriptExists(sha1);
@@ -1295,7 +1295,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public byte[] scriptLoad(final byte[] script, final byte[] key) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.scriptLoad(script);
@@ -1305,7 +1305,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public String scriptFlush(final byte[] key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.scriptFlush();
@@ -1315,7 +1315,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public String scriptKill(byte[] key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.scriptKill();
@@ -1325,7 +1325,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long del(final byte[]... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.del(keys);
@@ -1335,7 +1335,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public List<byte[]> blpop(final int timeout, final byte[]... keys) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public List<byte[]> execute(Jedis connection) {
         return connection.blpop(timeout, keys);
@@ -1345,7 +1345,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public List<byte[]> brpop(final int timeout, final byte[]... keys) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public List<byte[]> execute(Jedis connection) {
         return connection.brpop(timeout, keys);
@@ -1355,7 +1355,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public List<byte[]> mget(final byte[]... keys) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public List<byte[]> execute(Jedis connection) {
         return connection.mget(keys);
@@ -1371,7 +1371,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
       keys[keyIdx] = keysvalues[keyIdx * 2];
     }
 
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.mset(keysvalues);
@@ -1387,7 +1387,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
       keys[keyIdx] = keysvalues[keyIdx * 2];
     }
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.msetnx(keysvalues);
@@ -1397,7 +1397,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public String rename(final byte[] oldkey, final byte[] newkey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.rename(oldkey, newkey);
@@ -1407,7 +1407,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long renamenx(final byte[] oldkey, final byte[] newkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.renamenx(oldkey, newkey);
@@ -1417,7 +1417,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public byte[] rpoplpush(final byte[] srckey, final byte[] dstkey) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.rpoplpush(srckey, dstkey);
@@ -1427,7 +1427,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<byte[]> sdiff(final byte[]... keys) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.sdiff(keys);
@@ -1439,7 +1439,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   public Long sdiffstore(final byte[] dstkey, final byte[]... keys) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sdiffstore(dstkey, keys);
@@ -1449,7 +1449,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<byte[]> sinter(final byte[]... keys) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.sinter(keys);
@@ -1461,7 +1461,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   public Long sinterstore(final byte[] dstkey, final byte[]... keys) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sinterstore(dstkey, keys);
@@ -1471,7 +1471,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long smove(final byte[] srckey, final byte[] dstkey, final byte[] member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.smove(srckey, dstkey, member);
@@ -1481,7 +1481,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long sort(final byte[] key, final SortingParams sortingParameters, final byte[] dstkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sort(key, sortingParameters, dstkey);
@@ -1491,7 +1491,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long sort(final byte[] key, final byte[] dstkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sort(key, dstkey);
@@ -1501,7 +1501,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Set<byte[]> sunion(final byte[]... keys) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public Set<byte[]> execute(Jedis connection) {
         return connection.sunion(keys);
@@ -1513,7 +1513,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   public Long sunionstore(final byte[] dstkey, final byte[]... keys) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sunionstore(dstkey, keys);
@@ -1525,7 +1525,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   public Long zinterstore(final byte[] dstkey, final byte[]... sets) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zinterstore(dstkey, sets);
@@ -1537,7 +1537,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   public Long zinterstore(final byte[] dstkey, final ZParams params, final byte[]... sets) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zinterstore(dstkey, params, sets);
@@ -1549,7 +1549,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   public Long zunionstore(final byte[] dstkey, final byte[]... sets) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zunionstore(dstkey, sets);
@@ -1561,7 +1561,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   public Long zunionstore(final byte[] dstkey, final ZParams params, final byte[]... sets) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zunionstore(dstkey, params, sets);
@@ -1571,7 +1571,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public byte[] brpoplpush(final byte[] source, final byte[] destination, final int timeout) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.brpoplpush(source, destination, timeout);
@@ -1581,7 +1581,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long publish(final byte[] channel, final byte[] message) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.publish(channel, message);
@@ -1591,7 +1591,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public void subscribe(final BinaryJedisPubSub jedisPubSub, final byte[]... channels) {
-    new JedisClusterCommand<Integer>(connectionHandler, maxRedirections) {
+    new JedisClusterCommand<Integer>(connectionHandler, maxAttempts) {
       @Override
       public Integer execute(Jedis connection) {
         connection.subscribe(jedisPubSub, channels);
@@ -1602,7 +1602,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public void psubscribe(final BinaryJedisPubSub jedisPubSub, final byte[]... patterns) {
-    new JedisClusterCommand<Integer>(connectionHandler, maxRedirections) {
+    new JedisClusterCommand<Integer>(connectionHandler, maxAttempts) {
       @Override
       public Integer execute(Jedis connection) {
         connection.psubscribe(jedisPubSub, patterns);
@@ -1615,7 +1615,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   public Long bitop(final BitOP op, final byte[] destKey, final byte[]... srcKeys) {
     byte[][] wholeKeys = KeyMergeUtil.merge(destKey, srcKeys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.bitop(op, destKey, srcKeys);
@@ -1627,7 +1627,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   public String pfmerge(final byte[] destkey, final byte[]... sourcekeys) {
     byte[][] wholeKeys = KeyMergeUtil.merge(destkey, sourcekeys);
 
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.pfmerge(destkey, sourcekeys);
@@ -1637,7 +1637,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long pfcount(final byte[]... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pfcount(keys);
@@ -1648,7 +1648,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Long geoadd(final byte[] key, final double longitude, final double latitude,
       final byte[] member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.geoadd(key, longitude, latitude, member);
@@ -1658,7 +1658,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Long geoadd(final byte[] key, final Map<byte[], GeoCoordinate> memberCoordinateMap) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.geoadd(key, memberCoordinateMap);
@@ -1668,7 +1668,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public Double geodist(final byte[] key, final byte[] member1, final byte[] member2) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
       @Override
       public Double execute(Jedis connection) {
         return connection.geodist(key, member1, member2);
@@ -1679,7 +1679,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public Double geodist(final byte[] key, final byte[] member1, final byte[] member2,
       final GeoUnit unit) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
       @Override
       public Double execute(Jedis connection) {
         return connection.geodist(key, member1, member2, unit);
@@ -1689,7 +1689,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public List<byte[]> geohash(final byte[] key, final byte[]... members) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public List<byte[]> execute(Jedis connection) {
         return connection.geohash(key, members);
@@ -1699,7 +1699,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public List<GeoCoordinate> geopos(final byte[] key, final byte[]... members) {
-    return new JedisClusterCommand<List<GeoCoordinate>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<GeoCoordinate>>(connectionHandler, maxAttempts) {
       @Override
       public List<GeoCoordinate> execute(Jedis connection) {
         return connection.geopos(key, members);
@@ -1710,7 +1710,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public List<GeoRadiusResponse> georadius(final byte[] key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadius(key, longitude, latitude, radius, unit);
@@ -1721,7 +1721,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public List<GeoRadiusResponse> georadius(final byte[] key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadius(key, longitude, latitude, radius, unit, param);
@@ -1732,7 +1732,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public List<GeoRadiusResponse> georadiusByMember(final byte[] key, final byte[] member,
       final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadiusByMember(key, member, radius, unit);
@@ -1743,7 +1743,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public List<GeoRadiusResponse> georadiusByMember(final byte[] key, final byte[] member,
       final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadiusByMember(key, member, radius, unit, param);
@@ -1763,7 +1763,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
     if (JedisClusterHashTagUtil.isClusterCompliantMatchPattern(matchPattern)) {
 
       return new JedisClusterCommand< ScanResult<byte[]>>(connectionHandler,
-              maxRedirections) {
+                                                          maxAttempts) {
         @Override
         public ScanResult<byte[]> execute(Jedis connection) {
           return connection.scan(cursor, params);
@@ -1777,7 +1777,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   @Override
   public ScanResult<Map.Entry<byte[], byte[]>> hscan(final byte[] key, final byte[] cursor) {
     return new JedisClusterCommand<ScanResult<Map.Entry<byte[], byte[]>>>(connectionHandler,
-        maxRedirections) {
+                                                                          maxAttempts) {
       @Override
       public ScanResult<Map.Entry<byte[], byte[]>> execute(Jedis connection) {
         return connection.hscan(key, cursor);
@@ -1789,7 +1789,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   public ScanResult<Map.Entry<byte[], byte[]>> hscan(final byte[] key, final byte[] cursor,
       final ScanParams params) {
     return new JedisClusterCommand<ScanResult<Map.Entry<byte[], byte[]>>>(connectionHandler,
-        maxRedirections) {
+                                                                          maxAttempts) {
       @Override
       public ScanResult<Map.Entry<byte[], byte[]>> execute(Jedis connection) {
         return connection.hscan(key, cursor, params);
@@ -1799,7 +1799,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public ScanResult<byte[]> sscan(final byte[] key, final byte[] cursor) {
-    return new JedisClusterCommand<ScanResult<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<ScanResult<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public ScanResult<byte[]> execute(Jedis connection) {
         return connection.sscan(key, cursor);
@@ -1809,7 +1809,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public ScanResult<byte[]> sscan(final byte[] key, final byte[] cursor, final ScanParams params) {
-    return new JedisClusterCommand<ScanResult<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<ScanResult<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public ScanResult<byte[]> execute(Jedis connection) {
         return connection.sscan(key, cursor, params);
@@ -1819,7 +1819,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public ScanResult<Tuple> zscan(final byte[] key, final byte[] cursor) {
-    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public ScanResult<Tuple> execute(Jedis connection) {
         return connection.zscan(key, cursor);
@@ -1829,7 +1829,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public ScanResult<Tuple> zscan(final byte[] key, final byte[] cursor, final ScanParams params) {
-    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public ScanResult<Tuple> execute(Jedis connection) {
         return connection.zscan(key, cursor, params);
@@ -1839,7 +1839,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public List<byte[]> bitfield(final byte[] key, final byte[]... arguments) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
       @Override
       public List<byte[]> execute(Jedis connection) {
         return connection.bitfield(key, arguments);

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -35,8 +35,8 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
     this(Collections.singleton(node), timeout, DEFAULT_MAX_REDIRECTIONS);
   }
 
-  public JedisCluster(HostAndPort node, int timeout, int maxRedirections) {
-    this(Collections.singleton(node), timeout, maxRedirections, new GenericObjectPoolConfig());
+  public JedisCluster(HostAndPort node, int timeout, int maxAttempts) {
+    this(Collections.singleton(node), timeout, maxAttempts, new GenericObjectPoolConfig());
   }
 
   public JedisCluster(HostAndPort node, final GenericObjectPoolConfig poolConfig) {
@@ -47,19 +47,19 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
     this(Collections.singleton(node), timeout, DEFAULT_MAX_REDIRECTIONS, poolConfig);
   }
 
-  public JedisCluster(HostAndPort node, int timeout, int maxRedirections,
+  public JedisCluster(HostAndPort node, int timeout, int maxAttempts,
       final GenericObjectPoolConfig poolConfig) {
-    this(Collections.singleton(node), timeout, maxRedirections, poolConfig);
+    this(Collections.singleton(node), timeout, maxAttempts, poolConfig);
   }
 
   public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout,
-      int maxRedirections, final GenericObjectPoolConfig poolConfig) {
-    super(Collections.singleton(node), connectionTimeout, soTimeout, maxRedirections, poolConfig);
+      int maxAttempts, final GenericObjectPoolConfig poolConfig) {
+    super(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, poolConfig);
   }
 
   public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout,
-                      int maxRedirections, String password, final GenericObjectPoolConfig poolConfig) {
-    super(Collections.singleton(node), connectionTimeout, soTimeout, maxRedirections, password, poolConfig);
+                      int maxAttempts, String password, final GenericObjectPoolConfig poolConfig) {
+    super(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, password, poolConfig);
   }
   
   public JedisCluster(Set<HostAndPort> nodes) {
@@ -70,8 +70,8 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
     this(nodes, timeout, DEFAULT_MAX_REDIRECTIONS);
   }
 
-  public JedisCluster(Set<HostAndPort> nodes, int timeout, int maxRedirections) {
-    this(nodes, timeout, maxRedirections, new GenericObjectPoolConfig());
+  public JedisCluster(Set<HostAndPort> nodes, int timeout, int maxAttempts) {
+    this(nodes, timeout, maxAttempts, new GenericObjectPoolConfig());
   }
 
   public JedisCluster(Set<HostAndPort> nodes, final GenericObjectPoolConfig poolConfig) {
@@ -82,24 +82,24 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
     this(nodes, timeout, DEFAULT_MAX_REDIRECTIONS, poolConfig);
   }
 
-  public JedisCluster(Set<HostAndPort> jedisClusterNode, int timeout, int maxRedirections,
+  public JedisCluster(Set<HostAndPort> jedisClusterNode, int timeout, int maxAttempts,
       final GenericObjectPoolConfig poolConfig) {
-    super(jedisClusterNode, timeout, maxRedirections, poolConfig);
+    super(jedisClusterNode, timeout, maxAttempts, poolConfig);
   }
 
   public JedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout,
-      int maxRedirections, final GenericObjectPoolConfig poolConfig) {
-    super(jedisClusterNode, connectionTimeout, soTimeout, maxRedirections, poolConfig);
+      int maxAttempts, final GenericObjectPoolConfig poolConfig) {
+    super(jedisClusterNode, connectionTimeout, soTimeout, maxAttempts, poolConfig);
   }
 
   public JedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout,
-                      int maxRedirections, String password, final GenericObjectPoolConfig poolConfig) {
-    super(jedisClusterNode, connectionTimeout, soTimeout, maxRedirections, password, poolConfig);
+                      int maxAttempts, String password, final GenericObjectPoolConfig poolConfig) {
+    super(jedisClusterNode, connectionTimeout, soTimeout, maxAttempts, password, poolConfig);
   }
 
   @Override
   public String set(final String key, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.set(key, value);
@@ -109,7 +109,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String set(final String key, final String value, final SetParams params) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.set(key, value, params);
@@ -119,7 +119,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String get(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.get(key);
@@ -129,7 +129,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean exists(final String key) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.exists(key);
@@ -139,7 +139,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long exists(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.exists(keys);
@@ -149,7 +149,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long persist(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.persist(key);
@@ -159,7 +159,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String type(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.type(key);
@@ -169,7 +169,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long expire(final String key, final int seconds) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.expire(key, seconds);
@@ -179,7 +179,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long pexpire(final String key, final long milliseconds) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pexpire(key, milliseconds);
@@ -189,7 +189,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long expireAt(final String key, final long unixTime) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.expireAt(key, unixTime);
@@ -199,7 +199,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long pexpireAt(final String key, final long millisecondsTimestamp) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pexpireAt(key, millisecondsTimestamp);
@@ -209,7 +209,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long ttl(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.ttl(key);
@@ -219,7 +219,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean setbit(final String key, final long offset, final boolean value) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.setbit(key, offset, value);
@@ -229,7 +229,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean setbit(final String key, final long offset, final String value) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.setbit(key, offset, value);
@@ -239,7 +239,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean getbit(final String key, final long offset) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.getbit(key, offset);
@@ -249,7 +249,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long setrange(final String key, final long offset, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.setrange(key, offset, value);
@@ -259,7 +259,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String getrange(final String key, final long startOffset, final long endOffset) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.getrange(key, startOffset, endOffset);
@@ -269,7 +269,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String getSet(final String key, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.getSet(key, value);
@@ -279,7 +279,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long setnx(final String key, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.setnx(key, value);
@@ -289,7 +289,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String setex(final String key, final int seconds, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.setex(key, seconds, value);
@@ -299,7 +299,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long decrBy(final String key, final long integer) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.decrBy(key, integer);
@@ -309,7 +309,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long decr(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.decr(key);
@@ -319,7 +319,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long incrBy(final String key, final long integer) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.incrBy(key, integer);
@@ -329,7 +329,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Double incrByFloat(final String key, final double value) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
       @Override
       public Double execute(Jedis connection) {
         return connection.incrByFloat(key, value);
@@ -339,7 +339,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long incr(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.incr(key);
@@ -349,7 +349,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long append(final String key, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.append(key, value);
@@ -359,7 +359,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String substr(final String key, final int start, final int end) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.substr(key, start, end);
@@ -369,7 +369,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long hset(final String key, final String field, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hset(key, field, value);
@@ -379,7 +379,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String hget(final String key, final String field) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.hget(key, field);
@@ -389,7 +389,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long hsetnx(final String key, final String field, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hsetnx(key, field, value);
@@ -399,7 +399,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String hmset(final String key, final Map<String, String> hash) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.hmset(key, hash);
@@ -409,7 +409,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> hmget(final String key, final String... fields) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.hmget(key, fields);
@@ -419,7 +419,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long hincrBy(final String key, final String field, final long value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hincrBy(key, field, value);
@@ -429,7 +429,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean hexists(final String key, final String field) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.hexists(key, field);
@@ -439,7 +439,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long hdel(final String key, final String... field) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hdel(key, field);
@@ -449,7 +449,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long hlen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hlen(key);
@@ -459,7 +459,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> hkeys(final String key) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.hkeys(key);
@@ -469,7 +469,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> hvals(final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.hvals(key);
@@ -479,7 +479,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Map<String, String> hgetAll(final String key) {
-    return new JedisClusterCommand<Map<String, String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Map<String, String>>(connectionHandler, maxAttempts) {
       @Override
       public Map<String, String> execute(Jedis connection) {
         return connection.hgetAll(key);
@@ -489,7 +489,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long rpush(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.rpush(key, string);
@@ -499,7 +499,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long lpush(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lpush(key, string);
@@ -509,7 +509,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long llen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.llen(key);
@@ -519,7 +519,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> lrange(final String key, final long start, final long end) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.lrange(key, start, end);
@@ -529,7 +529,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String ltrim(final String key, final long start, final long end) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.ltrim(key, start, end);
@@ -539,7 +539,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String lindex(final String key, final long index) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.lindex(key, index);
@@ -549,7 +549,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String lset(final String key, final long index, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.lset(key, index, value);
@@ -559,7 +559,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long lrem(final String key, final long count, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lrem(key, count, value);
@@ -569,7 +569,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String lpop(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.lpop(key);
@@ -579,7 +579,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String rpop(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.rpop(key);
@@ -589,7 +589,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long sadd(final String key, final String... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sadd(key, member);
@@ -599,7 +599,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> smembers(final String key) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.smembers(key);
@@ -609,7 +609,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long srem(final String key, final String... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.srem(key, member);
@@ -619,7 +619,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String spop(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.spop(key);
@@ -629,7 +629,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> spop(final String key, final long count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.spop(key, count);
@@ -639,7 +639,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long scard(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.scard(key);
@@ -649,7 +649,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean sismember(final String key, final String member) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.sismember(key, member);
@@ -659,7 +659,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String srandmember(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.srandmember(key);
@@ -669,7 +669,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> srandmember(final String key, final int count) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.srandmember(key, count);
@@ -679,7 +679,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long strlen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.strlen(key);
@@ -689,7 +689,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zadd(final String key, final double score, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zadd(key, score, member);
@@ -700,7 +700,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Long zadd(final String key, final double score, final String member,
       final ZAddParams params) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zadd(key, score, member, params);
@@ -710,7 +710,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zadd(final String key, final Map<String, Double> scoreMembers) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zadd(key, scoreMembers);
@@ -720,7 +720,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zadd(final String key, final Map<String, Double> scoreMembers, final ZAddParams params) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zadd(key, scoreMembers, params);
@@ -730,7 +730,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrange(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrange(key, start, end);
@@ -740,7 +740,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zrem(final String key, final String... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zrem(key, member);
@@ -750,7 +750,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Double zincrby(final String key, final double score, final String member) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
       @Override
       public Double execute(Jedis connection) {
         return connection.zincrby(key, score, member);
@@ -761,7 +761,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Double zincrby(final String key, final double score, final String member,
       final ZIncrByParams params) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
       @Override
       public Double execute(Jedis connection) {
         return connection.zincrby(key, score, member, params);
@@ -771,7 +771,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zrank(final String key, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zrank(key, member);
@@ -781,7 +781,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zrevrank(final String key, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zrevrank(key, member);
@@ -791,7 +791,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrevrange(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrange(key, start, end);
@@ -801,7 +801,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrangeWithScores(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeWithScores(key, start, end);
@@ -811,7 +811,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrevrangeWithScores(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeWithScores(key, start, end);
@@ -821,7 +821,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zcard(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcard(key);
@@ -831,7 +831,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Double zscore(final String key, final String member) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
       @Override
       public Double execute(Jedis connection) {
         return connection.zscore(key, member);
@@ -841,7 +841,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> sort(final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.sort(key);
@@ -851,7 +851,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> sort(final String key, final SortingParams sortingParameters) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.sort(key, sortingParameters);
@@ -861,7 +861,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zcount(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcount(key, min, max);
@@ -871,7 +871,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zcount(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcount(key, min, max);
@@ -881,7 +881,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrangeByScore(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max);
@@ -891,7 +891,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrangeByScore(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max);
@@ -901,7 +901,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final double max, final double min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min);
@@ -912,7 +912,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrangeByScore(final String key, final double min, final double max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max, offset, count);
@@ -922,7 +922,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min);
@@ -933,7 +933,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrangeByScore(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max, offset, count);
@@ -944,7 +944,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrevrangeByScore(final String key, final double max, final double min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min, offset, count);
@@ -954,7 +954,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max);
@@ -964,7 +964,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final double max, final double min) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min);
@@ -975,7 +975,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final double min, final double max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max, offset, count);
@@ -986,7 +986,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrevrangeByScore(final String key, final String max, final String min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min, offset, count);
@@ -996,7 +996,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max);
@@ -1006,7 +1006,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min);
@@ -1017,7 +1017,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max, offset, count);
@@ -1028,7 +1028,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final double max,
       final double min, final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min, offset, count);
@@ -1039,7 +1039,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final String max,
       final String min, final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min, offset, count);
@@ -1049,7 +1049,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zremrangeByRank(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByRank(key, start, end);
@@ -1059,7 +1059,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zremrangeByScore(final String key, final double start, final double end) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByScore(key, start, end);
@@ -1069,7 +1069,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zremrangeByScore(final String key, final String start, final String end) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByScore(key, start, end);
@@ -1079,7 +1079,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zlexcount(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zlexcount(key, min, max);
@@ -1089,7 +1089,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrangeByLex(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByLex(key, min, max);
@@ -1100,7 +1100,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrangeByLex(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByLex(key, min, max, offset, count);
@@ -1110,7 +1110,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrevrangeByLex(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByLex(key, max, min);
@@ -1121,7 +1121,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrevrangeByLex(final String key, final String max, final String min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByLex(key, max, min, offset, count);
@@ -1131,7 +1131,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zremrangeByLex(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByLex(key, min, max);
@@ -1142,7 +1142,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Long linsert(final String key, final LIST_POSITION where, final String pivot,
       final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.linsert(key, where, pivot, value);
@@ -1152,7 +1152,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long lpushx(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lpushx(key, string);
@@ -1162,7 +1162,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long rpushx(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.rpushx(key, string);
@@ -1172,7 +1172,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long del(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.del(key);
@@ -1183,7 +1183,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public String echo(final String string) {
     // note that it'll be run from arbitary node
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.echo(string);
@@ -1193,7 +1193,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long bitcount(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.bitcount(key);
@@ -1203,7 +1203,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long bitcount(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.bitcount(key, start, end);
@@ -1223,7 +1223,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
     if (JedisClusterHashTagUtil.isClusterCompliantMatchPattern(matchPattern)) {
 
       return new JedisClusterCommand< ScanResult<String>>(connectionHandler,
-              maxRedirections) {
+                                                          maxAttempts) {
         @Override
         public ScanResult<String> execute(Jedis connection) {
           return connection.scan(cursor, params);
@@ -1237,7 +1237,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public ScanResult<Entry<String, String>> hscan(final String key, final String cursor) {
     return new JedisClusterCommand<ScanResult<Entry<String, String>>>(connectionHandler,
-        maxRedirections) {
+                                                                      maxAttempts) {
       @Override
       public ScanResult<Entry<String, String>> execute(Jedis connection) {
         return connection.hscan(key, cursor);
@@ -1247,7 +1247,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public ScanResult<String> sscan(final String key, final String cursor) {
-    return new JedisClusterCommand<ScanResult<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<ScanResult<String>>(connectionHandler, maxAttempts) {
       @Override
       public ScanResult<String> execute(Jedis connection) {
         return connection.sscan(key, cursor);
@@ -1257,7 +1257,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public ScanResult<Tuple> zscan(final String key, final String cursor) {
-    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxAttempts) {
       @Override
       public ScanResult<Tuple> execute(Jedis connection) {
         return connection.zscan(key, cursor);
@@ -1267,7 +1267,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long pfadd(final String key, final String... elements) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pfadd(key, elements);
@@ -1277,7 +1277,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public long pfcount(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pfcount(key);
@@ -1287,7 +1287,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> blpop(final int timeout, final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.blpop(timeout, key);
@@ -1297,7 +1297,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> brpop(final int timeout, final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.brpop(timeout, key);
@@ -1307,7 +1307,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long del(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.del(keys);
@@ -1317,7 +1317,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> blpop(final int timeout, final String... keys) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.blpop(timeout, keys);
@@ -1328,7 +1328,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> brpop(final int timeout, final String... keys) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.brpop(timeout, keys);
@@ -1338,7 +1338,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> mget(final String... keys) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.mget(keys);
@@ -1354,7 +1354,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       keys[keyIdx] = keysvalues[keyIdx * 2];
     }
 
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.mset(keysvalues);
@@ -1370,7 +1370,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       keys[keyIdx] = keysvalues[keyIdx * 2];
     }
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.msetnx(keysvalues);
@@ -1380,7 +1380,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String rename(final String oldkey, final String newkey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.rename(oldkey, newkey);
@@ -1390,7 +1390,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long renamenx(final String oldkey, final String newkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.renamenx(oldkey, newkey);
@@ -1400,7 +1400,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String rpoplpush(final String srckey, final String dstkey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.rpoplpush(srckey, dstkey);
@@ -1410,7 +1410,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> sdiff(final String... keys) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.sdiff(keys);
@@ -1422,7 +1422,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long sdiffstore(final String dstkey, final String... keys) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sdiffstore(dstkey, keys);
@@ -1432,7 +1432,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> sinter(final String... keys) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.sinter(keys);
@@ -1444,7 +1444,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long sinterstore(final String dstkey, final String... keys) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sinterstore(dstkey, keys);
@@ -1454,7 +1454,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long smove(final String srckey, final String dstkey, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.smove(srckey, dstkey, member);
@@ -1464,7 +1464,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long sort(final String key, final SortingParams sortingParameters, final String dstkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sort(key, sortingParameters, dstkey);
@@ -1474,7 +1474,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long sort(final String key, final String dstkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sort(key, dstkey);
@@ -1484,7 +1484,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> sunion(final String... keys) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.sunion(keys);
@@ -1496,7 +1496,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long sunionstore(final String dstkey, final String... keys) {
     String[] wholeKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sunionstore(dstkey, keys);
@@ -1508,7 +1508,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long zinterstore(final String dstkey, final String... sets) {
     String[] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zinterstore(dstkey, sets);
@@ -1520,7 +1520,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long zinterstore(final String dstkey, final ZParams params, final String... sets) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zinterstore(dstkey, params, sets);
@@ -1532,7 +1532,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long zunionstore(final String dstkey, final String... sets) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zunionstore(dstkey, sets);
@@ -1544,7 +1544,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long zunionstore(final String dstkey, final ZParams params, final String... sets) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zunionstore(dstkey, params, sets);
@@ -1554,7 +1554,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String brpoplpush(final String source, final String destination, final int timeout) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.brpoplpush(source, destination, timeout);
@@ -1564,7 +1564,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long publish(final String channel, final String message) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.publish(channel, message);
@@ -1574,7 +1574,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public void subscribe(final JedisPubSub jedisPubSub, final String... channels) {
-    new JedisClusterCommand<Integer>(connectionHandler, maxRedirections) {
+    new JedisClusterCommand<Integer>(connectionHandler, maxAttempts) {
       @Override
       public Integer execute(Jedis connection) {
         connection.subscribe(jedisPubSub, channels);
@@ -1585,7 +1585,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public void psubscribe(final JedisPubSub jedisPubSub, final String... patterns) {
-    new JedisClusterCommand<Integer>(connectionHandler, maxRedirections) {
+    new JedisClusterCommand<Integer>(connectionHandler, maxAttempts) {
       @Override
       public Integer execute(Jedis connection) {
         connection.psubscribe(jedisPubSub, patterns);
@@ -1598,7 +1598,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long bitop(final BitOP op, final String destKey, final String... srcKeys) {
     String[] mergedKeys = KeyMergeUtil.merge(destKey, srcKeys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.bitop(op, destKey, srcKeys);
@@ -1610,7 +1610,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public String pfmerge(final String destkey, final String... sourcekeys) {
     String[] mergedKeys = KeyMergeUtil.merge(destkey, sourcekeys);
 
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.pfmerge(destkey, sourcekeys);
@@ -1620,7 +1620,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public long pfcount(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pfcount(keys);
@@ -1630,7 +1630,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Object eval(final String script, final int keyCount, final String... params) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
       @Override
       public Object execute(Jedis connection) {
         return connection.eval(script, keyCount, params);
@@ -1640,7 +1640,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Object eval(final String script, final String key) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
       @Override
       public Object execute(Jedis connection) {
         return connection.eval(script);
@@ -1650,7 +1650,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Object eval(final String script, final List<String> keys, final List<String> args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
       @Override
       public Object execute(Jedis connection) {
         return connection.eval(script, keys, args);
@@ -1660,7 +1660,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Object evalsha(final String sha1, final int keyCount, final String... params) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
       @Override
       public Object execute(Jedis connection) {
         return connection.evalsha(sha1, keyCount, params);
@@ -1670,7 +1670,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Object evalsha(final String sha1, final List<String> keys, final List<String> args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
       @Override
       public Object execute(Jedis connection) {
         return connection.evalsha(sha1, keys, args);
@@ -1680,7 +1680,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Object evalsha(final String script, final String key) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
       @Override
       public Object execute(Jedis connection) {
         return connection.evalsha(script);
@@ -1690,7 +1690,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean scriptExists(final String sha1, final String key) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.scriptExists(sha1);
@@ -1700,7 +1700,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<Boolean> scriptExists(final String key, final String... sha1) {
-    return new JedisClusterCommand<List<Boolean>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<Boolean>>(connectionHandler, maxAttempts) {
       @Override
       public List<Boolean> execute(Jedis connection) {
         return connection.scriptExists(sha1);
@@ -1710,7 +1710,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String scriptLoad(final String script, final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
       @Override
       public String execute(Jedis connection) {
         return connection.scriptLoad(script);
@@ -1721,7 +1721,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Long geoadd(final String key, final double longitude, final double latitude,
       final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.geoadd(key, longitude, latitude, member);
@@ -1731,7 +1731,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long geoadd(final String key, final Map<String, GeoCoordinate> memberCoordinateMap) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
       @Override
       public Long execute(Jedis connection) {
         return connection.geoadd(key, memberCoordinateMap);
@@ -1741,7 +1741,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Double geodist(final String key, final String member1, final String member2) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
       @Override
       public Double execute(Jedis connection) {
         return connection.geodist(key, member1, member2);
@@ -1752,7 +1752,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Double geodist(final String key, final String member1, final String member2,
       final GeoUnit unit) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
       @Override
       public Double execute(Jedis connection) {
         return connection.geodist(key, member1, member2, unit);
@@ -1762,7 +1762,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> geohash(final String key, final String... members) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.geohash(key, members);
@@ -1772,7 +1772,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<GeoCoordinate> geopos(final String key, final String... members) {
-    return new JedisClusterCommand<List<GeoCoordinate>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<GeoCoordinate>>(connectionHandler, maxAttempts) {
       @Override
       public List<GeoCoordinate> execute(Jedis connection) {
         return connection.geopos(key, members);
@@ -1783,7 +1783,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public List<GeoRadiusResponse> georadius(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadius(key, longitude, latitude, radius, unit);
@@ -1794,7 +1794,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public List<GeoRadiusResponse> georadius(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadius(key, longitude, latitude, radius, unit, param);
@@ -1805,7 +1805,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public List<GeoRadiusResponse> georadiusByMember(final String key, final String member,
       final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadiusByMember(key, member, radius, unit);
@@ -1816,7 +1816,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public List<GeoRadiusResponse> georadiusByMember(final String key, final String member,
       final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadiusByMember(key, member, radius, unit, param);
@@ -1826,7 +1826,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<Long> bitfield(final String key, final String... arguments) {
-    return new JedisClusterCommand<List<Long>>(connectionHandler, maxRedirections) {
+    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts) {
       @Override
       public List<Long> execute(Jedis connection) {
         return connection.bitfield(key, arguments);

--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -15,12 +15,12 @@ public abstract class JedisClusterCommand<T> {
   private static final String NO_DISPATCH_MESSAGE = "No way to dispatch this command to Redis Cluster.";
 
   private JedisClusterConnectionHandler connectionHandler;
-  private int redirections;
+  private int maxAttempts;
   private ThreadLocal<Jedis> askConnection = new ThreadLocal<Jedis>();
 
-  public JedisClusterCommand(JedisClusterConnectionHandler connectionHandler, int maxRedirections) {
+  public JedisClusterCommand(JedisClusterConnectionHandler connectionHandler, int maxAttempts) {
     this.connectionHandler = connectionHandler;
-    this.redirections = maxRedirections;
+    this.maxAttempts = maxAttempts;
   }
 
   public abstract T execute(Jedis connection);
@@ -30,7 +30,7 @@ public abstract class JedisClusterCommand<T> {
       throw new JedisClusterException(NO_DISPATCH_MESSAGE);
     }
 
-    return runWithRetries(SafeEncoder.encode(key), this.redirections, false, false);
+    return runWithRetries(SafeEncoder.encode(key), this.maxAttempts, false, false);
   }
 
   public T run(int keyCount, String... keys) {
@@ -51,7 +51,7 @@ public abstract class JedisClusterCommand<T> {
       }
     }
 
-    return runWithRetries(SafeEncoder.encode(keys[0]), this.redirections, false, false);
+    return runWithRetries(SafeEncoder.encode(keys[0]), this.maxAttempts, false, false);
   }
 
   public T runBinary(byte[] key) {
@@ -59,7 +59,7 @@ public abstract class JedisClusterCommand<T> {
       throw new JedisClusterException(NO_DISPATCH_MESSAGE);
     }
 
-    return runWithRetries(key, this.redirections, false, false);
+    return runWithRetries(key, this.maxAttempts, false, false);
   }
 
   public T runBinary(int keyCount, byte[]... keys) {
@@ -80,7 +80,7 @@ public abstract class JedisClusterCommand<T> {
       }
     }
 
-    return runWithRetries(keys[0], this.redirections, false, false);
+    return runWithRetries(keys[0], this.maxAttempts, false, false);
   }
 
   public T runWithAnyNode() {
@@ -95,8 +95,8 @@ public abstract class JedisClusterCommand<T> {
     }
   }
 
-  private T runWithRetries(byte[] key, int redirections, boolean tryRandomNode, boolean asking) {
-    if (redirections <= 0) {
+  private T runWithRetries(byte[] key, int attempts, boolean tryRandomNode, boolean asking) {
+    if (attempts <= 0) {
       throw new JedisClusterMaxRedirectionsException("Too many Cluster redirections?");
     }
 
@@ -128,10 +128,10 @@ public abstract class JedisClusterCommand<T> {
       releaseConnection(connection);
       connection = null;
 
-      if (redirections <= 1) {
+      if (attempts <= 1) {
         //We need this because if node is not reachable anymore - we need to finally initiate slots renewing,
         //or we can stuck with cluster state without one node in opposite case.
-        //But now if maxRedirections = 1 or 2 we will do it too often. For each time-outed request.
+        //But now if maxAttempts = 1 or 2 we will do it too often. For each time-outed request.
         //TODO make tracking of successful/unsuccessful operations for node - do renewing only
         //if there were no successful responses from this node last few seconds
         this.connectionHandler.renewSlotCache();
@@ -140,7 +140,7 @@ public abstract class JedisClusterCommand<T> {
         throw jce;
       }
 
-      return runWithRetries(key, redirections - 1, tryRandomNode, asking);
+      return runWithRetries(key, attempts - 1, tryRandomNode, asking);
     } catch (JedisRedirectionException jre) {
       // if MOVED redirection occurred,
       if (jre instanceof JedisMovedDataException) {
@@ -161,7 +161,7 @@ public abstract class JedisClusterCommand<T> {
         throw new JedisClusterException(jre);
       }
 
-      return runWithRetries(key, redirections - 1, false, asking);
+      return runWithRetries(key, attempts - 1, false, asking);
     } finally {
       releaseConnection(connection);
     }

--- a/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
@@ -5,8 +5,8 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
 import java.util.Set;
 
-import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.exceptions.JedisNoReachableClusterNodeException;
 
 public class JedisSlotBasedConnectionHandler extends JedisClusterConnectionHandler {
 
@@ -54,7 +54,7 @@ public class JedisSlotBasedConnectionHandler extends JedisClusterConnectionHandl
       }
     }
 
-    throw new JedisConnectionException("no reachable node in cluster");
+    throw new JedisNoReachableClusterNodeException("No reachable node in cluster");
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/exceptions/JedisNoReachableClusterNodeException.java
+++ b/src/main/java/redis/clients/jedis/exceptions/JedisNoReachableClusterNodeException.java
@@ -1,0 +1,17 @@
+package redis.clients.jedis.exceptions;
+
+public class JedisNoReachableClusterNodeException extends JedisConnectionException {
+    private static final long serialVersionUID = 3878122572474110407L;
+
+    public JedisNoReachableClusterNodeException(String message) {
+        super(message);
+    }
+
+    public JedisNoReachableClusterNodeException(Throwable cause) {
+        super(cause);
+    }
+
+    public JedisNoReachableClusterNodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
Type of address problem with flow "just one timeout -> random node for nothing -> rediscovering" on each timed out request for Issue #1252:

1. Don’t try random node with immediate initiate cluster renewal after that if we got ConnectionTimeout from proper slot jedis. Try proper slot until last attempt, if last attempt failed - just make cluster rediscovery, without trying random nodes which is useless.
2. New special exception for “No reachable nodes”
3. Fixed situation when simple connection exception with tryRandomNode=true proceed as just no reachable nodes
4. Fix rewriting real root cause JedisConnectionException with JedisClusterMaxRedirectionsException

This PR mostly address my comment on another PR https://github.com/xetorthio/jedis/pull/1253#issuecomment-206480244
And should be merged after merging this more critical PR https://github.com/xetorthio/jedis/pull/1253