### PR TITLE
Fixing squid: S1168 Empty arrays and collections should be returned instead of null Jedis.java class part 1

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -1180,7 +1180,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     client.smembers(key);
     final List<String> members = client.getMultiBulkReply();
     if (members == null) {
-      return null;
+      return Collections.emptySet();
     }
     return SetFromList.of(members);
   }
@@ -1226,7 +1226,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     client.spop(key, count);
     final List<String> members = client.getMultiBulkReply();
     if (members == null) {
-      return null;
+      return Collections.emptySet();
     }
     return SetFromList.of(members);
   }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1168- “ Empty arrays and collections should be returned instead of null”. 
 You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1168
 Please let me know if you have any questions.
 Fevzi Ozgul