### PR TITLE
Move back interfaces to proper place to respect backward compatibility (2.9)

### DIFF
--- a/src/main/java/redis/clients/jedis/PipelineBase.java
+++ b/src/main/java/redis/clients/jedis/PipelineBase.java
@@ -1,7 +1,6 @@
 package redis.clients.jedis;
 
 import redis.clients.jedis.BinaryClient.LIST_POSITION;
-import redis.clients.jedis.commands.RedisPipeline;
 import redis.clients.jedis.params.geo.GeoRadiusParam;
 import redis.clients.jedis.params.sortedset.ZAddParams;
 import redis.clients.jedis.params.sortedset.ZIncrByParams;

--- a/src/main/java/redis/clients/jedis/RedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/RedisPipeline.java
@@ -1,4 +1,4 @@
-package redis.clients.jedis.commands;
+package redis.clients.jedis;
 
 import redis.clients.jedis.*;
 import redis.clients.jedis.params.geo.GeoRadiusParam;


### PR DESCRIPTION
2.8.x breaks this, and we're about to rollback.

It shouldn't be backported to master.
If we're planning to release any 2.8.x versions, please merge this to 2.8 branch, too.

@marcosnils Please review and merge when it's OK. Thanks!