### PR TITLE
Fixing squid: S2583 Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -45,9 +45,7 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
       } catch (JedisConnectionException e) {
         // try next nodes
       } finally {
-        if (jedis != null) {
           jedis.close();
-        }
       }
     }
   }
@@ -62,9 +60,7 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
       } catch (JedisConnectionException e) {
         // try next nodes
       } finally {
-        if (jedis != null) {
           jedis.close();
-        }
       }
     }
   }

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -163,9 +163,7 @@ public class JedisSentinelPool extends JedisPoolAbstract {
         log.warning("Cannot get master address from sentinel running @ " + hap + ". Reason: " + e
             + ". Trying next one.");
       } finally {
-        if (jedis != null) {
           jedis.close();
-        }
       }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2583 - “ Conditions should not unconditionally evaluate to ""TRUE"" or to ""FALSE"" ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2583
 Please let me know if you have any questions.
Fevzi Ozgul
