### PR TITLE
Modified Tuple.compareTo()

### DIFF
--- a/src/main/java/redis/clients/jedis/Tuple.java
+++ b/src/main/java/redis/clients/jedis/Tuple.java
@@ -2,6 +2,7 @@ package redis.clients.jedis;
 
 import java.util.Arrays;
 
+import redis.clients.util.ByteArrayComparator;
 import redis.clients.util.SafeEncoder;
 
 public class Tuple implements Comparable<Tuple> {
@@ -50,8 +51,14 @@ public class Tuple implements Comparable<Tuple> {
 
   @Override
   public int compareTo(Tuple other) {
-    if (this.score == other.getScore() || Arrays.equals(this.element, other.element)) return 0;
-    else return this.score < other.getScore() ? -1 : 1;
+    return compare(this, other);
+  }
+
+  public static int compare(Tuple t1, Tuple t2) {
+    int compScore = Double.compare(t1.score, t2.score);
+    if(compScore != 0) return compScore;
+
+    return ByteArrayComparator.compare(t1.element, t2.element);
   }
 
   public String getElement() {

--- a/src/main/java/redis/clients/util/ByteArrayComparator.java
+++ b/src/main/java/redis/clients/util/ByteArrayComparator.java
@@ -1,0 +1,24 @@
+package redis.clients.util;
+
+public final class ByteArrayComparator {
+  private ByteArrayComparator() {
+    throw new InstantiationError( "Must not instantiate this class" );
+  }
+
+  public static int compare(final byte[] val1, final byte[] val2) {
+    int len1 = val1.length;
+    int len2 = val2.length;
+    int lmin = Math.min(len1, len2);
+
+    for (int i = 0; i < lmin; i++) {
+      byte b1 = val1[i];
+      byte b2 = val2[i];
+      if(b1 < b2) return -1;
+      if(b1 > b2) return 1;
+    }
+
+    if(len1 < len2) return -1;
+    if(len1 > len2) return 1;
+    return 0;
+  }
+}

--- a/src/test/java/redis/clients/jedis/tests/TupleSortedSetTest.java
+++ b/src/test/java/redis/clients/jedis/tests/TupleSortedSetTest.java
@@ -1,5 +1,7 @@
 package redis.clients.jedis.tests;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -9,14 +11,14 @@ import org.junit.Test;
 import redis.clients.jedis.Tuple;
 import redis.clients.jedis.tests.commands.JedisCommandTestBase;
 
-import static org.junit.Assert.assertEquals;
-
 public class TupleSortedSetTest extends JedisCommandTestBase {
   final byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };
   final byte[] ba = { 0x0A };
   final byte[] bb = { 0x0B };
   final byte[] bc = { 0x0C };
   final byte[] bd = { 0x0D };
+  final byte[] be = { 0x0E };
+  final byte[] bf = { 0x0F };
 
   @Test
   public void testBinary() {
@@ -33,6 +35,12 @@ public class TupleSortedSetTest extends JedisCommandTestBase {
 
     jedis.zadd(bfoo, -0.3, bc);
     sortedSet.add(new Tuple(bc, -0.3));
+
+    jedis.zadd(bfoo, 0.3, bf);
+    sortedSet.add(new Tuple(bf, 0.3));
+
+    jedis.zadd(bfoo, 0.3, be);
+    sortedSet.add(new Tuple(be, 0.3));
 
     jedis.zadd(bfoo, 0.3, bd);
     sortedSet.add(new Tuple(bd, 0.3));
@@ -56,6 +64,12 @@ public class TupleSortedSetTest extends JedisCommandTestBase {
 
     jedis.zadd("foo", -0.3, "c");
     sortedSet.add(new Tuple("c", -0.3));
+
+    jedis.zadd("foo", 0.3, "f");
+    sortedSet.add(new Tuple("f", 0.3));
+
+    jedis.zadd("foo", 0.3, "e");
+    sortedSet.add(new Tuple("e", 0.3));
 
     jedis.zadd("foo", 0.3, "d");
     sortedSet.add(new Tuple("d", 0.3));

--- a/src/test/java/redis/clients/jedis/tests/TupleSortedSetTest.java
+++ b/src/test/java/redis/clients/jedis/tests/TupleSortedSetTest.java
@@ -1,0 +1,66 @@
+package redis.clients.jedis.tests;
+
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.junit.Test;
+
+import redis.clients.jedis.Tuple;
+import redis.clients.jedis.tests.commands.JedisCommandTestBase;
+
+import static org.junit.Assert.assertEquals;
+
+public class TupleSortedSetTest extends JedisCommandTestBase {
+  final byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };
+  final byte[] ba = { 0x0A };
+  final byte[] bb = { 0x0B };
+  final byte[] bc = { 0x0C };
+  final byte[] bd = { 0x0D };
+
+  @Test
+  public void testBinary() {
+    SortedSet<Tuple> sortedSet = new TreeSet<Tuple>();
+
+    jedis.zadd(bfoo, 0d, ba);
+    sortedSet.add(new Tuple(ba, 0d));
+
+    jedis.zadd(bfoo, 1d, bb);
+    sortedSet.add(new Tuple(bb, 1d));
+
+    Set<Tuple> zrange = jedis.zrangeWithScores(bfoo, 0, -1);
+    assertEquals(sortedSet, zrange);
+
+    jedis.zadd(bfoo, -0.3, bc);
+    sortedSet.add(new Tuple(bc, -0.3));
+
+    jedis.zadd(bfoo, 0.3, bd);
+    sortedSet.add(new Tuple(bd, 0.3));
+
+    zrange = jedis.zrangeWithScores(bfoo, 0, -1);
+    assertEquals(sortedSet, zrange);
+  }
+
+  @Test
+  public void testString() {
+    SortedSet<Tuple> sortedSet = new TreeSet<Tuple>();
+
+    jedis.zadd("foo", 0d, "a");
+    sortedSet.add(new Tuple("a", 0d));
+
+    jedis.zadd("foo", 1d, "b");
+    sortedSet.add(new Tuple("b", 1d));
+
+    Set<Tuple> range = jedis.zrangeWithScores("foo", 0, -1);
+    assertEquals(sortedSet, range);
+
+    jedis.zadd("foo", -0.3, "c");
+    sortedSet.add(new Tuple("c", -0.3));
+
+    jedis.zadd("foo", 0.3, "d");
+    sortedSet.add(new Tuple("d", 0.3));
+
+    range = jedis.zrangeWithScores("foo", 0, -1);
+    assertEquals(sortedSet, range);
+  }
+}

--- a/src/test/java/redis/clients/jedis/tests/TupleTest.java
+++ b/src/test/java/redis/clients/jedis/tests/TupleTest.java
@@ -5,33 +5,53 @@ import org.junit.Test;
 import redis.clients.jedis.Tuple;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-/**
- * @author Antonio Tomac <antonio.tomac@mediatoolkit.com>
- */
 public class TupleTest {
 
   @Test
-  public void tupleCompare() {
+  public void compareEqual() {
+    Tuple t1 = new Tuple("foo", 1d);
+    Tuple t2 = new Tuple("foo", 1d);
+
+    assertEquals(0, t1.compareTo(t2));
+    assertEquals(0, t2.compareTo(t1));
+    assertTrue(t1.equals(t2));
+    assertTrue(t2.equals(t1));
+  }
+
+  @Test
+  public void compareSameScore() {
+    Tuple t1 = new Tuple("foo", 1d);
+    Tuple t2 = new Tuple("bar", 1d);
+
+    assertEquals(1, t1.compareTo(t2));
+    assertEquals(-1, t2.compareTo(t1));
+    assertFalse(t1.equals(t2));
+    assertFalse(t2.equals(t1));
+  }
+
+  @Test
+  public void compareSameScoreObject() {
+    Double score = 1d;
+    Tuple t1 = new Tuple("foo", score);
+    Tuple t2 = new Tuple("bar", score);
+
+    assertEquals(1, t1.compareTo(t2));
+    assertEquals(-1, t2.compareTo(t1));
+    assertFalse(t1.equals(t2));
+    assertFalse(t2.equals(t1));
+  }
+
+  @Test
+  public void compareNoMatch() {
     Tuple t1 = new Tuple("foo", 1d);
     Tuple t2 = new Tuple("bar", 2d);
 
     assertEquals(-1, t1.compareTo(t2));
     assertEquals(1, t2.compareTo(t1));
-    assertEquals(0, t2.compareTo(t2));
+    assertFalse(t1.equals(t2));
+    assertFalse(t2.equals(t1));
   }
-
-  @Test
-  public void testCompareTo() {
-    Tuple t1 = new Tuple("foo", 1.0);
-    Tuple t2 = new Tuple("bar", 1.0);
-    Tuple t3 = new Tuple("foo", 10.0);
-
-    assertEquals(0, t1.compareTo(t2));
-    assertEquals(0, t2.compareTo(t1));
-
-    assertEquals(0, t1.compareTo(t3));
-    assertEquals(0, t3.compareTo(t1));
-  }
-
 }

--- a/src/test/java/redis/clients/jedis/tests/TupleTest.java
+++ b/src/test/java/redis/clients/jedis/tests/TupleTest.java
@@ -1,12 +1,12 @@
 package redis.clients.jedis.tests;
 
-import org.junit.Test;
-
-import redis.clients.jedis.Tuple;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import redis.clients.jedis.Tuple;
 
 public class TupleTest {
 

--- a/src/test/java/redis/clients/jedis/tests/utils/ByteArrayComparatorTest.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/ByteArrayComparatorTest.java
@@ -1,0 +1,22 @@
+package redis.clients.jedis.tests.utils;
+
+import org.junit.Test;
+import redis.clients.util.ByteArrayComparator;
+
+import redis.clients.util.SafeEncoder;
+
+import static org.junit.Assert.assertEquals;
+
+public class ByteArrayComparatorTest {
+
+  @Test
+  public void test() {
+    byte[] foo = SafeEncoder.encode("foo");
+    byte[] foo2 = SafeEncoder.encode("foo");
+    byte[] bar = SafeEncoder.encode("bar");
+
+    assertEquals(0, ByteArrayComparator.compare(foo, foo2));
+    assertEquals(1, ByteArrayComparator.compare(foo, bar));
+    assertEquals(-1, ByteArrayComparator.compare(bar, foo));
+  }
+}

--- a/src/test/java/redis/clients/jedis/tests/utils/ByteArrayComparatorTest.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/ByteArrayComparatorTest.java
@@ -1,11 +1,11 @@
 package redis.clients.jedis.tests.utils;
 
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
+
 import redis.clients.util.ByteArrayComparator;
-
 import redis.clients.util.SafeEncoder;
-
-import static org.junit.Assert.assertEquals;
 
 public class ByteArrayComparatorTest {
 
@@ -15,8 +15,16 @@ public class ByteArrayComparatorTest {
     byte[] foo2 = SafeEncoder.encode("foo");
     byte[] bar = SafeEncoder.encode("bar");
 
-    assertEquals(0, ByteArrayComparator.compare(foo, foo2));
-    assertEquals(1, ByteArrayComparator.compare(foo, bar));
-    assertEquals(-1, ByteArrayComparator.compare(bar, foo));
+    assertTrue(ByteArrayComparator.compare(foo, foo2) == 0);
+    assertTrue(ByteArrayComparator.compare(foo, bar) > 0);
+    assertTrue(ByteArrayComparator.compare(bar, foo) < 0);
+  }
+
+  @Test
+  public void testPrefix() {
+    byte[] foo = SafeEncoder.encode("foo");
+    byte[] fooo = SafeEncoder.encode("fooo");
+    assertTrue(ByteArrayComparator.compare(foo, fooo) < 0);
+    assertTrue(ByteArrayComparator.compare(fooo, foo) > 0);
   }
 }


### PR DESCRIPTION
Tuple.compareTo() was not handled correctly. For example, following code used to output `0`, but it should not.

```
    Tuple tuple1 = new Tuple(user1, 1d);
    Tuple tuple2 = new Tuple(user2, 1d);
    System.out.println(tuple1.compareTo(tuple2));
```

This issue is _attempted_ to be solved.

Furthermore, SortedSet<Tuple> will maintain the default order of Redis SortedSet as long as the precision issue does not come into play.