### PR TITLE
eval returns Response<Object>

### DIFF
--- a/src/main/java/redis/clients/jedis/PipelineBase.java
+++ b/src/main/java/redis/clients/jedis/PipelineBase.java
@@ -1314,18 +1314,18 @@ public abstract class PipelineBase extends Queable implements BinaryRedisPipelin
     return getResponse(BuilderFactory.DOUBLE);
   }
 
-  public Response<String> eval(String script) {
+  public Response<Object> eval(String script) {
     return this.eval(script, 0);
   }
 
-  public Response<String> eval(String script, List<String> keys, List<String> args) {
+  public Response<Object> eval(String script, List<String> keys, List<String> args) {
     String[] argv = Jedis.getParams(keys, args);
     return this.eval(script, keys.size(), argv);
   }
 
-  public Response<String> eval(String script, int numKeys, String... args) {
+  public Response<Object> eval(String script, int numKeys, String... args) {
     getClient(script).eval(script, numKeys, args);
-    return getResponse(BuilderFactory.STRING);
+    return getResponse(BuilderFactory.EVAL_RESULT);
   }
 
   public Response<String> evalsha(String script) {

--- a/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
@@ -362,7 +362,7 @@ public class PipeliningTest {
     String script = "return 'success!'";
 
     Pipeline p = jedis.pipelined();
-    Response<String> result = p.eval(script);
+    Response<Object> result = p.eval(script);
     p.sync();
 
     assertEquals("success!", result.get());
@@ -387,9 +387,9 @@ public class PipeliningTest {
 
     Pipeline p = jedis.pipelined();
     p.set(key, "0");
-    Response<String> result0 = p.eval(script, Arrays.asList(key), Arrays.asList(arg));
+    Response<Object> result0 = p.eval(script, Arrays.asList(key), Arrays.asList(arg));
     p.incr(key);
-    Response<String> result1 = p.eval(script, Arrays.asList(key), Arrays.asList(arg));
+    Response<Object> result1 = p.eval(script, Arrays.asList(key), Arrays.asList(arg));
     Response<String> result2 = p.get(key);
     p.sync();
 


### PR DESCRIPTION
Eval return value may not be a string and trying to coerce it into one causes a ClassCastException.

This appears to be a regression. Version 2.2.5, from which I am trying to upgrade, did the right thing...
