### PR TITLE
Using toLowerCase method causes a ERR syntax error if default Locale is Turkish

### DIFF
--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -3,6 +3,7 @@ package redis.clients.jedis;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.exceptions.JedisAskDataException;
@@ -250,7 +251,7 @@ public final class Protocol {
     public final byte[] raw;
 
     Keyword() {
-      raw = SafeEncoder.encode(this.name().toLowerCase());
+      raw = SafeEncoder.encode(this.name().toLowerCase(Locale.ENGLISH));
     }
   }
 }


### PR DESCRIPTION
Because I dotted and I dottless are different in turkish, e.g. WITHSCORES

http://mattryall.net/blog/2009/02/the-infamous-turkish-locale-bug