### PR TITLE
Altered usage of runBinary with run in JedisCluster

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -1258,7 +1258,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
         public ScanResult<String> execute(Jedis connection) {
           return connection.scan(cursor, params);
         }
-      }.runBinary(SafeEncoder.encode(matchPattern));
+      }.run(matchPattern);
     } else {
       throw new IllegalArgumentException(JedisCluster.class.getSimpleName() + " only supports SCAN commands with MATCH patterns containing hash-tags ( curly-brackets enclosed strings )");
     }


### PR DESCRIPTION
`JedisClusterCommand.runBinary` is used in only BinaryJedisCluster and `JedisClusterCommand.run` is used only in JedisCluster. The only exception is altered in this PR.