### PR TITLE
Fixing squid S1168 Empty arrays and collections should be returned instead of null- part 1

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -1,6 +1,14 @@
 package redis.clients.jedis;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import redis.clients.util.JedisByteHashMap;
 import redis.clients.util.SafeEncoder;

--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -1,13 +1,6 @@
 package redis.clients.jedis;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import redis.clients.util.JedisByteHashMap;
 import redis.clients.util.SafeEncoder;
@@ -72,7 +65,7 @@ public final class BuilderFactory {
     @SuppressWarnings("unchecked")
     public List<String> build(Object data) {
       if (null == data) {
-        return null;
+        return Collections.emptyList();
       }
       List<byte[]> l = (List<byte[]>) data;
       final ArrayList<String> result = new ArrayList<String>(l.size());
@@ -137,7 +130,7 @@ public final class BuilderFactory {
     @SuppressWarnings("unchecked")
     public Set<String> build(Object data) {
       if (null == data) {
-        return null;
+        return Collections.emptySet();
       }
       List<byte[]> l = (List<byte[]>) data;
       final Set<String> result = new HashSet<String>(l.size());
@@ -162,7 +155,7 @@ public final class BuilderFactory {
     @SuppressWarnings("unchecked")
     public List<byte[]> build(Object data) {
       if (null == data) {
-        return null;
+        return Collections.emptyList();
       }
       List<byte[]> l = (List<byte[]>) data;
 
@@ -179,7 +172,7 @@ public final class BuilderFactory {
     @SuppressWarnings("unchecked")
     public Set<byte[]> build(Object data) {
       if (null == data) {
-        return null;
+        return Collections.emptySet();
       }
       List<byte[]> l = (List<byte[]>) data;
       final Set<byte[]> result = new LinkedHashSet<byte[]>(l);
@@ -222,7 +215,7 @@ public final class BuilderFactory {
     @SuppressWarnings("unchecked")
     public Set<String> build(Object data) {
       if (null == data) {
-        return null;
+        return Collections.emptySet();
       }
       List<byte[]> l = (List<byte[]>) data;
       final Set<String> result = new LinkedHashSet<String>(l.size());
@@ -247,7 +240,7 @@ public final class BuilderFactory {
     @SuppressWarnings("unchecked")
     public Set<Tuple> build(Object data) {
       if (null == data) {
-        return null;
+        return Collections.emptySet();
       }
       List<byte[]> l = (List<byte[]>) data;
       final Set<Tuple> result = new LinkedHashSet<Tuple>(l.size());
@@ -270,7 +263,7 @@ public final class BuilderFactory {
     @SuppressWarnings("unchecked")
     public Set<Tuple> build(Object data) {
       if (null == data) {
-        return null;
+        return Collections.emptySet();
       }
       List<byte[]> l = (List<byte[]>) data;
       final Set<Tuple> result = new LinkedHashSet<Tuple>(l.size());
@@ -348,7 +341,7 @@ public final class BuilderFactory {
     @Override
     public List<GeoCoordinate> build(Object data) {
       if (null == data) {
-        return null;
+        return Collections.emptyList();
       }
       return interpretGeoposResult((List<Object>) data);
     }
@@ -378,7 +371,7 @@ public final class BuilderFactory {
     @Override
     public List<GeoRadiusResponse> build(Object data) {
       if (data == null) {
-        return null;
+        return Collections.emptyList();
       } else {
         List<Object> objectList = (List<Object>) data;
 
@@ -438,7 +431,7 @@ public final class BuilderFactory {
     @Override
     public List<Module> build(Object data) {
       if (data == null) {
-        return null;
+        return Collections.emptyList();
       } else {
         List<List<Object>> objectList = (List<List<Object>>) data;
 

--- a/src/test/java/redis/clients/jedis/tests/commands/ListCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ListCommandsTest.java
@@ -418,6 +418,9 @@ public class ListCommandsTest extends JedisCommandTestBase {
   @Test
   public void blpop() throws InterruptedException {
     List<String> result = jedis.blpop(1, "foo");
+    if(result.isEmpty()){
+      result = null;
+    }
     assertNull(result);
 
     jedis.lpush("foo", "bar");
@@ -442,6 +445,9 @@ public class ListCommandsTest extends JedisCommandTestBase {
   @Test
   public void brpop() throws InterruptedException {
     List<String> result = jedis.brpop(1, "foo");
+    if(result.isEmpty()){
+      result = null;
+    }
     assertNull(result);
 
     jedis.lpush("foo", "bar");


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1168- “ Empty arrays and collections should be returned instead of null”. 
 You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1168
 Please let me know if you have any questions.
 Fevzi Ozgul