### PR TITLE
Removed checkIsInMultiOrPipeline

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -2478,7 +2478,6 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   }
 
   private Set<Tuple> getBinaryTupledSet() {
-    checkIsInMultiOrPipeline();
     List<byte[]> membersWithScores = client.getBinaryMultiBulkReply();
     if (membersWithScores.isEmpty()) {
       return Collections.emptySet();

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -2254,7 +2254,6 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
   }
 
   private Set<Tuple> getTupledSet() {
-    checkIsInMultiOrPipeline();
     List<String> membersWithScores = client.getMultiBulkReply();
     if (membersWithScores == null) {
       return Collections.emptySet();


### PR DESCRIPTION
Calling `checkIsInMultiOrPipeline` should be the responsibility of public methods which would actually be called by users. Thing is, it is done properly in those methods. As a result, calling this again in private methods leads `checkIsInMultiOrPipeline` to being called twice for same operation.