### PR TITLE
Prevent ShardedJedis from closing healthy connections

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -35,6 +35,17 @@ import redis.clients.util.Slowlog;
 public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommands,
     AdvancedJedisCommands, ScriptingCommands, BasicCommands, ClusterCommands, SentinelCommands, ModuleCommands {
 
+  public static void destroy(Jedis jedis) {
+    try {
+      try {
+        jedis.quit();
+      } catch(Exception e) {
+      }
+      jedis.disconnect();
+    } catch(Exception e) {
+    }
+  }
+	
   protected JedisPoolAbstract dataSource = null;
 
   public Jedis() {

--- a/src/main/java/redis/clients/util/Sharded.java
+++ b/src/main/java/redis/clients/util/Sharded.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
@@ -64,11 +65,19 @@ public class Sharded<R, S extends ShardInfo<R>> {
   }
 
   public R getShard(byte[] key) {
-    return resources.get(getShardInfo(key));
+    return getShard(getShardInfo(key));
   }
 
   public R getShard(String key) {
-    return resources.get(getShardInfo(key));
+    return getShard(getShardInfo(key));
+  }
+
+  public R getShard(S shardInfo) {
+    return resources.get(shardInfo);
+  }
+
+  public void replaceShard(S shardInfo) {
+    resources.put(shardInfo, shardInfo.createResource());
   }
 
   public S getShardInfo(byte[] key) {
@@ -100,6 +109,10 @@ public class Sharded<R, S extends ShardInfo<R>> {
 
   public Collection<S> getAllShardInfo() {
     return Collections.unmodifiableCollection(nodes.values());
+  }
+
+  public Set<S> getDistinctShardInfo() {
+    return (Set<S>) Collections.unmodifiableSet(resources.keySet());
   }
 
   public Collection<R> getAllShards() {


### PR DESCRIPTION
Problem

The current behavior of ShardedJedisPool is destroying the ShardedJedis instance once it is detected invalid. It impacts the performance when a shard is broken, because connections to the healthy shards will also be closed, and the client will have to communicate with the healthy shards with short lived connections.

Solution

Instead of abandon the ShardedJedis instance, we can just replace the broken connections.