### PR TITLE
Added missing flush in getRawObjectMultiBulkReply

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -273,11 +273,11 @@ public class Connection implements Closeable {
 
   @SuppressWarnings("unchecked")
   public List<Object> getRawObjectMultiBulkReply() {
+    flush();
     return (List<Object>) readProtocolWithCheckingBroken();
   }
 
   public List<Object> getObjectMultiBulkReply() {
-    flush();
     return getRawObjectMultiBulkReply();
   }
 


### PR DESCRIPTION
`flush()` was missing in `getRawObjectMultiBulkReply()`. It is added there. Also `getObjectMultiBulkReply()` just calls `getRawObjectMultiBulkReply()`. So `flush()` is removed from `getObjectMultiBulkReply()` as it is already added in `getRawObjectMultiBulkReply()`.