### PR TITLE
Fixing squid S1168 Collections should return empty list instead of null jedis class part 2

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -1308,7 +1308,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     client.sinter(keys);
     final List<String> members = client.getMultiBulkReply();
     if (members == null) {
-      return null;
+      return Collections.emptySet();
     }
     return SetFromList.of(members);
   }
@@ -1348,7 +1348,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     client.sunion(keys);
     final List<String> members = client.getMultiBulkReply();
     if (members == null) {
-      return null;
+      return Collections.emptySet();
     }
     return SetFromList.of(members);
   }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1168 - “Collections should return empty list instead of null ”. 
This PR will remove 60min TD. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1168
 Please let me know if you have any questions.
Fevzi Ozgul