### PR TITLE
Fixing squid: S1948 Fields in a "Serializable" class should either be transient or serializable

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -3623,7 +3623,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    */
   protected static class SetFromList<E> extends AbstractSet<E> implements Serializable {
     private static final long serialVersionUID = -2850347066962734052L;
-    private final List<E> list;
+    private final transient List<E> list;
 
     private SetFromList(List<E> list) {
       if (list == null) {

--- a/src/main/java/redis/clients/util/JedisByteHashMap.java
+++ b/src/main/java/redis/clients/util/JedisByteHashMap.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 public class JedisByteHashMap implements Map<byte[], byte[]>, Cloneable, Serializable {
   private static final long serialVersionUID = -6971431362627219416L;
-  private Map<ByteArrayWrapper, byte[]> internalMap = new HashMap<ByteArrayWrapper, byte[]>();
+  private transient Map<ByteArrayWrapper, byte[]> internalMap = new HashMap<ByteArrayWrapper, byte[]>();
 
   @Override
   public void clear() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1948 - “Fields in a "Serializable" class should either be transient or serializable”. 
This PR will remove 1h TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1948
 Please let me know if you have any questions.
Fevzi Ozgul