### PR TITLE
Make BinaryJedis constructor accept "rediss" scheme

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -45,7 +45,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 
   public BinaryJedis(final String host) {
     URI uri = URI.create(host);
-    if (uri.getScheme() != null && uri.getScheme().equals("redis")) {
+    if (uri.getScheme() != null && (uri.getScheme().equals("redis") || uri.getScheme().equals("rediss"))) {
       initializeClientFromURI(uri);
     } else {
       client = new Client(host);

--- a/src/test/java/redis/clients/jedis/tests/SSLJedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/SSLJedisTest.java
@@ -46,6 +46,18 @@ public class SSLJedisTest extends JedisCommandTestBase {
   }
 
   /**
+   * Tests opening a default SSL/TLS connection to redis using "rediss://" scheme url.
+   */
+  @Test
+  public void connectWithUrl() {
+    // The "rediss" scheme instructs jedis to open a SSL/TLS connection.
+    Jedis jedis = new Jedis("rediss://localhost:6390");
+    jedis.auth("foobared");
+    jedis.get("foo");
+    jedis.close();
+  }
+
+  /**
    * Tests opening a default SSL/TLS connection to redis.
    */
   @Test


### PR DESCRIPTION
`initializeClientFromURI` accepts `rediss` scheme, but the constructor does not accept it at the moment.