### PR TITLE
Moved some test codes (mostly Tuple related)

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/HostAndPortTest.java
+++ b/src/test/java/redis/clients/jedis/tests/HostAndPortTest.java
@@ -1,4 +1,4 @@
-package redis.clients.jedis;
+package redis.clients.jedis.tests;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -8,6 +8,8 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.*;
+
+import redis.clients.jedis.HostAndPort;
 
 /**
  * Created by smagellan on 7/11/16.

--- a/src/test/java/redis/clients/jedis/tests/HostAndPortTest.java
+++ b/src/test/java/redis/clients/jedis/tests/HostAndPortTest.java
@@ -1,15 +1,12 @@
 package redis.clients.jedis.tests;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-
-import static org.junit.Assert.*;
 
 import redis.clients.jedis.HostAndPort;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Created by smagellan on 7/11/16.
@@ -20,28 +17,28 @@ public class HostAndPortTest {
     String host = "2a11:1b1:0:111:e111:1f11:1111:1f1e:1999";
     String port = "6379";
 
-    Assert.assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
+    assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
             Arrays.asList(host, port));
 
     host = "";
     port = "";
-    Assert.assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
+    assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
             Arrays.asList(host, port));
 
     host = "localhost";
     port = "";
-    Assert.assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
+    assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
             Arrays.asList(host, port));
 
 
     host = "";
     port = "6379";
-    Assert.assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
+    assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
             Arrays.asList(host, port));
 
     host = "11:22:33:44:55";
     port = "";
-    Assert.assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
+    assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
             Arrays.asList(host, port));
   }
 
@@ -50,8 +47,8 @@ public class HostAndPortTest {
     String host = "2a11:1b1:0:111:e111:1f11:1111:1f1e:1999";
     int port = 6379;
     HostAndPort hp = HostAndPort.parseString(host + ":" + Integer.toString(port));
-    Assert.assertEquals(host, hp.getHost());
-    Assert.assertEquals(port, hp.getPort());
+    assertEquals(host, hp.getHost());
+    assertEquals(port, hp.getPort());
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -63,6 +60,6 @@ public class HostAndPortTest {
   @Test
   public void checkConvertHost() {
     String host = "2a11:1b1:0:111:e111:1f11:1111:1f1e";
-    Assert.assertEquals(HostAndPort.convertHost(host), host);
+    assertEquals(HostAndPort.convertHost(host), host);
   }
 }

--- a/src/test/java/redis/clients/jedis/tests/TupleTest.java
+++ b/src/test/java/redis/clients/jedis/tests/TupleTest.java
@@ -12,6 +12,16 @@ import static org.junit.Assert.assertEquals;
 public class TupleTest {
 
   @Test
+  public void tupleCompare() {
+    Tuple t1 = new Tuple("foo", 1d);
+    Tuple t2 = new Tuple("bar", 2d);
+
+    assertEquals(-1, t1.compareTo(t2));
+    assertEquals(1, t2.compareTo(t1));
+    assertEquals(0, t2.compareTo(t2));
+  }
+
+  @Test
   public void testCompareTo() {
     Tuple t1 = new Tuple("foo", 1.0);
     Tuple t2 = new Tuple("bar", 1.0);

--- a/src/test/java/redis/clients/jedis/tests/TupleTest.java
+++ b/src/test/java/redis/clients/jedis/tests/TupleTest.java
@@ -1,9 +1,10 @@
 package redis.clients.jedis.tests;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 import redis.clients.jedis.Tuple;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Antonio Tomac <antonio.tomac@mediatoolkit.com>

--- a/src/test/java/redis/clients/jedis/tests/TupleTest.java
+++ b/src/test/java/redis/clients/jedis/tests/TupleTest.java
@@ -1,7 +1,9 @@
-package redis.clients.jedis;
+package redis.clients.jedis.tests;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
+
+import redis.clients.jedis.Tuple;
 
 /**
  * @author Antonio Tomac <antonio.tomac@mediatoolkit.com>

--- a/src/test/java/redis/clients/jedis/tests/TupleTest.java
+++ b/src/test/java/redis/clients/jedis/tests/TupleTest.java
@@ -25,17 +25,13 @@ public class TupleTest {
   public void testCompareTo() {
     Tuple t1 = new Tuple("foo", 1.0);
     Tuple t2 = new Tuple("bar", 1.0);
-    Tuple t3 = new Tuple("elem3", 2.0);
-    Tuple t4 = new Tuple("foo", 10.0);
+    Tuple t3 = new Tuple("foo", 10.0);
 
     assertEquals(0, t1.compareTo(t2));
     assertEquals(0, t2.compareTo(t1));
 
-    assertEquals(-1, t1.compareTo(t3));
-    assertEquals(1, t3.compareTo(t1));
-
-    assertEquals(0, t1.compareTo(t4));
-    assertEquals(0, t4.compareTo(t1));
+    assertEquals(0, t1.compareTo(t3));
+    assertEquals(0, t3.compareTo(t1));
   }
 
 }

--- a/src/test/java/redis/clients/jedis/tests/commands/SortedSetCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/SortedSetCommandsTest.java
@@ -1114,16 +1114,6 @@ public class SortedSetCommandsTest extends JedisCommandTestBase {
   }
 
   @Test
-  public void tupleCompare() {
-    Tuple t1 = new Tuple("foo", 1d);
-    Tuple t2 = new Tuple("bar", 2d);
-
-    assertEquals(-1, t1.compareTo(t2));
-    assertEquals(1, t2.compareTo(t1));
-    assertEquals(0, t2.compareTo(t2));
-  }
-
-  @Test
   public void zscan() {
     jedis.zadd("foo", 1, "a");
     jedis.zadd("foo", 2, "b");


### PR DESCRIPTION
1. There were two test classes in redis.clients.jedis package which are now moved to redis.clients.jedis.tests package.
2. `import static` is used for `assertEquals` in HostAndPortTest class.
3. `tupleCompare` test method is moved into TupleTest class and removed two redundant checks.