### PR TITLE
Add support to set password in JedisCluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,18 +190,6 @@ cluster-enabled yes
 cluster-config-file /tmp/redis_cluster_node5.conf
 endef
 
-define REDIS_CLUSTER_NODE6_CONF
-daemonize yes
-port 7384
-cluster-node-timeout 5000
-pidfile /tmp/redis_cluster_node6.pid
-logfile /tmp/redis_cluster_node6.log
-save ""
-appendonly no
-cluster-enabled yes
-cluster-config-file /tmp/redis_cluster_node6.conf
-endef
-
 #STUNNEL
 define STUNNEL_CONF
 cert = src/test/resources/private.pem
@@ -227,7 +215,6 @@ export REDIS_CLUSTER_NODE2_CONF
 export REDIS_CLUSTER_NODE3_CONF
 export REDIS_CLUSTER_NODE4_CONF
 export REDIS_CLUSTER_NODE5_CONF
-export REDIS_CLUSTER_NODE6_CONF
 export STUNNEL_CONF
 export STUNNEL_BIN
 
@@ -257,7 +244,6 @@ start: stunnel cleanup
 	echo "$$REDIS_CLUSTER_NODE3_CONF" | redis-server -
 	echo "$$REDIS_CLUSTER_NODE4_CONF" | redis-server -
 	echo "$$REDIS_CLUSTER_NODE5_CONF" | redis-server -
-	echo "$$REDIS_CLUSTER_NODE6_CONF" | redis-server -
 
 cleanup:
 	- rm -vf /tmp/redis_cluster_node*.conf 2>/dev/null
@@ -284,7 +270,6 @@ stop:
 	kill `cat /tmp/redis_cluster_node3.pid` || true
 	kill `cat /tmp/redis_cluster_node4.pid` || true
 	kill `cat /tmp/redis_cluster_node5.pid` || true
-	kill `cat /tmp/redis_cluster_node6.pid` || true
 	kill `cat /tmp/stunnel.pid` || true
 	rm -f /tmp/sentinel1.conf
 	rm -f /tmp/sentinel2.conf
@@ -294,7 +279,6 @@ stop:
 	rm -f /tmp/redis_cluster_node3.conf
 	rm -f /tmp/redis_cluster_node4.conf
 	rm -f /tmp/redis_cluster_node5.conf
-	rm -f /tmp/redis_cluster_node6.conf
 
 test:
 	make start

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ endef
 # CLUSTER REDIS NODES
 define REDIS_CLUSTER_NODE1_CONF
 daemonize yes
+requirepass cluster
 port 7379
 cluster-node-timeout 50
 pidfile /tmp/redis_cluster_node1.pid
@@ -144,6 +145,7 @@ endef
 
 define REDIS_CLUSTER_NODE2_CONF
 daemonize yes
+requirepass cluster
 port 7380
 cluster-node-timeout 50
 pidfile /tmp/redis_cluster_node2.pid
@@ -156,6 +158,7 @@ endef
 
 define REDIS_CLUSTER_NODE3_CONF
 daemonize yes
+requirepass cluster
 port 7381
 cluster-node-timeout 50
 pidfile /tmp/redis_cluster_node3.pid
@@ -168,6 +171,7 @@ endef
 
 define REDIS_CLUSTER_NODE4_CONF
 daemonize yes
+requirepass cluster
 port 7382
 cluster-node-timeout 50
 pidfile /tmp/redis_cluster_node4.pid
@@ -180,6 +184,7 @@ endef
 
 define REDIS_CLUSTER_NODE5_CONF
 daemonize yes
+requirepass cluster
 port 7383
 cluster-node-timeout 5000
 pidfile /tmp/redis_cluster_node5.pid

--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -51,6 +51,12 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
     this.maxRedirections = maxRedirections;
   }
 
