### PR TITLE
JedisCluster support choosing database.

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -58,6 +58,12 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
     this.maxAttempts = maxAttempts;
   }
 
+  public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout, int maxAttempts, String password, int database, GenericObjectPoolConfig poolConfig) {
+    this.connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
+            connectionTimeout, soTimeout, password, database);
+    this.maxAttempts = maxAttempts;
+  }
+
   @Override
   public void close() {
     if (connectionHandler != null) {

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -61,7 +61,12 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
                       int maxAttempts, String password, final GenericObjectPoolConfig poolConfig) {
     super(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, password, poolConfig);
   }
-  
+
+  public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout,
+          int maxAttempts, String password, int database, final GenericObjectPoolConfig poolConfig) {
+    super(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, password, database, poolConfig);
+  }
+
   public JedisCluster(Set<HostAndPort> nodes) {
     this(nodes, DEFAULT_TIMEOUT);
   }
@@ -96,6 +101,11 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
                       int maxAttempts, String password, final GenericObjectPoolConfig poolConfig) {
     super(jedisClusterNode, connectionTimeout, soTimeout, maxAttempts, password, poolConfig);
   }
+
+  public JedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout,
+          int maxAttempts, String password, int database, final GenericObjectPoolConfig poolConfig) {
+    super(jedisClusterNode, connectionTimeout, soTimeout, maxAttempts, password, database, poolConfig);
+}
 
   @Override
   public String set(final String key, final String value) {

--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -13,9 +13,14 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
 
   public JedisClusterConnectionHandler(Set<HostAndPort> nodes,
                                        final GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password) {
-    this.cache = new JedisClusterInfoCache(poolConfig, connectionTimeout, soTimeout, password);
-    initializeSlotsCache(nodes, poolConfig, password);
+    this(nodes, poolConfig, connectionTimeout, soTimeout, password, 0);
   }
+
+  public JedisClusterConnectionHandler(Set<HostAndPort> nodes,
+          final GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password, int database) {
+    this.cache = new JedisClusterInfoCache(poolConfig, connectionTimeout, soTimeout, password, database);
+    initializeSlotsCache(nodes, poolConfig, password);
+}
 
   abstract Jedis getConnection();
 

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -31,19 +31,21 @@ public class JedisClusterInfoCache {
   private int connectionTimeout;
   private int soTimeout;
   private String password;
+  private int database;
 
   private static final int MASTER_NODE_INDEX = 2;
 
   public JedisClusterInfoCache(final GenericObjectPoolConfig poolConfig, int timeout) {
-    this(poolConfig, timeout, timeout, null);
+    this(poolConfig, timeout, timeout, null, 0);
   }
 
   public JedisClusterInfoCache(final GenericObjectPoolConfig poolConfig,
-      final int connectionTimeout, final int soTimeout, final String password) {
+      final int connectionTimeout, final int soTimeout, final String password, final int database) {
     this.poolConfig = poolConfig;
     this.connectionTimeout = connectionTimeout;
     this.soTimeout = soTimeout;
     this.password = password;
+    this.database = database;
   }
 
   public void discoverClusterNodesAndSlots(Jedis jedis) {
@@ -156,7 +158,7 @@ public class JedisClusterInfoCache {
       if (existingPool != null) return existingPool;
 
       JedisPool nodePool = new JedisPool(poolConfig, node.getHost(), node.getPort(),
-          connectionTimeout, soTimeout, password, 0, null, false, null, null, null);
+          connectionTimeout, soTimeout, password, database, null, false, null, null, null);
       nodes.put(nodeKey, nodePool);
       return nodePool;
     } finally {

--- a/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
@@ -24,6 +24,10 @@ public class JedisSlotBasedConnectionHandler extends JedisClusterConnectionHandl
     super(nodes, poolConfig, connectionTimeout, soTimeout, password);
   }
 
+  public JedisSlotBasedConnectionHandler(Set<HostAndPort> nodes, GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password, int database) {
+    super(nodes, poolConfig, connectionTimeout, soTimeout, password, database);
+  }
+
   @Override
   public Jedis getConnection() {
     // In antirez's redis-rb-cluster implementation,

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -164,7 +164,23 @@ public class JedisClusterTest {
     JedisCluster jc2 = new JedisCluster(new HostAndPort("127.0.0.1", 7379), DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
     assertEquals(3, jc2.getClusterNodes().size());
   }
-  
+
+  @Test
+  public void testSelectDatabase() {
+    Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
+    jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
+    int database = 1;
+    JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", database, DEFAULT_CONFIG);
+    jc.set("foo", "bar");
+    assertNotEquals("bar", node3.get("foo"));
+    node3.select(database);
+    try{
+        assertEquals("bar", node3.get("foo"));
+    }finally{
+        node3.select(0);
+    }
+  }
+
   @Test
   public void testCalculateConnectionPerSlot() {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();


### PR DESCRIPTION
[Motivation]

JedisCluster should support choosing database instead of default 0.


[Modifications]

(1) add private member: database in JedisClusterInfoCache;
(2) add new constructor with database for JedisCluster;

[Result]

JedisCluster support choosing database.