### PR TITLE
simple the call chain for cluster related commands

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -9,6 +9,7 @@ import redis.clients.jedis.params.sortedset.ZAddParams;
 import redis.clients.jedis.params.sortedset.ZIncrByParams;
 import redis.clients.util.KeyMergeUtil;
 import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.exceptions.JedisClusterException;
 
 import java.io.Closeable;
 import java.util.Collection;
@@ -73,6 +74,14 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   public Map<String, JedisPool> getClusterNodes() {
     return connectionHandler.getNodes();
+  }
+	    
+  public JedisPool getAnyClusterNode() {
+    Collection<JedisPool> jedisPools = getClusterNodes().values();
+    if(jedisPools.isEmpty()) {
+	throw new JedisClusterException("not any known node in cluster");
+    }
+    return jedisPools.stream().findAny().get();
   }
 
   public Jedis getConnectionFromSlot(int slot) {


### PR DESCRIPTION
Simple the call chain for cluster related commands for JedisCluster.

Motivation:
The long call chain will be written to execute all cluster commands in ClusterCommands.
For example. to retrieve cluster related info:

`
JedisCluster.getClusterNodes().values().iterator().next().getResource().clusterInfo()
JedisCluster.getClusterNodes().values().iterator().next().getResource().clusterSlots()
JedisCluster.getClusterNodes().values().iterator().next().getResource().clusterNodes()
`

What's more, to avoid hot calls to single fixed node:

```
Collection<JedisPool> jedisPools = JedisCluster.getClusterNodes().values();
if(jedisPools.isEmpty()) {
     throw new JedisClusterException("not any known node in cluster");
      }
      return jedisPools.stream().findAny().get().getResource().clusterInfo();
}
```

Modifications:
provide new method: getAnyClusterNode() with nodes shuffled.
 
Result: 
it will be simple to execute all cluster related commands:

`JedisCluster.getAnyClusterNode().getResource().clusterInfo()
JedisCluster.getAnyClusterNode().getResource().clusterSlots()
JedisCluster.getAnyClusterNode().getResource().clusterNodes()
`