### PR TITLE
Fixing squid: S1226 Method parameters, caught exceptions and foreach variables should not be reassigned

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -165,6 +165,7 @@ public class Connection implements Closeable {
   }
 
   public void connect() {
+    //just a trial
     if (!isConnected()) {
       try {
         socket = new Socket();

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -133,7 +133,7 @@ public class Connection implements Closeable {
       try {
         String errorMessage = Protocol.readErrorLineIfPossible(inputStream);
         if (errorMessage != null && errorMessage.length() > 0) {
-          ex = new JedisConnectionException(errorMessage, ex.getCause());
+          JedisConnectionException  exLocal = new JedisConnectionException(errorMessage, ex.getCause());
         }
       } catch (Exception e) {
         /*

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -133,7 +133,7 @@ public class Connection implements Closeable {
       try {
         String errorMessage = Protocol.readErrorLineIfPossible(inputStream);
         if (errorMessage != null && errorMessage.length() > 0) {
-          JedisConnectionException  exLocal = new JedisConnectionException(errorMessage, ex.getCause());
+            ex = new JedisConnectionException(errorMessage, ex.getCause());
         }
       } catch (Exception e) {
         /*

--- a/src/main/java/redis/clients/util/JedisClusterCRC16.java
+++ b/src/main/java/redis/clients/util/JedisClusterCRC16.java
@@ -37,15 +37,16 @@ public final class JedisClusterCRC16 {
 
   public static int getSlot(String key) {
     int s = key.indexOf("{");
+    String keyLocal = key;
     if (s > -1) {
       int e = key.indexOf("}", s + 1);
       if (e > -1 && e != s + 1) {
-        key = key.substring(s + 1, e);
+        keyLocal = key.substring(s + 1, e);
       }
     }
     // optimization with modulo operator with power of 2
     // equivalent to getCRC16(key) % 16384
-    return getCRC16(key) & (16384 - 1);
+    return getCRC16(keyLocal) & (16384 - 1);
   }
 
   public static int getSlot(byte[] key) {

--- a/src/main/java/redis/clients/util/RedisOutputStream.java
+++ b/src/main/java/redis/clients/util/RedisOutputStream.java
@@ -172,13 +172,14 @@ public final class RedisOutputStream extends FilterOutputStream {
   }
   
   public void writeIntCrLf(int value) throws IOException {
+    int valueLocal = value;
     if (value < 0) {
       write((byte) '-');
-      value = -value;
+      valueLocal = -value;
     }
 
     int size = 0;
-    while (value > sizeTable[size])
+    while (valueLocal > sizeTable[size])
       size++;
 
     size++;
@@ -189,20 +190,20 @@ public final class RedisOutputStream extends FilterOutputStream {
     int q, r;
     int charPos = count + size;
 
-    while (value >= 65536) {
-      q = value / 100;
-      r = value - ((q << 6) + (q << 5) + (q << 2));
-      value = q;
+    while (valueLocal >= 65536) {
+      q = valueLocal / 100;
+      r = valueLocal - ((q << 6) + (q << 5) + (q << 2));
+      valueLocal = q;
       buf[--charPos] = DigitOnes[r];
       buf[--charPos] = DigitTens[r];
     }
 
     for (;;) {
-      q = (value * 52429) >>> (16 + 3);
-      r = value - ((q << 3) + (q << 1));
+      q = (valueLocal * 52429) >>> (16 + 3);
+      r = valueLocal - ((q << 3) + (q << 1));
       buf[--charPos] = digits[r];
       value = q;
-      if (value == 0) break;
+      if (valueLocal == 0) break;
     }
     count += size;
 


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1226 - “Method parameters, caught exceptions and foreach variables should not be reassigned”. 
This PR will remove 40min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1226
 Please let me know if you have any questions.
Fevzi Ozgul