### PR TITLE
Fixing squid: S134 Control flow statements "if", "for", "while", "switch" and "try" should not be nested too deeply

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -394,23 +394,7 @@ public final class BuilderFactory {
             List<Object> informations = (List<Object>) obj;
 
             resp = new GeoRadiusResponse((byte[]) informations.get(0));
-
-            int size = informations.size();
-            for (int idx = 1; idx < size; idx++) {
-              Object info = informations.get(idx);
-              if (info instanceof List<?>) {
-                // coordinate
-                List<Object> coord = (List<Object>) info;
-
-                resp.setCoordinate(new GeoCoordinate(convertByteArrayToDouble(coord.get(0)),
-                    convertByteArrayToDouble(coord.get(1))));
-              } else {
-                // distance
-                resp.setDistance(convertByteArrayToDouble(info));
-              }
-            }
-
-            responses.add(resp);
+            responses.add(setDistanceAndRadius(resp, informations));
           }
         } else {
           // list of members
@@ -418,9 +402,26 @@ public final class BuilderFactory {
             responses.add(new GeoRadiusResponse((byte[]) obj));
           }
         }
-
         return responses;
       }
+    }
+
+    private GeoRadiusResponse setDistanceAndRadius(GeoRadiusResponse resp, List<Object> informations) {
+      int size = informations.size();
+      for (int idx = 1; idx < size; idx++) {
+        Object info = informations.get(idx);
+        if (info instanceof List<?>) {
+          // coordinate
+          List<Object> coord = (List<Object>) info;
+
+          resp.setCoordinate(new GeoCoordinate(convertByteArrayToDouble(coord.get(0)),
+                  convertByteArrayToDouble(coord.get(1))));
+        } else {
+          // distance
+          resp.setDistance(convertByteArrayToDouble(info));
+        }
+      }
+      return resp;
     }
 
     private Double convertByteArrayToDouble(Object obj) {

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -188,7 +188,6 @@ public class Connection implements Closeable {
           setSocketParams(socket);
           connectionFailMessage(socket);
         }
-
         outputStream = new RedisOutputStream(socket.getOutputStream());
         inputStream = new RedisInputStream(socket.getInputStream());
       } catch (IOException ex) {


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S134 - “Control flow statements "if", "for", "while", "switch" and "try" should not be nested too deeply ”. This PR will remove 90 min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S134
 Please let me know if you have any questions.
 Fevzi Ozgul