### PR TITLE
Handle infinite doubles in Client (Pipeline, Transaction etc.)

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -780,6 +780,13 @@ public class BinaryClient extends Connection {
     sendCommand(ZREMRANGEBYRANK, key, toByteArray(start), toByteArray(end));
   }
 
+  public void zremrangeByScore(final byte[] key, final double start, final double end) {
+    byte[] byteArrayStart = (start == Double.NEGATIVE_INFINITY) ? "-inf".getBytes() : toByteArray(start);
+    byte[] byteArrayEnd = (end == Double.POSITIVE_INFINITY) ? "+inf".getBytes() : toByteArray(end);
+
+    sendCommand(ZREMRANGEBYSCORE, key, byteArrayStart, byteArrayEnd);
+  }
+
   public void zremrangeByScore(final byte[] key, final byte[] start, final byte[] end) {
     sendCommand(ZREMRANGEBYSCORE, key, start, end);
   }

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -560,7 +560,7 @@ public class Client extends BinaryClient implements Commands {
 
   @Override
   public void zcount(final String key, final double min, final double max) {
-    zcount(SafeEncoder.encode(key), toByteArray(min), toByteArray(max));
+    zcount(SafeEncoder.encode(key), min, max);
   }
 
   @Override
@@ -570,7 +570,7 @@ public class Client extends BinaryClient implements Commands {
 
   @Override
   public void zrangeByScore(final String key, final double min, final double max) {
-    zrangeByScore(SafeEncoder.encode(key), toByteArray(min), toByteArray(max));
+    zrangeByScore(SafeEncoder.encode(key), min, max);
   }
 
   @Override
@@ -581,24 +581,24 @@ public class Client extends BinaryClient implements Commands {
   @Override
   public void zrangeByScore(final String key, final double min, final double max, final int offset,
       int count) {
-    zrangeByScore(SafeEncoder.encode(key), toByteArray(min), toByteArray(max), offset, count);
+    zrangeByScore(SafeEncoder.encode(key), min, max, offset, count);
   }
 
   @Override
   public void zrangeByScoreWithScores(final String key, final double min, final double max) {
-    zrangeByScoreWithScores(SafeEncoder.encode(key), toByteArray(min), toByteArray(max));
+    zrangeByScoreWithScores(SafeEncoder.encode(key), min, max);
   }
 
   @Override
   public void zrangeByScoreWithScores(final String key, final double min, final double max,
       final int offset, final int count) {
-    zrangeByScoreWithScores(SafeEncoder.encode(key), toByteArray(min), toByteArray(max), offset,
+    zrangeByScoreWithScores(SafeEncoder.encode(key), min, max, offset,
       count);
   }
 
   @Override
   public void zrevrangeByScore(final String key, final double max, final double min) {
-    zrevrangeByScore(SafeEncoder.encode(key), toByteArray(max), toByteArray(min));
+    zrevrangeByScore(SafeEncoder.encode(key), max, min);
   }
 
   public void zrangeByScore(final String key, final String min, final String max, final int offset,
@@ -628,7 +628,7 @@ public class Client extends BinaryClient implements Commands {
   @Override
   public void zrevrangeByScore(final String key, final double max, final double min,
       final int offset, int count) {
-    zrevrangeByScore(SafeEncoder.encode(key), toByteArray(max), toByteArray(min), offset, count);
+    zrevrangeByScore(SafeEncoder.encode(key), max, min, offset, count);
   }
 
   public void zrevrangeByScore(final String key, final String max, final String min,
@@ -639,7 +639,7 @@ public class Client extends BinaryClient implements Commands {
 
   @Override
   public void zrevrangeByScoreWithScores(final String key, final double max, final double min) {
-    zrevrangeByScoreWithScores(SafeEncoder.encode(key), toByteArray(max), toByteArray(min));
+    zrevrangeByScoreWithScores(SafeEncoder.encode(key), max, min);
   }
 
   @Override
@@ -651,7 +651,7 @@ public class Client extends BinaryClient implements Commands {
   @Override
   public void zrevrangeByScoreWithScores(final String key, final double max, final double min,
       final int offset, final int count) {
-    zrevrangeByScoreWithScores(SafeEncoder.encode(key), toByteArray(max), toByteArray(min), offset,
+    zrevrangeByScoreWithScores(SafeEncoder.encode(key), max, min, offset,
       count);
   }
 
@@ -669,7 +669,7 @@ public class Client extends BinaryClient implements Commands {
 
   @Override
   public void zremrangeByScore(final String key, final double start, final double end) {
-    zremrangeByScore(SafeEncoder.encode(key), toByteArray(start), toByteArray(end));
+    zremrangeByScore(SafeEncoder.encode(key), start, end);
   }
 
   @Override

--- a/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
@@ -632,6 +632,114 @@ public class PipeliningTest extends Assert {
     retFuture2.get();
   }
 
+  @Test
+  public void testInfinities() {
+    jedis.zadd("foo", 1d, "a");
+    jedis.zadd("foo", 10d, "b");
+    jedis.zadd("foo", 0.1d, "c");
+    jedis.zadd("foo", 2d, "a");
+
+    // zcount
+    {
+      Pipeline pipeline = jedis.pipelined();
+      Response<Long> result = pipeline.zcount("foo", Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+      pipeline.sync();
+      assertEquals(new Long(3L), result.get());
+    }
+
+    // zrangeByScore
+    {
+      Pipeline pipeline = jedis.pipelined();
+      Response<Set<String>> range = pipeline.zrangeByScore("foo", Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+      Set<String> expected = new LinkedHashSet<String>();
+      expected.add("c");
+      expected.add("a");
+      expected.add("b");
+      pipeline.sync();
+      assertEquals(expected, range.get());
+    }
+    // zrangeByScore with offset and count
+    {
+      Pipeline pipeline = jedis.pipelined();
+      Response<Set<String>> range = pipeline.zrangeByScore("foo", Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 1, 1);
+      Set<String> expected = new LinkedHashSet<String>();
+      expected.add("a");
+      pipeline.sync();
+      assertEquals(expected, range.get());
+    }
+
+    // zrevrangeByScore
+    {
+      Pipeline pipeline = jedis.pipelined();
+      Response<Set<String>> range = pipeline.zrevrangeByScore("foo", Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
+      Set<String> expected = new LinkedHashSet<String>();
+      expected.add("b");
+      expected.add("a");
+      expected.add("c");
+      pipeline.sync();
+      assertEquals(expected, range.get());
+    }
+    // zrevrangeByScore with offset and count
+    {
+      Pipeline pipeline = jedis.pipelined();
+      Response<Set<String>> range = pipeline.zrevrangeByScore("foo", Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 1, 1);
+      Set<String> expected = new LinkedHashSet<String>();
+      expected.add("a");
+      pipeline.sync();
+      assertEquals(expected, range.get());
+    }
+
+    // zrangeByScoreWithScores
+    {
+      Pipeline pipeline = jedis.pipelined();
+      Response<Set<Tuple>> range = pipeline.zrangeByScoreWithScores("foo", Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+      Set<Tuple> expected = new LinkedHashSet<Tuple>();
+      expected.add(new Tuple("c", 0.1d));
+      expected.add(new Tuple("a", 2d));
+      expected.add(new Tuple("b", 10d));
+      pipeline.sync();
+      assertEquals(expected, range.get());
+    }
+    // zrangeByScoreWithScores with offset and count
+    {
+      Pipeline pipeline = jedis.pipelined();
+      Response<Set<Tuple>> range = pipeline.zrangeByScoreWithScores("foo", Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 1, 1);
+      Set<Tuple> expected = new LinkedHashSet<Tuple>();
+      expected.add(new Tuple("a", 2d));
+      pipeline.sync();
+      assertEquals(expected, range.get());
+    }
+
+    // zrevrangeByScoreWithScores
+    {
+      Pipeline pipeline = jedis.pipelined();
+      Response<Set<Tuple>> range = pipeline.zrevrangeByScoreWithScores("foo", Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
+      Set<Tuple> expected = new LinkedHashSet<Tuple>();
+      expected.add(new Tuple("b", 10d));
+      expected.add(new Tuple("a", 2d));
+      expected.add(new Tuple("c", 0.1d));
+      pipeline.sync();
+      assertEquals(expected, range.get());
+    }
+    // zrevrangeByScoreWithScores with offset and count
+    {
+      Pipeline pipeline = jedis.pipelined();
+      Response<Set<Tuple>> range = pipeline.zrevrangeByScoreWithScores("foo", Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 1, 1);
+      Set<Tuple> expected = new LinkedHashSet<Tuple>();
+      expected.add(new Tuple("a", 2d));
+      pipeline.sync();
+      assertEquals(expected, range.get());
+    }
+
+    // zremrangeByScore
+    {
+      Pipeline pipeline = jedis.pipelined();
+      Response<Long> result = pipeline.zremrangeByScore("foo", Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+      pipeline.sync();
+      assertEquals(new Long(3L), result.get());
+    }
+  }
+
   private void verifyHasBothValues(String firstKey, String secondKey, String value1, String value2) {
     assertFalse(firstKey.equals(secondKey));
     assertTrue(firstKey.equals(value1) || firstKey.equals(value2));


### PR DESCRIPTION
Client used to encode double values before calling to BinaryClient methods with byte[] arguments thus skipping infinite values handling which is implemented in BinaryClient's methods with double arguments.