### PR TITLE
Add method to return connection handler to get native connection

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -75,6 +75,10 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
     return connectionHandler.getNodes();
   }
 
+  public JedisSlotBasedConnectionHandler getConnectionHandler() {
+	  return (JedisSlotBasedConnectionHandler) this.connectionHandler;
+  }
+
   @Override
   public String set(final byte[] key, final byte[] value) {
     return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {


### PR DESCRIPTION
Add method to return connection handler reference to get Jedis native connection from JedisPool in cluster mode. 

For more information kindly check following URL:
https://github.com/xetorthio/jedis/issues/1527

Google Group thread:
https://groups.google.com/forum/#!topic/jedis_redis/rK2G6F4FyuE