### PR TITLE
Removed exists(key) method from Commands interface

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -137,10 +137,6 @@ public class BinaryClient extends Connection {
     sendCommand(EXISTS, keys);
   }
 
-  public void exists(final byte[] key) {
-    sendCommand(EXISTS, key);
-  }
-
   public void del(final byte[]... keys) {
     sendCommand(DEL, keys);
   }

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -60,16 +60,12 @@ public class Client extends BinaryClient implements Commands {
   }
 
   @Override
-  public void exists(final String key) {
-    exists(SafeEncoder.encode(key));
-  }
-
-  @Override
   public void exists(final String... keys) {
     final byte[][] bkeys = SafeEncoder.encodeMany(keys);
     exists(bkeys);
   }
 
+  @Override
   public void del(final String... keys) {
     final byte[][] bkeys = new byte[keys.length][];
     for (int i = 0; i < keys.length; i++) {

--- a/src/main/java/redis/clients/jedis/commands/Commands.java
+++ b/src/main/java/redis/clients/jedis/commands/Commands.java
@@ -19,8 +19,6 @@ public interface Commands {
 
   void get(final String key);
 
-  void exists(final String key);
-
   void exists(final String... keys);
 
   void del(final String... keys);


### PR DESCRIPTION
Removed exists(key) methods. These can be served by existing exists(array_of_keys) methods.