### PR TITLE
zrangeByScore has wrong description for min / max paremeter.

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -2029,8 +2029,8 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
    * @see #zrangeByScoreWithScores(String, double, double, int, int)
    * @see #zcount(String, double, double)
    * @param key
-   * @param min a double or Double.MIN_VALUE for "-inf"
-   * @param max a double or Double.MAX_VALUE for "+inf"
+   * @param min a double or Double.NEGATIVE_INFINITY for "-inf"
+   * @param max a double or Double.POSITIVE_INFINITY for "+inf"
    * @return Multi bulk reply specifically a list of elements in the specified score range.
    */
   @Override


### PR DESCRIPTION
Double.MIN_VALUE & Double.MAX_VALUE doesn't work.
They should be Double.NEGATIVE_INIFINITY & Double.POSITIVE_INFINITY.