### PR TITLE
Workaround to Travis OpenJDK 6/7 buffer overflow issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ script: make test
 cache:
   directories:
     - $HOME/.m2
+addons:
+  hostname: jedis


### PR DESCRIPTION
* https://github.com/travis-ci/travis-ci/issues/5227

Will merge as hotfix when Travis build succeeds. 
Travis build succeeds on my repo.