### PR TITLE
Fixing squid:S1161  "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -3677,14 +3677,17 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
       return list.toArray(a);
     }
 
+    @Override
     public String toString() {
       return list.toString();
     }
 
+    @Override
     public int hashCode() {
       return list.hashCode();
     }
 
+    @Override
     public boolean equals(Object o) {
       if (o == this) {
         return true;

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -260,6 +260,7 @@ public class JedisSentinelPool extends JedisPoolAbstract {
       this.subscribeRetryWaitTimeMillis = subscribeRetryWaitTimeMillis;
     }
 
+    @Override
     public void run() {
 
       running.set(true);

--- a/src/main/java/redis/clients/jedis/Response.java
+++ b/src/main/java/redis/clients/jedis/Response.java
@@ -69,6 +69,7 @@ public class Response<T> {
     }
   }
 
+  @Override
   public String toString() {
     return "Response " + builder.toString();
   }

--- a/src/main/java/redis/clients/jedis/Tuple.java
+++ b/src/main/java/redis/clients/jedis/Tuple.java
@@ -20,6 +20,7 @@ public class Tuple implements Comparable<Tuple> {
     this.score = score;
   }
 
+  @Override
   public int hashCode() {
     final int prime = 31;
     int result = 1;
@@ -35,6 +36,7 @@ public class Tuple implements Comparable<Tuple> {
     return result;
   }
 
+  @Override
   public boolean equals(Object obj) {
     if (this == obj) return true;
     if (obj == null) return false;
@@ -46,11 +48,12 @@ public class Tuple implements Comparable<Tuple> {
     return true;
   }
 
+  @Override
   public int compareTo(Tuple other) {
     if (this.score == other.getScore() || Arrays.equals(this.element, other.element)) return 0;
     else return this.score < other.getScore() ? -1 : 1;
   }
-  
+
   public String getElement() {
     if (null != element) {
       return SafeEncoder.encode(element);
@@ -67,6 +70,7 @@ public class Tuple implements Comparable<Tuple> {
     return score;
   }
 
+  @Override
   public String toString() {
     return '[' + Arrays.toString(element) + ',' + score + ']';
   }

--- a/src/main/java/redis/clients/util/Hashing.java
+++ b/src/main/java/redis/clients/util/Hashing.java
@@ -8,10 +8,12 @@ public interface Hashing {
   ThreadLocal<MessageDigest> md5Holder = new ThreadLocal<MessageDigest>();
 
   Hashing MD5 = new Hashing() {
+    @Override
     public long hash(String key) {
       return hash(SafeEncoder.encode(key));
     }
 
+    @Override
     public long hash(byte[] key) {
       try {
         if (md5Holder.get() == null) {

--- a/src/main/java/redis/clients/util/JedisByteHashMap.java
+++ b/src/main/java/redis/clients/util/JedisByteHashMap.java
@@ -104,6 +104,7 @@ public class JedisByteHashMap implements Map<byte[], byte[]>, Cloneable, Seriali
       this.data = data;
     }
 
+    @Override
     public boolean equals(Object other) {
       if (!(other instanceof ByteArrayWrapper)) {
         return false;
@@ -111,6 +112,7 @@ public class JedisByteHashMap implements Map<byte[], byte[]>, Cloneable, Seriali
       return Arrays.equals(data, ((ByteArrayWrapper) other).data);
     }
 
+    @Override
     public int hashCode() {
       return Arrays.hashCode(data);
     }

--- a/src/main/java/redis/clients/util/RedisInputStream.java
+++ b/src/main/java/redis/clients/util/RedisInputStream.java
@@ -176,6 +176,7 @@ public class RedisInputStream extends FilterInputStream {
     return (isNeg ? -value : value);
   }
 
+  @Override
   public int read(byte[] b, int off, int len) throws JedisConnectionException {
     ensureFill();
 

--- a/src/main/java/redis/clients/util/RedisOutputStream.java
+++ b/src/main/java/redis/clients/util/RedisOutputStream.java
@@ -61,10 +61,12 @@ public final class RedisOutputStream extends FilterOutputStream {
     buf[count++] = b;
   }
 
+  @Override
   public void write(final byte[] b) throws IOException {
     write(b, 0, b.length);
   }
 
+  @Override
   public void write(final byte[] b, final int off, final int len) throws IOException {
     if (len >= buf.length) {
       flushBuffer();
@@ -209,6 +211,7 @@ public final class RedisOutputStream extends FilterOutputStream {
     writeCrLf();
   }
 
+  @Override
   public void flush() throws IOException {
     flushBuffer();
     out.flush();


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1161 - “"@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one”. 
This PR will remove 85min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1161
 Please let me know if you have any questions.
 Fevzi Ozgul