### PR TITLE
Revert empty-list-on-transaction-rollback change.

### DIFF
--- a/src/main/java/redis/clients/jedis/Transaction.java
+++ b/src/main/java/redis/clients/jedis/Transaction.java
@@ -46,7 +46,7 @@ public class Transaction extends MultiKeyPipelineBase implements Closeable {
 
     List<Object> unformatted = client.getObjectMultiBulkReply();
     if (unformatted == null) {
-      return Collections.emptyList();
+      return null;
     }
     List<Object> formatted = new ArrayList<Object>();
     for (Object o : unformatted) {
@@ -66,7 +66,7 @@ public class Transaction extends MultiKeyPipelineBase implements Closeable {
 
     List<Object> unformatted = client.getObjectMultiBulkReply();
     if (unformatted == null) {
-      return Collections.emptyList();
+      return null;
     }
     List<Response<?>> response = new ArrayList<Response<?>>();
     for (Object o : unformatted) {

--- a/src/test/java/redis/clients/jedis/tests/commands/TransactionCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/TransactionCommandsTest.java
@@ -89,9 +89,6 @@ public class TransactionCommandsTest extends JedisCommandTestBase {
 
     t.set("mykey", "foo");
     List<Object> resp = t.exec();
-    if(resp.isEmpty()){
-      resp = null;
-    }
     assertEquals(null, resp);
     assertEquals("bar", jedis.get("mykey"));
 
@@ -106,9 +103,6 @@ public class TransactionCommandsTest extends JedisCommandTestBase {
 
     t.set(bmykey, bfoo);
     resp = t.exec();
-    if(resp.isEmpty()){
-      resp = null;
-    }
     assertEquals(null, resp);
     assertTrue(Arrays.equals(bbar, jedis.get(bmykey)));
   }
@@ -269,9 +263,6 @@ public class TransactionCommandsTest extends JedisCommandTestBase {
     jedis2.set("foo", "bar2");
 
     List<Object> results = t.exec();
-    if(results.isEmpty()){
-      results = null;
-    }
     assertNull(results);
   }
 


### PR DESCRIPTION
Revert baed64ca91952f51c3f0bbcfbe4e323a9a302972 (#1301) because it's no longer possible to tell apart whether a transaction was rolled back or the result was just empty. This change restores the previous method contract.

This change should be ported forward to 3.0.0 (`master`).