### PR TITLE
Updating Redis supported versions to 3.x.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Jedis is a blazingly small and sane [Redis](http://github.com/antirez/redis "Red
 
 Jedis was conceived to be EASY to use.
 
-Jedis is fully compatible with redis 2.8.x and 3.0.x.
+Jedis is fully compatible with redis 2.8.x and 3.x.x.
 
 ## Community
 


### PR DESCRIPTION
You should say that Jedis is compatible with Redis 3.x.x or say what feature of the 3.2.x you don't support.