### PR TITLE
Disable protected mode for test environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ STUNNEL_BIN := $(shell which stunnel)
 
 define REDIS1_CONF
 daemonize yes
+protected-mode no
 port 6379
 requirepass foobared
 pidfile /tmp/redis1.pid
@@ -14,6 +15,7 @@ endef
 
 define REDIS2_CONF
 daemonize yes
+protected-mode no
 port 6380
 requirepass foobared
 pidfile /tmp/redis2.pid
@@ -24,6 +26,7 @@ endef
 
 define REDIS3_CONF
 daemonize yes
+protected-mode no
 port 6381
 requirepass foobared
 masterauth foobared
@@ -35,6 +38,7 @@ endef
 
 define REDIS4_CONF
 daemonize yes
+protected-mode no
 port 6382
 requirepass foobared
 masterauth foobared
@@ -47,6 +51,7 @@ endef
 
 define REDIS5_CONF
 daemonize yes
+protected-mode no
 port 6383
 requirepass foobared
 masterauth foobared
@@ -59,6 +64,7 @@ endef
 
 define REDIS6_CONF
 daemonize yes
+protected-mode no
 port 6384
 requirepass foobared
 masterauth foobared
@@ -70,6 +76,7 @@ endef
 
 define REDIS7_CONF
 daemonize yes
+protected-mode no
 port 6385
 requirepass foobared
 masterauth foobared
@@ -84,6 +91,7 @@ endef
 define REDIS_SENTINEL1
 port 26379
 daemonize yes
+protected-mode no
 sentinel monitor mymaster 127.0.0.1 6379 1
 sentinel auth-pass mymaster foobared
 sentinel down-after-milliseconds mymaster 2000
@@ -96,6 +104,7 @@ endef
 define REDIS_SENTINEL2
 port 26380
 daemonize yes
+protected-mode no
 sentinel monitor mymaster 127.0.0.1 6381 1
 sentinel auth-pass mymaster foobared
 sentinel down-after-milliseconds mymaster 2000
@@ -108,6 +117,7 @@ endef
 define REDIS_SENTINEL3
 port 26381
 daemonize yes
+protected-mode no
 sentinel monitor mymasterfailover 127.0.0.1 6384 1
 sentinel auth-pass mymasterfailover foobared
 sentinel down-after-milliseconds mymasterfailover 2000
@@ -120,6 +130,7 @@ endef
 define REDIS_SENTINEL4
 port 26382
 daemonize yes
+protected-mode no
 sentinel monitor mymaster 127.0.0.1 6381 1
 sentinel auth-pass mymaster foobared
 sentinel down-after-milliseconds mymaster 2000
@@ -132,6 +143,7 @@ endef
 # CLUSTER REDIS NODES
 define REDIS_CLUSTER_NODE1_CONF
 daemonize yes
+protected-mode no
 requirepass cluster
 port 7379
 cluster-node-timeout 50
@@ -145,6 +157,7 @@ endef
 
 define REDIS_CLUSTER_NODE2_CONF
 daemonize yes
+protected-mode no
 requirepass cluster
 port 7380
 cluster-node-timeout 50
@@ -158,6 +171,7 @@ endef
 
 define REDIS_CLUSTER_NODE3_CONF
 daemonize yes
+protected-mode no
 requirepass cluster
 port 7381
 cluster-node-timeout 50
@@ -171,6 +185,7 @@ endef
 
 define REDIS_CLUSTER_NODE4_CONF
 daemonize yes
+protected-mode no
 requirepass cluster
 port 7382
 cluster-node-timeout 50
@@ -184,6 +199,7 @@ endef
 
 define REDIS_CLUSTER_NODE5_CONF
 daemonize yes
+protected-mode no
 requirepass cluster
 port 7383
 cluster-node-timeout 5000


### PR DESCRIPTION
* this makes whole tests fail

This resolves the build failure what @gogeof reported.
https://github.com/xetorthio/jedis/issues/1370#issuecomment-246120348

@marcosnils @xetorthio Please review this, and confirm it doesn't fail on Linux.