### PR TITLE
removing squid:s2925

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,23 @@
 			<version>2.8</version>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.awaitility/awaitility -->
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<version>3.0.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility-proxy</artifactId>
+			<version>3.0.0</version>
+			<scope>test</scope>
+		</dependency>
+
+
 	</dependencies>
 
   <distributionManagement>

--- a/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
@@ -1,6 +1,5 @@
 package redis.clients.jedis.tests.commands;
 
-
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -10,19 +9,16 @@ import static redis.clients.jedis.ScanParams.SCAN_POINTER_START;
 import static redis.clients.jedis.ScanParams.SCAN_POINTER_START_BINARY;
 import static redis.clients.jedis.params.set.SetParams.setParams;
 
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
-import static org.awaitility.Awaitility.*;
 
 import redis.clients.jedis.Protocol.Keyword;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
+import redis.clients.jedis.tests.utils.AwaitilityUtils;
 import redis.clients.util.SafeEncoder;
 
 public class AllKindOfValuesCommandsTest extends JedisCommandTestBase {
@@ -360,23 +356,6 @@ public class AllKindOfValuesCommandsTest extends JedisCommandTestBase {
 
   }
 
-  private Callable<Boolean> jedisTargetIsIdle(final String target) {
-    return new Callable<Boolean>() {
-      @Override
-      public Boolean call() throws Exception {
-        return jedis.objectIdletime(target) > 0;
-      }
-    };
-  }
-
-  private Callable<Boolean> jedisTargetIsIdle(final byte[] target) {
-    return new Callable<Boolean>() {
-      @Override
-      public Boolean call() throws Exception {
-        return jedis.objectIdletime(target) > 0;
-      }
-    };
-  }
   @Test
   public void touch() throws Exception {
     final String foo1 = "foo1";
@@ -385,7 +364,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandTestBase {
 
     jedis.set(foo1, "bar1");
 
-    await().atMost(2, TimeUnit.SECONDS).until(jedisTargetIsIdle(foo1));
+    AwaitilityUtils.waitFor(2000);
 
     assertTrue(jedis.objectIdletime("foo1") > 0);
 
@@ -409,7 +388,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandTestBase {
 
     jedis.set(bfoo1, bbar1);
 
-    await().atMost(2, TimeUnit.SECONDS).until(jedisTargetIsIdle(bfoo1));
+    AwaitilityUtils.waitFor(2000);
 
     assertTrue(jedis.objectIdletime(bfoo1) > 0);
 

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterBinaryJedisCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterBinaryJedisCommandsTest.java
@@ -196,7 +196,7 @@ public class ClusterBinaryJedisCommandsTest {
 
       }
 
-      AwaitilityUtils.waitFor(2000);
+      AwaitilityUtils.waitFor(50);
     }
   }
 }

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterBinaryJedisCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterBinaryJedisCommandsTest.java
@@ -1,6 +1,5 @@
 package redis.clients.jedis.tests.commands;
 
-import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -10,8 +9,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -23,6 +20,7 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.tests.HostAndPortUtil;
+import redis.clients.jedis.tests.utils.AwaitilityUtils;
 import redis.clients.util.JedisClusterCRC16;
 
 public class ClusterBinaryJedisCommandsTest {
@@ -189,18 +187,16 @@ public class ClusterBinaryJedisCommandsTest {
   }
 
   private void waitForClusterReady() throws InterruptedException {
-    await().atMost(50, TimeUnit.SECONDS).until(clusterIsReady());
-  }
+    boolean clusterOk = false;
+    while (!clusterOk) {
+      if (node1.clusterInfo().split("\n")[0].contains("ok")
+              && node2.clusterInfo().split("\n")[0].contains("ok")
+              && node3.clusterInfo().split("\n")[0].contains("ok")) {
+        clusterOk = true;
 
-  private Callable<Boolean> clusterIsReady() {
-    return new Callable<Boolean>() {
-      @Override
-      public Boolean call() throws Exception {
-        return node1.clusterInfo().split("\n")[0].contains("ok")
-                && node2.clusterInfo().split("\n")[0].contains("ok")
-                && node3.clusterInfo().split("\n")[0].contains("ok");
       }
-    };
-  }
 
+      AwaitilityUtils.waitFor(2000);
+    }
+  }
 }

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterBinaryJedisCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterBinaryJedisCommandsTest.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis.tests.commands;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -9,6 +10,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -186,14 +189,18 @@ public class ClusterBinaryJedisCommandsTest {
   }
 
   private void waitForClusterReady() throws InterruptedException {
-    boolean clusterOk = false;
-    while (!clusterOk) {
-      if (node1.clusterInfo().split("\n")[0].contains("ok")
-          && node2.clusterInfo().split("\n")[0].contains("ok")
-          && node3.clusterInfo().split("\n")[0].contains("ok")) {
-        clusterOk = true;
-      }
-      Thread.sleep(50);
-    }
+    await().atMost(50, TimeUnit.SECONDS).until(clusterIsReady());
   }
+
+  private Callable<Boolean> clusterIsReady() {
+    return new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+        return node1.clusterInfo().split("\n")[0].contains("ok")
+                && node2.clusterInfo().split("\n")[0].contains("ok")
+                && node3.clusterInfo().split("\n")[0].contains("ok");
+      }
+    };
+  }
+
 }

--- a/src/test/java/redis/clients/jedis/tests/utils/AwaitilityUtils.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/AwaitilityUtils.java
@@ -1,0 +1,35 @@
+package redis.clients.jedis.tests.utils;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Created by alompo on 27.11.17.
+ */
+public class AwaitilityUtils {
+    private AwaitilityUtils() {
+    }
+
+    /**
+     * We force await to wait at least the desired amount of time
+     * Using await alone with the until clause will timeout by default after 10 seconds
+     * which means that if the amount of time we need to wait is greater it will timeout too early
+     * But with the atLeast clause it will work fine.
+     * @param durationInMilliseconds
+     */
+    public static void waitFor(long durationInMilliseconds) {
+        final long now = System.currentTimeMillis();
+        await().atLeast(durationInMilliseconds, TimeUnit.MILLISECONDS).until(timeIsElapsed(now, durationInMilliseconds));
+    }
+
+    private static Callable<Boolean> timeIsElapsed(final long now, final long duration) {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return System.currentTimeMillis() - now >= duration;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Removing sonar squid:s2925 violation, using [org.awaitability](https://github.com/awaitility/awaitility/wiki/Usage#fork-destination-box)

See also: [Sonar Squid:s2925, thread.sleep should not be used in tests](https://sonarcloud.io/organizations/default/rules#rule_key=squid%3AS2925)