### PR TITLE
Replace JUL by slf4j (#1340)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.11</version>
-			<type>jar</type>
-			<scope>test</scope>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.22</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -65,6 +63,26 @@
 			<version>2.4.2</version>
 			<type>jar</type>
 			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<type>jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.8</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>2.8</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/redis/clients/jedis/HostAndPort.java
+++ b/src/main/java/redis/clients/jedis/HostAndPort.java
@@ -2,13 +2,14 @@ package redis.clients.jedis;
 
 import java.io.Serializable;
 import java.net.InetAddress;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HostAndPort implements Serializable {
   private static final long serialVersionUID = -519876229978427751L;
 
-  protected static Logger log = Logger.getLogger(HostAndPort.class.getName());
+  protected static Logger log = LoggerFactory.getLogger(HostAndPort.class.getName());
   public static final String LOCALHOST_STR = getLocalHostQuietly();
 
 
@@ -104,7 +105,8 @@ public class HostAndPort implements Serializable {
     try {
       localAddress = InetAddress.getLocalHost().getHostAddress();
     } catch (Exception ex) {
-      log.logp(Level.SEVERE, HostAndPort.class.getName(), "getLocalHostQuietly", "cant resolve localhost address", ex);
+      log.error("{}.getLocalHostQuietly : cant resolve localhost address",
+        HostAndPort.class.getName(), ex);
       localAddress = "localhost";
     }
     return localAddress;

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -22,13 +22,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
@@ -63,7 +64,7 @@ public class JedisClusterTest {
   private HostAndPort nodeInfo3 = HostAndPortUtil.getClusterServers().get(2);
   private HostAndPort nodeInfo4 = HostAndPortUtil.getClusterServers().get(3);
   private HostAndPort nodeInfoSlave2 = HostAndPortUtil.getClusterServers().get(4);
-  protected Logger log = Logger.getLogger(getClass().getName());
+  protected Logger log = LoggerFactory.getLogger(getClass().getName());
 
   @Before
   public void setUp() throws InterruptedException {

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+
+	<Appenders>
+		<Console name="CONSOLE" target="SYSTEM_OUT">
+			<PatternLayout
+				pattern="[%-5level] %d{ISO8601} [%t] %50.50logger{1.} - %msg%n" />
+		</Console>
+	</Appenders>
+
+	<Loggers>
+		<Root level="info">
+			<AppenderRef ref="CONSOLE" />
+		</Root>
+		<Logger name="redis.clients" level="debug" />
+	</Loggers>
+</Configuration>


### PR DESCRIPTION
A pull request to replace JUL by slf4j.

Used log4j2 with slf4j bridge for testing.

Just had a little trouble to replace  "logp" of JUL. It seems there is no equivalent in SLF4j. Did my best to simulate the same log with SLF4j.

I didn't manage to launch all unit tests. Only a fraction works on my environment. But I have the same number of failure before and after. I was able to saw logging redirect through log4j2 during unit testing. All seems OK, but please launch unit tests to be sure before merging.
