### PR TITLE
Performance decrease a lot during redis cluster fail over period #1512

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -20,7 +20,7 @@ import redis.clients.util.SafeEncoder;
 public class JedisClusterInfoCache {
 	private final Map<String, JedisPool> nodes = new HashMap<String, JedisPool>();
 	private final Map<Integer, JedisPool> slots = new HashMap<Integer, JedisPool>();
-	private final Map<HostAndPort, RedisNodeInfo> nodeInfo = new HashMap<HostAndPort, RedisNodeInfo>();//used to store current node&slot information
+	private final Map<HostAndPort, RedisNodeInfo> nodeInfo = new HashMap<HostAndPort, RedisNodeInfo>();
 
 	private final ReentrantLock slotsLock = new ReentrantLock();
 	private final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -55,6 +55,7 @@ public class JedisClusterInfoCache {
 	}
 
 	public void renewClusterSlots(Jedis jedis) {
+		//a separate lock used to reduce impaction on the workable nodes when a slave node is in failover.
 		if (slotsLock.tryLock()) {
 			try {
 				if (jedis != null) {

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -258,7 +258,7 @@ public class JedisClusterInfoCache {
 		public RedisNodeInfo(HostAndPort targetNode, boolean master) {
 			this.master = master;
 			this.node = targetNode;
-			this.slots = new HashSet<>();
+			this.slots = new HashSet<SlotSegment>();
 		}
 
 		final Set<SlotSegment> slots;

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -20,7 +20,7 @@ import redis.clients.util.SafeEncoder;
 public class JedisClusterInfoCache {
 	private final Map<String, JedisPool> nodes = new HashMap<String, JedisPool>();
 	private final Map<Integer, JedisPool> slots = new HashMap<Integer, JedisPool>();
-	private final Map<HostAndPort, RedisNodeInfo> nodeInfo = new HashMap<HostAndPort, RedisNodeInfo>();
+	private final Map<HostAndPort, RedisNodeInfo> nodeInfo = new HashMap<HostAndPort, RedisNodeInfo>();//used to store current node&slot information
 
 	private final ReentrantLock slotsLock = new ReentrantLock();
 	private final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -74,8 +74,6 @@ public class JedisClusterInfoCache {
 						jedis = jp.getResource();
 						Map<HostAndPort, RedisNodeInfo> _nodeInfo = retriveClusterSlots(jedis);
 						if (hasChanged(_nodeInfo, nodeInfo)) {
-							System.out.println("new slots:" + _nodeInfo);
-							System.out.println("old slots:" + nodeInfo);
 							assignSlots(_nodeInfo);
 						}
 						return;
@@ -240,7 +238,6 @@ public class JedisClusterInfoCache {
 
 	private boolean hasChanged(Map<HostAndPort, RedisNodeInfo> newNodeInfo,
 			Map<HostAndPort, RedisNodeInfo> oldNodeInfo) {
-		System.out.println("check changed");
 		if (newNodeInfo.size() != oldNodeInfo.size())
 			return true;
 
@@ -250,7 +247,6 @@ public class JedisClusterInfoCache {
 				return true;
 			}
 		}
-		System.out.println("unchanged");
 		return false;
 	}
 


### PR DESCRIPTION
The fix aims to reduce the impaction to the normal nodes when the failover is in progress. The core principle is to narrow the use of the write lock in JedisClusterInfoCache.

1. Make sure only one thread can retrieve the new slots by using another lock
2. Compare the new slots with old slots and replace the old slots with new slots when they are different only avoiding unnecessary occupation of the write lock.