### PR TITLE
Fixing squid: S1192 String literals should not be duplicated

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -11,6 +11,8 @@ import redis.clients.util.SafeEncoder;
 
 public abstract class JedisClusterCommand<T> {
 
+  private static final String NO_DISPATCH_MESSAGE = "No way to dispatch this command to Redis Cluster.";
+
   private JedisClusterConnectionHandler connectionHandler;
   private int redirections;
   private ThreadLocal<Jedis> askConnection = new ThreadLocal<Jedis>();
@@ -24,7 +26,7 @@ public abstract class JedisClusterCommand<T> {
 
   public T run(String key) {
     if (key == null) {
-      throw new JedisClusterException("No way to dispatch this command to Redis Cluster.");
+      throw new JedisClusterException(NO_DISPATCH_MESSAGE);
     }
 
     return runWithRetries(SafeEncoder.encode(key), this.redirections, false, false);
@@ -32,7 +34,7 @@ public abstract class JedisClusterCommand<T> {
 
   public T run(int keyCount, String... keys) {
     if (keys == null || keys.length == 0) {
-      throw new JedisClusterException("No way to dispatch this command to Redis Cluster.");
+      throw new JedisClusterException(NO_DISPATCH_MESSAGE);
     }
 
     // For multiple keys, only execute if they all share the
@@ -53,7 +55,7 @@ public abstract class JedisClusterCommand<T> {
 
   public T runBinary(byte[] key) {
     if (key == null) {
-      throw new JedisClusterException("No way to dispatch this command to Redis Cluster.");
+      throw new JedisClusterException(NO_DISPATCH_MESSAGE);
     }
 
     return runWithRetries(key, this.redirections, false, false);
@@ -61,7 +63,7 @@ public abstract class JedisClusterCommand<T> {
 
   public T runBinary(int keyCount, byte[]... keys) {
     if (keys == null || keys.length == 0) {
-      throw new JedisClusterException("No way to dispatch this command to Redis Cluster.");
+      throw new JedisClusterException(NO_DISPATCH_MESSAGE);
     }
 
     // For multiple keys, only execute if they all share the

--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -14,6 +14,8 @@ import redis.clients.util.JedisURIHelper;
 
 public class JedisPool extends JedisPoolAbstract {
 
+  private static final String REDISS = "rediss";
+
   public JedisPool() {
     this(Protocol.DEFAULT_HOST, Protocol.DEFAULT_PORT);
   }
@@ -35,7 +37,7 @@ public class JedisPool extends JedisPoolAbstract {
       int port = uri.getPort();
       String password = JedisURIHelper.getPassword(uri);
       int database = JedisURIHelper.getDBIndex(uri);
-      boolean ssl = uri.getScheme().equals("rediss");
+      boolean ssl = uri.getScheme().equals(REDISS);
       this.internalPool = new GenericObjectPool<Jedis>(new JedisFactory(h, port,
           Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, password, database, null,
             ssl, null, null, null), new GenericObjectPoolConfig());
@@ -54,7 +56,7 @@ public class JedisPool extends JedisPoolAbstract {
       int port = uri.getPort();
       String password = JedisURIHelper.getPassword(uri);
       int database = JedisURIHelper.getDBIndex(uri);
-      boolean ssl = uri.getScheme().equals("rediss");
+      boolean ssl = uri.getScheme().equals(REDISS);
       this.internalPool = new GenericObjectPool<Jedis>(new JedisFactory(h, port,
           Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, password, database, null, ssl,
             sslSocketFactory, sslParameters, hostnameVerifier),
@@ -216,7 +218,7 @@ public class JedisPool extends JedisPoolAbstract {
       final int connectionTimeout, final int soTimeout, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     super(poolConfig, new JedisFactory(uri, connectionTimeout, soTimeout, null,
-        (uri.getScheme() !=null && uri.getScheme().equals("rediss")), sslSocketFactory,
+        (uri.getScheme() !=null && uri.getScheme().equals(REDISS)), sslSocketFactory,
         sslParameters, hostnameVerifier));
   }
 

--- a/src/main/java/redis/clients/jedis/JedisPubSub.java
+++ b/src/main/java/redis/clients/jedis/JedisPubSub.java
@@ -16,6 +16,8 @@ import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.util.SafeEncoder;
 
 public abstract class JedisPubSub {
+
+  private static final String JEDIS_SUBSCRIPTION_MESSAGE = "JedisPubSub is not subscribed to a Jedis instance.";
   private int subscribedChannels = 0;
   private volatile Client client;
 
@@ -43,7 +45,7 @@ public abstract class JedisPubSub {
 
   public void unsubscribe() {
     if (client == null) {
-      throw new JedisConnectionException("JedisPubSub was not subscribed to a Jedis instance.");
+      throw new JedisConnectionException(JEDIS_SUBSCRIPTION_MESSAGE);
     }
     client.unsubscribe();
     client.flush();
@@ -51,7 +53,7 @@ public abstract class JedisPubSub {
 
   public void unsubscribe(String... channels) {
     if (client == null) {
-      throw new JedisConnectionException("JedisPubSub is not subscribed to a Jedis instance.");
+      throw new JedisConnectionException(JEDIS_SUBSCRIPTION_MESSAGE);
     }
     client.unsubscribe(channels);
     client.flush();
@@ -59,7 +61,7 @@ public abstract class JedisPubSub {
 
   public void subscribe(String... channels) {
     if (client == null) {
-      throw new JedisConnectionException("JedisPubSub is not subscribed to a Jedis instance.");
+      throw new JedisConnectionException(JEDIS_SUBSCRIPTION_MESSAGE);
     }
     client.subscribe(channels);
     client.flush();
@@ -67,7 +69,7 @@ public abstract class JedisPubSub {
 
   public void psubscribe(String... patterns) {
     if (client == null) {
-      throw new JedisConnectionException("JedisPubSub is not subscribed to a Jedis instance.");
+      throw new JedisConnectionException(JEDIS_SUBSCRIPTION_MESSAGE);
     }
     client.psubscribe(patterns);
     client.flush();
@@ -75,7 +77,7 @@ public abstract class JedisPubSub {
 
   public void punsubscribe() {
     if (client == null) {
-      throw new JedisConnectionException("JedisPubSub is not subscribed to a Jedis instance.");
+      throw new JedisConnectionException(JEDIS_SUBSCRIPTION_MESSAGE);
     }
     client.punsubscribe();
     client.flush();
@@ -83,7 +85,7 @@ public abstract class JedisPubSub {
 
   public void punsubscribe(String... patterns) {
     if (client == null) {
-      throw new JedisConnectionException("JedisPubSub is not subscribed to a Jedis instance.");
+      throw new JedisConnectionException(JEDIS_SUBSCRIPTION_MESSAGE);
     }
     client.punsubscribe(patterns);
     client.flush();
@@ -91,7 +93,7 @@ public abstract class JedisPubSub {
 
   public void ping() {
     if (client == null) {
-      throw new JedisConnectionException("JedisPubSub is not subscribed to a Jedis instance.");
+      throw new JedisConnectionException(JEDIS_SUBSCRIPTION_MESSAGE);
     }
     client.ping();
     client.flush();

--- a/src/main/java/redis/clients/jedis/JedisShardInfo.java
+++ b/src/main/java/redis/clients/jedis/JedisShardInfo.java
@@ -12,7 +12,8 @@ import redis.clients.util.ShardInfo;
 import redis.clients.util.Sharded;
 
 public class JedisShardInfo extends ShardInfo<Jedis> {
-  
+
+  private static final String REDISS = "rediss";
   private int connectionTimeout;
   private int soTimeout;
   private String host;
@@ -34,7 +35,7 @@ public class JedisShardInfo extends ShardInfo<Jedis> {
       this.port = uri.getPort();
       this.password = JedisURIHelper.getPassword(uri);
       this.db = JedisURIHelper.getDBIndex(uri);
-      this.ssl = uri.getScheme().equals("rediss");
+      this.ssl = uri.getScheme().equals(REDISS);
     } else {
       this.host = host;
       this.port = Protocol.DEFAULT_PORT;
@@ -50,7 +51,7 @@ public class JedisShardInfo extends ShardInfo<Jedis> {
       this.port = uri.getPort();
       this.password = JedisURIHelper.getPassword(uri);
       this.db = JedisURIHelper.getDBIndex(uri);
-      this.ssl = uri.getScheme().equals("rediss");
+      this.ssl = uri.getScheme().equals(REDISS);
       this.sslSocketFactory = sslSocketFactory;
       this.sslParameters = sslParameters;
       this.hostnameVerifier = hostnameVerifier;
@@ -207,7 +208,7 @@ public class JedisShardInfo extends ShardInfo<Jedis> {
     this.port = uri.getPort();
     this.password = JedisURIHelper.getPassword(uri);
     this.db = JedisURIHelper.getDBIndex(uri);
-    this.ssl = uri.getScheme().equals("rediss");
+    this.ssl = uri.getScheme().equals(REDISS);
   }
 
   public JedisShardInfo(URI uri, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
@@ -222,7 +223,7 @@ public class JedisShardInfo extends ShardInfo<Jedis> {
     this.port = uri.getPort();
     this.password = JedisURIHelper.getPassword(uri);
     this.db = JedisURIHelper.getDBIndex(uri);
-    this.ssl = uri.getScheme().equals("rediss");
+    this.ssl = uri.getScheme().equals(REDISS);
     this.sslSocketFactory = sslSocketFactory;
     this.sslParameters = sslParameters;
     this.hostnameVerifier = hostnameVerifier;


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1192 - “String literals should not be duplicated”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1192
 Please let me know if you have any questions.
Fevzi Ozgul