### PR TITLE
improve slots cache initialize‘s retry logic

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -37,13 +37,13 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
   private void initializeSlotsCache(Set<HostAndPort> startNodes, GenericObjectPoolConfig poolConfig, String password, String clientName) {
     for (HostAndPort hostAndPort : startNodes) {
       Jedis jedis = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
-      if (password != null) {
-        jedis.auth(password);
-      }
-      if (clientName != null) {
-        jedis.clientSetname(clientName);
-      }
       try {
+        if (password != null) {
+          jedis.auth(password);
+        }
+        if (clientName != null) {
+          jedis.clientSetname(clientName);
+        }
         cache.discoverClusterNodesAndSlots(jedis);
         break;
       } catch (JedisConnectionException e) {

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -609,20 +609,6 @@ public class JedisClusterTest {
   @Test
   public void testInvalidStartNodeNotAdded() {
     HostAndPort invalidHost = new HostAndPort("not-a-real-host", 7379);
-    Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
-    jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
-    jedisClusterNode.add(invalidHost);
-    JedisPoolConfig config = DEFAULT_CONFIG;
-    config.setMaxTotal(1);
-    JedisCluster jc = new JedisCluster(jedisClusterNode,  0, 2, DEFAULT_REDIRECTIONS, "cluster", config);
-    Map<String, JedisPool> clusterNodes = jc.getClusterNodes();
-    assertEquals(3, clusterNodes.size());
-    assertFalse(clusterNodes.containsKey(JedisClusterInfoCache.getNodeKey(invalidHost)));
-  }
-
-  @Test
-  public void testInvalidStartNodeAddedAsFirstOne() {
-    HostAndPort invalidHost = new HostAndPort("not-a-real-host", 7379);
     Set<HostAndPort> jedisClusterNode = new LinkedHashSet<HostAndPort>();
     jedisClusterNode.add(invalidHost);
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -611,6 +612,20 @@ public class JedisClusterTest {
     Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
     jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
     jedisClusterNode.add(invalidHost);
+    JedisPoolConfig config = DEFAULT_CONFIG;
+    config.setMaxTotal(1);
+    JedisCluster jc = new JedisCluster(jedisClusterNode,  0, 2, DEFAULT_REDIRECTIONS, "cluster", config);
+    Map<String, JedisPool> clusterNodes = jc.getClusterNodes();
+    assertEquals(3, clusterNodes.size());
+    assertFalse(clusterNodes.containsKey(JedisClusterInfoCache.getNodeKey(invalidHost)));
+  }
+
+  @Test
+  public void testInvalidStartNodeAddedAsFirstOne() {
+    HostAndPort invalidHost = new HostAndPort("not-a-real-host", 7379);
+    Set<HostAndPort> jedisClusterNode = new LinkedHashSet<HostAndPort>();
+    jedisClusterNode.add(invalidHost);
+    jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
     JedisPoolConfig config = DEFAULT_CONFIG;
     config.setMaxTotal(1);
     JedisCluster jc = new JedisCluster(jedisClusterNode,  0, 2, DEFAULT_REDIRECTIONS, "cluster", config);


### PR DESCRIPTION
[Motivation]
when jedis.auth(password) throw JedisConnectionException, it won't retry next node. It should be improved.

[Modifications]
move the code about auth/clientSetname into try-catch statements.

[Result]
When jedis fail to setup connection with one node to initial slots cache, it will retry next one.