### PR TITLE
active refresh currentHostMaster

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -274,6 +274,16 @@ public class JedisSentinelPool extends JedisPoolAbstract {
           if (!running.get()) {
             break;
           }
+          
+          /*
+           * Added code for active refresh
+           */
+          List<String> masterAddr = j.sentinelGetMasterAddrByName(masterName);  
+          if (masterAddr == null || masterAddr.size() != 2) {
+            log.warn("Can not get master addr, master name: {}. Sentinel: {}：{}.",masterName,host,port);
+          }else{
+              initPool(toHostAndPort(masterAddr)); 
+          }
 
           j.subscribe(new JedisPubSub() {
             @Override


### PR DESCRIPTION
Here's a problem,A master-slave switch occurred during the time of the client network failure,unable to receive subscription message,then currentHostMaster point to the slave.

Added code for active refresh