+  public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout, int maxRedirections, String password, GenericObjectPoolConfig poolConfig) {
+    this.connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
+            connectionTimeout, soTimeout, password);
+    this.maxRedirections = maxRedirections;
+  }
+
   @Override
   public void close() {
     if (connectionHandler != null) {

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -54,6 +54,11 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       int maxRedirections, final GenericObjectPoolConfig poolConfig) {
     super(Collections.singleton(node), connectionTimeout, soTimeout, maxRedirections, poolConfig);
   }
+
+  public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout,
+                      int maxRedirections, String password, final GenericObjectPoolConfig poolConfig) {
+    super(Collections.singleton(node), connectionTimeout, soTimeout, maxRedirections, password, poolConfig);
+  }
   
   public JedisCluster(Set<HostAndPort> nodes) {
     this(nodes, DEFAULT_TIMEOUT);
@@ -83,6 +88,11 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public JedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout,
       int maxRedirections, final GenericObjectPoolConfig poolConfig) {
     super(jedisClusterNode, connectionTimeout, soTimeout, maxRedirections, poolConfig);
+  }
+
+  public JedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout,
+                      int maxRedirections, String password, final GenericObjectPoolConfig poolConfig) {
+    super(jedisClusterNode, connectionTimeout, soTimeout, maxRedirections, password, poolConfig);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -15,9 +15,9 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
   protected final JedisClusterInfoCache cache;
 
   public JedisClusterConnectionHandler(Set<HostAndPort> nodes,
-                                       final GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout) {
-    this.cache = new JedisClusterInfoCache(poolConfig, connectionTimeout, soTimeout);
-    initializeSlotsCache(nodes, poolConfig);
+                                       final GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password) {
+    this.cache = new JedisClusterInfoCache(poolConfig, connectionTimeout, soTimeout, password);
+    initializeSlotsCache(nodes, poolConfig, password);
   }
 
   abstract Jedis getConnection();
@@ -33,9 +33,12 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
     return cache.getNodes();
   }
 
