### PR TITLE
Check jedis isConnected when destory it in ShardedJedisPool

### DIFF
--- a/src/main/java/redis/clients/jedis/ShardedJedisPool.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedisPool.java
@@ -77,15 +77,17 @@ public class ShardedJedisPool extends Pool<ShardedJedis> {
     public void destroyObject(PooledObject<ShardedJedis> pooledShardedJedis) throws Exception {
       final ShardedJedis shardedJedis = pooledShardedJedis.getObject();
       for (Jedis jedis : shardedJedis.getAllShards()) {
-        try {
+        if (jedis.isConnected()) {
           try {
-            jedis.quit();
+            try {
+              jedis.quit();
+            } catch (Exception e) {
+
+            }
+            jedis.disconnect();
           } catch (Exception e) {
 
           }
-          jedis.disconnect();
-        } catch (Exception e) {
-
         }
       }
     }


### PR DESCRIPTION
In some cases, a jedis object may not have connected, but need to be destroyed in Sharded env.

For example, three redis node(r1, r2, r3), r1 is out of network, when we make a ShardedJedis object, and use it to find a key that located in r1, we will get a connectionTimeout Exception, and the jedis of r1 will be marked as broken, but other two jedis object(r2, r3) has not call connect() method. In this case, r1, r2, r3 will first set up TCP connection, then send quit, and close TCP connection next, but we dont need do this!

So I add a check like JedisFactory.