### PR TITLE
add redis4.0 module Command and test

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -1300,4 +1300,13 @@ public class BinaryClient extends Connection {
   public void hstrlen(final byte[] key, final byte[] field) {
     sendCommand(Command.HSTRLEN, key, field);
   }
+  
+  public void moduleExecute(final byte[] command, final byte[] key, final byte[]... args) {
+    final byte[][] allArgs = new byte[args.length + 1][];
+    allArgs[0] = key;
+    for (int i = 0; i < args.length; i++)
+      allArgs[i + 1] = args[i];
+
+    sendCommand(command, args);
+  }
 }

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -1217,4 +1217,13 @@ public class Client extends BinaryClient implements Commands {
     hstrlen(SafeEncoder.encode(key), SafeEncoder.encode(field));
   }
 
+  @Override
+  public void moduleExecute(final String command, final String key, final String... arguments) {
+    byte[][] argumentArray = new byte[arguments.length][];
+    int index = 0;
+    for (String argument : arguments) {
+      argumentArray[index++] = SafeEncoder.encode(argument);
+    }
+    moduleExecute(SafeEncoder.encode(command), SafeEncoder.encode(key), argumentArray);
+  }
 }

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3575,4 +3575,10 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     return client.getIntegerReply();
   }
 
+  @Override
+  public Object moduleExecute(String command, String key, String... args) {
+    checkIsInMultiOrPipeline();
+      client.moduleExecute(command, key, args);
+      return client.getOne();
+  }
 }

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -1853,4 +1853,14 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       }
     }.run(key);
   }
+  
+  @Override
+  public Object moduleExecute(final String command, final String key, final String... args) {
+  return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
+      @Override
+        public Object execute(Jedis connection) {
+          return connection.moduleExecute(command, key, args);
+        }
+    }.run(key);
+  }
 }

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -85,7 +85,7 @@ public final class Protocol {
     sendCommand(os, command.getRaw(), args);
   }
 
-  private static void sendCommand(final RedisOutputStream os, final byte[] command,
+  protected static void sendCommand(final RedisOutputStream os, final byte[] command,
       final byte[]... args) {
     try {
       os.write(ASTERISK_BYTE);

--- a/src/main/java/redis/clients/jedis/commands/Commands.java
+++ b/src/main/java/redis/clients/jedis/commands/Commands.java
@@ -320,4 +320,6 @@ public interface Commands {
    * @param field
    */
   void hstrlen(final String key, final String field);
+  
+  void moduleExecute(final String command,final String key, final String... args);
 }

--- a/src/main/java/redis/clients/jedis/commands/JedisClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/JedisClusterCommands.java
@@ -284,4 +284,6 @@ public interface JedisClusterCommands {
    * @return lenth of the value for key
    */
   Long hstrlen(final String key, final String field);
+  
+  Object moduleExecute(final String command, final String key, final String... args);
 }

--- a/src/main/java/redis/clients/jedis/commands/ModuleCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/ModuleCommands.java
@@ -8,4 +8,6 @@ public interface ModuleCommands {
   String moduleLoad(String path);
   String moduleUnload(String name);
   List<Module> moduleList();
+  
+  Object moduleExecute(String command, String key, String... args) ;
 }

--- a/src/test/java/redis/clients/jedis/tests/commands/ModuleCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ModuleCommandsTest.java
@@ -1,0 +1,16 @@
+package redis.clients.jedis.tests.commands;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ModuleCommandsTest extends JedisCommandTestBase{
+  @Test
+  public void exec() {
+    Object obj = jedis.moduleExecute("testmodule.simple", "testkey", "arg1","arg2");
+    assertEquals(obj instanceof String, true);
+    
+    String str = (String)obj;
+    assertEquals(str,"OK");
+  }
+}


### PR DESCRIPTION
redis4.0 module Command,like 
Object obj = jedis.moduleExecute("testmodule.simple", "testkey", "arg1","arg2");
can be executed.

@marcosnils  ,i rearranged the code,but test need module,it may be not work,please guide me