### PR TITLE
rename DEFAULT_MAX_REDIRECTIONS to DEFAULT_MAX_ATTEMPTS

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -24,14 +24,14 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   public static final short HASHSLOTS = 16384;
   protected static final int DEFAULT_TIMEOUT = 2000;
-  protected static final int DEFAULT_MAX_REDIRECTIONS = 5;
+  protected static final int DEFAULT_MAX_ATTEMPTS = 5;
 
   protected int maxAttempts;
 
   protected JedisClusterConnectionHandler connectionHandler;
 
   public BinaryJedisCluster(Set<HostAndPort> nodes, int timeout) {
-    this(nodes, timeout, DEFAULT_MAX_REDIRECTIONS, new GenericObjectPoolConfig());
+    this(nodes, timeout, DEFAULT_MAX_ATTEMPTS, new GenericObjectPoolConfig());
   }
 
   public BinaryJedisCluster(Set<HostAndPort> nodes) {

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -32,7 +32,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   }
 
   public JedisCluster(HostAndPort node, int timeout) {
-    this(Collections.singleton(node), timeout, DEFAULT_MAX_REDIRECTIONS);
+    this(Collections.singleton(node), timeout, DEFAULT_MAX_ATTEMPTS);
   }
 
   public JedisCluster(HostAndPort node, int timeout, int maxAttempts) {
@@ -40,11 +40,11 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   }
 
   public JedisCluster(HostAndPort node, final GenericObjectPoolConfig poolConfig) {
-    this(Collections.singleton(node), DEFAULT_TIMEOUT, DEFAULT_MAX_REDIRECTIONS, poolConfig);
+    this(Collections.singleton(node), DEFAULT_TIMEOUT, DEFAULT_MAX_ATTEMPTS, poolConfig);
   }
 
   public JedisCluster(HostAndPort node, int timeout, final GenericObjectPoolConfig poolConfig) {
-    this(Collections.singleton(node), timeout, DEFAULT_MAX_REDIRECTIONS, poolConfig);
+    this(Collections.singleton(node), timeout, DEFAULT_MAX_ATTEMPTS, poolConfig);
   }
 
   public JedisCluster(HostAndPort node, int timeout, int maxAttempts,
@@ -72,7 +72,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   }
 
   public JedisCluster(Set<HostAndPort> nodes, int timeout) {
-    this(nodes, timeout, DEFAULT_MAX_REDIRECTIONS);
+    this(nodes, timeout, DEFAULT_MAX_ATTEMPTS);
   }
 
   public JedisCluster(Set<HostAndPort> nodes, int timeout, int maxAttempts) {
@@ -80,11 +80,11 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   }
 
   public JedisCluster(Set<HostAndPort> nodes, final GenericObjectPoolConfig poolConfig) {
-    this(nodes, DEFAULT_TIMEOUT, DEFAULT_MAX_REDIRECTIONS, poolConfig);
+    this(nodes, DEFAULT_TIMEOUT, DEFAULT_MAX_ATTEMPTS, poolConfig);
   }
 
   public JedisCluster(Set<HostAndPort> nodes, int timeout, final GenericObjectPoolConfig poolConfig) {
-    this(nodes, timeout, DEFAULT_MAX_REDIRECTIONS, poolConfig);
+    this(nodes, timeout, DEFAULT_MAX_ATTEMPTS, poolConfig);
   }
 
   public JedisCluster(Set<HostAndPort> jedisClusterNode, int timeout, int maxAttempts,


### PR DESCRIPTION
Find that maxRedirection has been rename to maxAttempts in JedisCluster.

Should we also rename DEFAULT_MAX_REDIRECYIONS to DEFAULT_MAX_ATTEMPTS.

This time, I make patch against to master.