-  private void initializeSlotsCache(Set<HostAndPort> startNodes, GenericObjectPoolConfig poolConfig) {
+  private void initializeSlotsCache(Set<HostAndPort> startNodes, GenericObjectPoolConfig poolConfig, String password) {
     for (HostAndPort hostAndPort : startNodes) {
       Jedis jedis = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
+      if (password != null) {
+        jedis.auth(password);
+      }
       try {
         cache.discoverClusterNodesAndSlots(jedis);
         break;

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -27,18 +27,20 @@ public class JedisClusterInfoCache {
 
   private int connectionTimeout;
   private int soTimeout;
+  private String password;
 
   private static final int MASTER_NODE_INDEX = 2;
 
   public JedisClusterInfoCache(final GenericObjectPoolConfig poolConfig, int timeout) {
-    this(poolConfig, timeout, timeout);
+    this(poolConfig, timeout, timeout, null);
   }
 
   public JedisClusterInfoCache(final GenericObjectPoolConfig poolConfig,
-      final int connectionTimeout, final int soTimeout) {
+      final int connectionTimeout, final int soTimeout, final String password) {
     this.poolConfig = poolConfig;
     this.connectionTimeout = connectionTimeout;
     this.soTimeout = soTimeout;
+    this.password = password;
   }
 
   public void discoverClusterNodesAndSlots(Jedis jedis) {
@@ -128,7 +130,7 @@ public class JedisClusterInfoCache {
       if (nodes.containsKey(nodeKey)) return;
 
       JedisPool nodePool = new JedisPool(poolConfig, node.getHost(), node.getPort(),
-          connectionTimeout, soTimeout, null, 0, null, false, null, null, null);
+          connectionTimeout, soTimeout, password, 0, null, false, null, null, null);
       nodes.put(nodeKey, nodePool);
     } finally {
       w.unlock();
@@ -142,7 +144,7 @@ public class JedisClusterInfoCache {
       if (nodes.containsKey(nodeKey)) return;
 
       JedisPool nodePool = new JedisPool(poolConfig, node.getHost(), node.getPort(),
-          connectionTimeout, soTimeout, null, 0, null, ssl, null, null, null);
+          connectionTimeout, soTimeout, password, 0, null, ssl, null, null, null);
       nodes.put(nodeKey, nodePool);
     } finally {
       w.unlock();
@@ -157,7 +159,7 @@ public class JedisClusterInfoCache {
       if (nodes.containsKey(nodeKey)) return;
 
       JedisPool nodePool = new JedisPool(poolConfig, node.getHost(), node.getPort(),
-          connectionTimeout, soTimeout, null, 0, null, ssl, sslSocketFactory, sslParameters,
+          connectionTimeout, soTimeout, password, 0, null, ssl, sslSocketFactory, sslParameters,
           hostnameVerifier);
       nodes.put(nodeKey, nodePool);
     } finally {

--- a/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
@@ -17,7 +17,11 @@ public class JedisSlotBasedConnectionHandler extends JedisClusterConnectionHandl
 
   public JedisSlotBasedConnectionHandler(Set<HostAndPort> nodes,
       final GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout) {
-    super(nodes, poolConfig, connectionTimeout, soTimeout);
+    super(nodes, poolConfig, connectionTimeout, soTimeout, null);
+  }
+
+  public JedisSlotBasedConnectionHandler(Set<HostAndPort> nodes, GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password) {
+    super(nodes, poolConfig, connectionTimeout, soTimeout, password);
   }
 
   @Override

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -23,6 +23,10 @@ public class JedisClusterTest extends Assert {
   private static Jedis nodeSlave2;
   private String localHost = "127.0.0.1";
 
+  private static final int DEFAULT_TIMEOUT = 2000;
+  private static final int DEFAULT_REDIRECTIONS = 5;
+  private static final JedisPoolConfig DEFAULT_CONFIG = new JedisPoolConfig();
+
   private HostAndPort nodeInfo1 = HostAndPortUtil.getClusterServers().get(0);
   private HostAndPort nodeInfo2 = HostAndPortUtil.getClusterServers().get(1);
   private HostAndPort nodeInfo3 = HostAndPortUtil.getClusterServers().get(2);
@@ -33,23 +37,23 @@ public class JedisClusterTest extends Assert {
   @Before
   public void setUp() throws InterruptedException {
     node1 = new Jedis(nodeInfo1.getHost(), nodeInfo1.getPort());
-    node1.connect();
+    node1.auth("cluster");
     node1.flushAll();
 
     node2 = new Jedis(nodeInfo2.getHost(), nodeInfo2.getPort());
-    node2.connect();
+    node2.auth("cluster");
     node2.flushAll();
 
     node3 = new Jedis(nodeInfo3.getHost(), nodeInfo3.getPort());
-    node3.connect();
+    node3.auth("cluster");
     node3.flushAll();
 
     node4 = new Jedis(nodeInfo4.getHost(), nodeInfo4.getPort());
-    node4.connect();
+    node4.auth("cluster");
     node4.flushAll();
 
     nodeSlave2 = new Jedis(nodeInfoSlave2.getHost(), nodeInfoSlave2.getPort());
-    nodeSlave2.connect();
+    nodeSlave2.auth("cluster");
     nodeSlave2.flushAll();
     // ---- configure cluster
 
@@ -125,10 +129,10 @@ public class JedisClusterTest extends Assert {
   public void testDiscoverNodesAutomatically() {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
-    JedisCluster jc = new JedisCluster(jedisClusterNode);
+    JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
     assertEquals(3, jc.getClusterNodes().size());
     
-    JedisCluster jc2 = new JedisCluster(new HostAndPort("127.0.0.1", 7379));
+    JedisCluster jc2 = new JedisCluster(new HostAndPort("127.0.0.1", 7379), DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
     assertEquals(3, jc2.getClusterNodes().size());
   }
   
@@ -136,13 +140,13 @@ public class JedisClusterTest extends Assert {
   public void testCalculateConnectionPerSlot() {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
-    JedisCluster jc = new JedisCluster(jedisClusterNode);
+    JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
     jc.set("foo", "bar");
     jc.set("test", "test");
     assertEquals("bar", node3.get("foo"));
     assertEquals("test", node2.get("test"));
     
-    JedisCluster jc2 = new JedisCluster(new HostAndPort("127.0.0.1", 7379));
+    JedisCluster jc2 = new JedisCluster(new HostAndPort("127.0.0.1", 7379), DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
     jc2.set("foo", "bar");
     jc2.set("test", "test");
     assertEquals("bar", node3.get("foo"));
@@ -180,7 +184,7 @@ public class JedisClusterTest extends Assert {
     log.info("test migrate slot");
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(nodeInfo1);
-    JedisCluster jc = new JedisCluster(jedisClusterNode);
+    JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
     String node3Id = JedisClusterTestUtil.getNodeId(node3.clusterNodes());
     String node2Id = JedisClusterTestUtil.getNodeId(node2.clusterNodes());
     node3.clusterSetSlotMigrating(15363, node2Id);
@@ -230,7 +234,7 @@ public class JedisClusterTest extends Assert {
     log.info("test migrate slot to new node");
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(nodeInfo1);
-    JedisCluster jc = new JedisCluster(jedisClusterNode);
+    JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
     node4.clusterMeet(localHost, nodeInfo1.getPort());
 
     String node3Id = JedisClusterTestUtil.getNodeId(node3.clusterNodes());
@@ -282,7 +286,7 @@ public class JedisClusterTest extends Assert {
   public void testRecalculateSlotsWhenMoved() throws InterruptedException {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
-    JedisCluster jc = new JedisCluster(jedisClusterNode);
+    JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
     int slot51 = JedisClusterCRC16.getSlot("51");
     node2.clusterDelSlots(slot51);
     node3.clusterDelSlots(slot51);
@@ -297,7 +301,7 @@ public class JedisClusterTest extends Assert {
   public void testAskResponse() throws InterruptedException {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
-    JedisCluster jc = new JedisCluster(jedisClusterNode);
+    JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
     int slot51 = JedisClusterCRC16.getSlot("51");
     node3.clusterSetSlotImporting(slot51, JedisClusterTestUtil.getNodeId(node2.clusterNodes()));
     node2.clusterSetSlotMigrating(slot51, JedisClusterTestUtil.getNodeId(node3.clusterNodes()));
@@ -309,7 +313,7 @@ public class JedisClusterTest extends Assert {
   public void testRedisClusterMaxRedirections() {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
-    JedisCluster jc = new JedisCluster(jedisClusterNode);
+    JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
     int slot51 = JedisClusterCRC16.getSlot("51");
     // This will cause an infinite redirection loop
     node2.clusterSetSlotMigrating(slot51, JedisClusterTestUtil.getNodeId(node3.clusterNodes()));
@@ -393,14 +397,14 @@ public class JedisClusterTest extends Assert {
   public void testClusterCountKeysInSlot() {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(new HostAndPort(nodeInfo1.getHost(), nodeInfo1.getPort()));
-    JedisCluster jc = new JedisCluster(jedisClusterNode);
+    JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
 
     for (int index = 0; index < 5; index++) {
       jc.set("foo{bar}" + index, "hello");
     }
 
     int slot = JedisClusterCRC16.getSlot("foo{bar}");
-    assertEquals(5, node1.clusterCountKeysInSlot(slot).intValue());
+    assertEquals(DEFAULT_REDIRECTIONS, node1.clusterCountKeysInSlot(slot).intValue());
   }
 
   @Test
@@ -408,7 +412,7 @@ public class JedisClusterTest extends Assert {
       throws InterruptedException {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(new HostAndPort(nodeInfo1.getHost(), nodeInfo1.getPort()));
-    JedisCluster jc = new JedisCluster(jedisClusterNode);
+    JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
 
     int slot51 = JedisClusterCRC16.getSlot("51");
     jc.set("51", "foo");
@@ -429,10 +433,10 @@ public class JedisClusterTest extends Assert {
   public void testIfPoolConfigAppliesToClusterPools() {
     GenericObjectPoolConfig config = new GenericObjectPoolConfig();
     config.setMaxTotal(0);
-    config.setMaxWaitMillis(2000);
+    config.setMaxWaitMillis(DEFAULT_TIMEOUT);
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
-    JedisCluster jc = new JedisCluster(jedisClusterNode, config);
+    JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", config);
     jc.set("52", "poolTestValue");
   }
 
@@ -443,7 +447,7 @@ public class JedisClusterTest extends Assert {
 
     JedisCluster jc = null;
     try {
-      jc = new JedisCluster(jedisClusterNode);
+      jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
       jc.set("51", "foo");
     } finally {
       if (jc != null) {
@@ -468,7 +472,7 @@ public class JedisClusterTest extends Assert {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(new HostAndPort(nodeInfo1.getHost(), nodeInfo1.getPort()));
 
-    JedisCluster jc = new JedisCluster(jedisClusterNode, 4000);
+    JedisCluster jc = new JedisCluster(jedisClusterNode, 4000, 4000, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
 
     for (JedisPool pool : jc.getClusterNodes().values()) {
       Jedis jedis = pool.getResource();
@@ -484,7 +488,7 @@ public class JedisClusterTest extends Assert {
       ExecutionException, IOException {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
-    final JedisCluster jc = new JedisCluster(jedisClusterNode);
+    final JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
     jc.set("foo", "bar");
 
     ThreadPoolExecutor executor = new ThreadPoolExecutor(10, 100, 0, TimeUnit.SECONDS,
@@ -509,13 +513,13 @@ public class JedisClusterTest extends Assert {
     jc.close();
   }
 
-  @Test(timeout = 2000)
+  @Test(timeout = DEFAULT_TIMEOUT)
   public void testReturnConnectionOnJedisConnectionException() throws InterruptedException {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
-    JedisPoolConfig config = new JedisPoolConfig();
+    JedisPoolConfig config = DEFAULT_CONFIG;
     config.setMaxTotal(1);
-    JedisCluster jc = new JedisCluster(jedisClusterNode, config);
+    JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", config);
 
     Jedis j = jc.getClusterNodes().get("127.0.0.1:7380").getResource();
     ClientKillerUtil.tagClient(j, "DEAD");
@@ -525,13 +529,13 @@ public class JedisClusterTest extends Assert {
     jc.get("test");
   }
 
-  @Test(expected = JedisClusterMaxRedirectionsException.class, timeout = 2000)
+  @Test(expected = JedisClusterMaxRedirectionsException.class, timeout = DEFAULT_TIMEOUT)
   public void testReturnConnectionOnRedirection() {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
-    JedisPoolConfig config = new JedisPoolConfig();
+    JedisPoolConfig config = DEFAULT_CONFIG;
     config.setMaxTotal(1);
-    JedisCluster jc = new JedisCluster(jedisClusterNode, 0, 2, config);
+    JedisCluster jc = new JedisCluster(jedisClusterNode, 0, 2, DEFAULT_REDIRECTIONS, "cluster", config);
 
     // This will cause an infinite redirection between node 2 and 3
     node3.clusterSetSlotMigrating(15363, JedisClusterTestUtil.getNodeId(node2.clusterNodes()));
@@ -545,9 +549,9 @@ public class JedisClusterTest extends Assert {
     // cluster node is defined as 127.0.0.1; adding localhost should work,
     // but shouldn't show up.
     jedisClusterNode.add(localhost);
-    JedisPoolConfig config = new JedisPoolConfig();
+    JedisPoolConfig config = DEFAULT_CONFIG;
     config.setMaxTotal(1);
-    JedisCluster jc = new JedisCluster(jedisClusterNode, 0, 2, config);
+    JedisCluster jc = new JedisCluster(jedisClusterNode, 0, 2, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
     Map<String, JedisPool> clusterNodes = jc.getClusterNodes();
     assertEquals(3, clusterNodes.size());
     assertFalse(clusterNodes.containsKey(JedisClusterInfoCache.getNodeKey(localhost)));
@@ -559,9 +563,9 @@ public class JedisClusterTest extends Assert {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
     jedisClusterNode.add(invalidHost);
-    JedisPoolConfig config = new JedisPoolConfig();
+    JedisPoolConfig config = DEFAULT_CONFIG;
     config.setMaxTotal(1);
-    JedisCluster jc = new JedisCluster(jedisClusterNode, 0, 2, config);
+    JedisCluster jc = new JedisCluster(jedisClusterNode,  0, 2, DEFAULT_REDIRECTIONS, "cluster", config);
     Map<String, JedisPool> clusterNodes = jc.getClusterNodes();
     assertEquals(3, clusterNodes.size());
     assertFalse(clusterNodes.containsKey(JedisClusterInfoCache.getNodeKey(invalidHost)));

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterBinaryJedisCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterBinaryJedisCommandsTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.tests.HostAndPortUtil;
 import redis.clients.jedis.tests.JedisTestBase;
 import redis.clients.util.JedisClusterCRC16;
@@ -27,15 +28,15 @@ public class ClusterBinaryJedisCommandsTest extends JedisTestBase {
   @Before
   public void setUp() throws InterruptedException {
     node1 = new Jedis(nodeInfo1.getHost(), nodeInfo1.getPort());
-    node1.connect();
+    node1.auth("cluster");
     node1.flushAll();
 
     node2 = new Jedis(nodeInfo2.getHost(), nodeInfo2.getPort());
-    node2.connect();
+    node2.auth("cluster");
     node2.flushAll();
 
     node3 = new Jedis(nodeInfo3.getHost(), nodeInfo3.getPort());
-    node3.connect();
+    node3.auth("cluster");
     node3.flushAll();
 
     // ---- configure cluster
@@ -66,7 +67,7 @@ public class ClusterBinaryJedisCommandsTest extends JedisTestBase {
     waitForClusterReady();
 
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
-    jedisCluster = new JedisCluster(jedisClusterNode);
+    jedisCluster = new JedisCluster(jedisClusterNode, 2000, 2000, 5, "cluster", new JedisPoolConfig());
 
   }
 

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
@@ -25,11 +25,11 @@ public class ClusterCommandsTest extends JedisTestBase {
   public void setUp() throws Exception {
 
     node1 = new Jedis(nodeInfo1.getHost(), nodeInfo1.getPort());
-    node1.connect();
+    node1.auth("cluster");
     node1.flushAll();
 
     node2 = new Jedis(nodeInfo2.getHost(), nodeInfo2.getPort());
-    node2.connect();
+    node2.auth("cluster");
     node2.flushAll();
   }
 

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterScriptingCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterScriptingCommandsTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.exceptions.JedisClusterException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.tests.HostAndPortUtil;
@@ -32,15 +33,15 @@ public class ClusterScriptingCommandsTest extends JedisTestBase {
   @Before
   public void setUp() throws InterruptedException {
     node1 = new Jedis(nodeInfo1.getHost(), nodeInfo1.getPort());
-    node1.connect();
+    node1.auth("cluster");
     node1.flushAll();
 
     node2 = new Jedis(nodeInfo2.getHost(), nodeInfo2.getPort());
-    node2.connect();
+    node2.auth("cluster");
     node2.flushAll();
 
     node3 = new Jedis(nodeInfo3.getHost(), nodeInfo3.getPort());
-    node3.connect();
+    node3.auth("cluster");
     node3.flushAll();
 
     // ---- configure cluster
@@ -71,7 +72,7 @@ public class ClusterScriptingCommandsTest extends JedisTestBase {
     waitForClusterReady();
 
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
-    jedisCluster = new JedisCluster(jedisClusterNode);
+    jedisCluster = new JedisCluster(jedisClusterNode, 2000, 2000, 5, "cluster", new JedisPoolConfig());
 
   }
 


### PR DESCRIPTION
Even though the Redis Cluster spec doesn't say anything about it and the redis community still hasn't agreed about how to handle it, seems like many Redis / Jedis users need this functionality. 

I've implemented a very basic (I didn't add the parameter in all the possible constructor combinations) approach by just forwarding the password parameter to the inner JedisPool and discovery instances. 