### PR TITLE
simple the call chain for cluster related commands

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -74,6 +74,15 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   public Map<String, JedisPool> getClusterNodes() {
     return connectionHandler.getNodes();
   }
+	    
+  public JedisPool getAnyClusterNode() {
+    Collection<JedisPool> jedisPools = getClusterNodes().values();
+    if(jedisPools.isEmpty()) {
+	throw new JedisClusterException("not any known node in cluster");
+    }
+    Collections.shuffle(jedisPools);
+    return jedisPools.iterator().next();
+  }
 
   public Jedis getConnectionFromSlot(int slot) {
 	  return  this.connectionHandler.getConnectionFromSlot(slot);


### PR DESCRIPTION
Simple the call chain for cluster related commands for JedisCluster

**Motivation**:
The long call chain will be written to execute all cluster commands in ClusterCommands.
For example. to retrieve cluster info:

`JedisCluster.getClusterNodes().values().iterator().next().getResource().clusterInfo()
`
What's more, to avoid hot calls to single fixed node:
```
Collection<JedisPool> jedisPools = JedisCluster.getClusterNodes().values();
if(jedisPools.isEmpty()) {
     throw new JedisClusterException("not any known node in cluster");
      }
      Collections.shuffle(jedisPools);
     return jedisPools.iterator().next().getResource().clusterInfo();
}
```
**Modifications**:
provide new method: getAnyClusterNode() with nodes shuffled.
 
**Result**: 
it will be simple to execute all cluster related commands:

`JedisCluster.getAnyClusterNode().getResource().clusterInfo()`