### PR TITLE
Place the connection of the socket in the BinaryClient constructor

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -50,24 +50,29 @@ public class BinaryClient extends Connection {
 
   public BinaryClient() {
     super();
+    connect();
   }
 
   public BinaryClient(final String host) {
     super(host);
+    connect();
   }
 
   public BinaryClient(final String host, final int port) {
     super(host, port);
+    connect();
   }
 
   public BinaryClient(final String host, final int port, final boolean ssl) {
     super(host, port, ssl);
+    connect();
   }
 
   public BinaryClient(final String host, final int port, final boolean ssl,
       final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
       final HostnameVerifier hostnameVerifier) {
     super(host, port, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
+    connect();
   }
 
   public boolean isInMulti() {

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -89,9 +89,6 @@ public class Connection implements Closeable {
 
   public void setTimeoutInfinite() {
     try {
-      if (!isConnected()) {
-        connect();
-      }
       socket.setSoTimeout(0);
     } catch (SocketException ex) {
       broken = true;
@@ -122,7 +119,6 @@ public class Connection implements Closeable {
 
   public Connection sendCommand(final ProtocolCommand cmd, final byte[]... args) {
     try {
-      connect();
       Protocol.sendCommand(outputStream, cmd, args);
       return this;
     } catch (JedisConnectionException ex) {


### PR DESCRIPTION
After testing, when Socket to establish a connection, Socket state will no longer change, unless it calls the appropriate method, if the network causes the Socket connection is disconnected or the server is automatically disconnected, Socket state will not change, So the following code can not detect whether the connection is available
`socket != null && socket.isBound() && !socket.isClosed() && socket.isConnected()
        && !socket.isInputShutdown() && !socket.isOutputShutdown()`
That is, every time you send a command to detect the availability of the connection is not necessary, so intend to remove the detection code, and connect the Socket code to the construction method.