### PR TITLE
JedisCluster should support setting client name.

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -58,6 +58,12 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
     this.maxAttempts = maxAttempts;
   }
 
+  public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout, int maxAttempts, String password, String clientName, GenericObjectPoolConfig poolConfig) {
+    this.connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
+            connectionTimeout, soTimeout, password, clientName);
+    this.maxAttempts = maxAttempts;
+  }
+
   @Override
   public void close() {
     if (connectionHandler != null) {

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -61,7 +61,12 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
                       int maxAttempts, String password, final GenericObjectPoolConfig poolConfig) {
     super(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, password, poolConfig);
   }
-  
+
+  public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout,
+          int maxAttempts, String password, String clientName, final GenericObjectPoolConfig poolConfig) {
+    super(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, password, clientName, poolConfig);
+  }
+
   public JedisCluster(Set<HostAndPort> nodes) {
     this(nodes, DEFAULT_TIMEOUT);
   }
@@ -96,6 +101,11 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
                       int maxAttempts, String password, final GenericObjectPoolConfig poolConfig) {
     super(jedisClusterNode, connectionTimeout, soTimeout, maxAttempts, password, poolConfig);
   }
+
+  public JedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout,
+          int maxAttempts, String password, String clientName, final GenericObjectPoolConfig poolConfig) {
+    super(jedisClusterNode, connectionTimeout, soTimeout, maxAttempts, password, clientName, poolConfig);
+}
 
   @Override
   public String set(final String key, final String value) {

--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -13,9 +13,14 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
 
   public JedisClusterConnectionHandler(Set<HostAndPort> nodes,
                                        final GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password) {
-    this.cache = new JedisClusterInfoCache(poolConfig, connectionTimeout, soTimeout, password);
-    initializeSlotsCache(nodes, poolConfig, password);
+    this(nodes, poolConfig, connectionTimeout, soTimeout, password, null);
   }
+
+  public JedisClusterConnectionHandler(Set<HostAndPort> nodes,
+          final GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password, String clientName) {
+    this.cache = new JedisClusterInfoCache(poolConfig, connectionTimeout, soTimeout, password, clientName);
+    initializeSlotsCache(nodes, poolConfig, password, clientName);
+}
 
   abstract Jedis getConnection();
 
@@ -29,11 +34,14 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
     return cache.getNodes();
   }
 
-  private void initializeSlotsCache(Set<HostAndPort> startNodes, GenericObjectPoolConfig poolConfig, String password) {
+  private void initializeSlotsCache(Set<HostAndPort> startNodes, GenericObjectPoolConfig poolConfig, String password, String clientName) {
     for (HostAndPort hostAndPort : startNodes) {
       Jedis jedis = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
       if (password != null) {
         jedis.auth(password);
+      }
+      if (clientName != null) {
+        jedis.clientSetname(clientName);
       }
       try {
         cache.discoverClusterNodesAndSlots(jedis);

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -31,19 +31,21 @@ public class JedisClusterInfoCache {
   private int connectionTimeout;
   private int soTimeout;
   private String password;
+  private String clientName;
 
   private static final int MASTER_NODE_INDEX = 2;
 
   public JedisClusterInfoCache(final GenericObjectPoolConfig poolConfig, int timeout) {
-    this(poolConfig, timeout, timeout, null);
+    this(poolConfig, timeout, timeout, null, null);
   }
 
   public JedisClusterInfoCache(final GenericObjectPoolConfig poolConfig,
-      final int connectionTimeout, final int soTimeout, final String password) {
+      final int connectionTimeout, final int soTimeout, final String password, final String clientName) {
     this.poolConfig = poolConfig;
     this.connectionTimeout = connectionTimeout;
     this.soTimeout = soTimeout;
     this.password = password;
+    this.clientName = clientName;
   }
 
   public void discoverClusterNodesAndSlots(Jedis jedis) {
@@ -156,7 +158,7 @@ public class JedisClusterInfoCache {
       if (existingPool != null) return existingPool;
 
       JedisPool nodePool = new JedisPool(poolConfig, node.getHost(), node.getPort(),
-          connectionTimeout, soTimeout, password, 0, null, false, null, null, null);
+          connectionTimeout, soTimeout, password, 0, clientName, false, null, null, null);
       nodes.put(nodeKey, nodePool);
       return nodePool;
     } finally {

--- a/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
@@ -24,6 +24,10 @@ public class JedisSlotBasedConnectionHandler extends JedisClusterConnectionHandl
     super(nodes, poolConfig, connectionTimeout, soTimeout, password);
   }
 
+  public JedisSlotBasedConnectionHandler(Set<HostAndPort> nodes, GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password, String clientName) {
+    super(nodes, poolConfig, connectionTimeout, soTimeout, password, clientName);
+  }
+
   @Override
   public Jedis getConnection() {
     // In antirez's redis-rb-cluster implementation,

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -164,7 +165,25 @@ public class JedisClusterTest {
     JedisCluster jc2 = new JedisCluster(new HostAndPort("127.0.0.1", 7379), DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
     assertEquals(3, jc2.getClusterNodes().size());
   }
-  
+
+  @Test
+  public void testSetClientName() {
+    Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
+    jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
+    String clientName = "myAppName";
+    JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS, "cluster", clientName, DEFAULT_CONFIG);
+    Map<String, JedisPool> clusterNodes = jc.getClusterNodes();
+    Collection<JedisPool> values = clusterNodes.values();
+    for(JedisPool jedisPool: values){
+        Jedis jedis = jedisPool.getResource();
+        try{
+            assertEquals(clientName, jedis.clientGetname());
+        }finally{
+            jedis.close();
+        }
+    }
+  }
+
   @Test
   public void testCalculateConnectionPerSlot() {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();


### PR DESCRIPTION
[Motivation]

JedisCluster should support setting client name similar with other types
of Jedis.

[Modifications]

(1) add private member: clientName in JedisClusterInfoCache;
(2) add new constructor with clientName for JedisCluster;

[Result]

JedisCluster support setting client name.
