### PR TITLE
Using available BinaryClient methods for zrange operations from BinaryJedis

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -617,7 +617,6 @@ public class BinaryClient extends Connection {
   }
 
   public void zcount(final byte[] key, final double min, final double max) {
-
     sendCommand(ZCOUNT, key, toByteArray(min), toByteArray(max));
   }
 
@@ -625,12 +624,7 @@ public class BinaryClient extends Connection {
     sendCommand(ZCOUNT, key, min, max);
   }
 
-  public void zcount(final byte[] key, final String min, final String max) {
-    sendCommand(ZCOUNT, key, min.getBytes(), max.getBytes());
-  }
-
   public void zrangeByScore(final byte[] key, final double min, final double max) {
-
     sendCommand(ZRANGEBYSCORE, key, toByteArray(min), toByteArray(max));
   }
 
@@ -638,12 +632,7 @@ public class BinaryClient extends Connection {
     sendCommand(ZRANGEBYSCORE, key, min, max);
   }
 
-  public void zrangeByScore(final byte[] key, final String min, final String max) {
-    sendCommand(ZRANGEBYSCORE, key, min.getBytes(), max.getBytes());
-  }
-
   public void zrevrangeByScore(final byte[] key, final double max, final double min) {
-
     sendCommand(ZREVRANGEBYSCORE, key, toByteArray(max), toByteArray(min));
   }
 
@@ -651,82 +640,36 @@ public class BinaryClient extends Connection {
     sendCommand(ZREVRANGEBYSCORE, key, max, min);
   }
 
-  public void zrevrangeByScore(final byte[] key, final String max, final String min) {
-    sendCommand(ZREVRANGEBYSCORE, key, max.getBytes(), min.getBytes());
-  }
-
   public void zrangeByScore(final byte[] key, final double min, final double max, final int offset,
       final int count) {
-
     sendCommand(ZRANGEBYSCORE, key, toByteArray(min), toByteArray(max), LIMIT.raw, toByteArray(offset),
-      toByteArray(count));
-  }
-
-  public void zrangeByScore(final byte[] key, final String min, final String max, final int offset,
-      final int count) {
-
-    sendCommand(ZRANGEBYSCORE, key, min.getBytes(), max.getBytes(), LIMIT.raw, toByteArray(offset),
       toByteArray(count));
   }
 
   public void zrevrangeByScore(final byte[] key, final double max, final double min,
       final int offset, final int count) {
-
     sendCommand(ZREVRANGEBYSCORE, key, toByteArray(max), toByteArray(min), LIMIT.raw, toByteArray(offset),
       toByteArray(count));
   }
 
-  public void zrevrangeByScore(final byte[] key, final String max, final String min,
-      final int offset, final int count) {
-
-    sendCommand(ZREVRANGEBYSCORE, key, max.getBytes(), min.getBytes(), LIMIT.raw,
-      toByteArray(offset), toByteArray(count));
-  }
-
   public void zrangeByScoreWithScores(final byte[] key, final double min, final double max) {
-
     sendCommand(ZRANGEBYSCORE, key, toByteArray(min), toByteArray(max), WITHSCORES.raw);
   }
 
-  public void zrangeByScoreWithScores(final byte[] key, final String min, final String max) {
-
-    sendCommand(ZRANGEBYSCORE, key, min.getBytes(), max.getBytes(), WITHSCORES.raw);
-  }
-
   public void zrevrangeByScoreWithScores(final byte[] key, final double max, final double min) {
-
     sendCommand(ZREVRANGEBYSCORE, key, toByteArray(max), toByteArray(min), WITHSCORES.raw);
-  }
-
-  public void zrevrangeByScoreWithScores(final byte[] key, final String max, final String min) {
-    sendCommand(ZREVRANGEBYSCORE, key, max.getBytes(), min.getBytes(), WITHSCORES.raw);
   }
 
   public void zrangeByScoreWithScores(final byte[] key, final double min, final double max,
       final int offset, final int count) {
-
     sendCommand(ZRANGEBYSCORE, key, toByteArray(min), toByteArray(max), LIMIT.raw, toByteArray(offset),
-      toByteArray(count), WITHSCORES.raw);
-  }
-
-  public void zrangeByScoreWithScores(final byte[] key, final String min, final String max,
-      final int offset, final int count) {
-    sendCommand(ZRANGEBYSCORE, key, min.getBytes(), max.getBytes(), LIMIT.raw, toByteArray(offset),
       toByteArray(count), WITHSCORES.raw);
   }
 
   public void zrevrangeByScoreWithScores(final byte[] key, final double max, final double min,
       final int offset, final int count) {
-
     sendCommand(ZREVRANGEBYSCORE, key, toByteArray(max), toByteArray(min), LIMIT.raw, toByteArray(offset),
       toByteArray(count), WITHSCORES.raw);
-  }
-
-  public void zrevrangeByScoreWithScores(final byte[] key, final String max, final String min,
-      final int offset, final int count) {
-
-    sendCommand(ZREVRANGEBYSCORE, key, max.getBytes(), min.getBytes(), LIMIT.raw,
-      toByteArray(offset), toByteArray(count), WITHSCORES.raw);
   }
 
   public void zrangeByScore(final byte[] key, final byte[] min, final byte[] max, final int offset,
@@ -769,10 +712,6 @@ public class BinaryClient extends Connection {
 
   public void zremrangeByScore(final byte[] key, final byte[] start, final byte[] end) {
     sendCommand(ZREMRANGEBYSCORE, key, start, end);
-  }
-
-  public void zremrangeByScore(final byte[] key, final String start, final String end) {
-    sendCommand(ZREMRANGEBYSCORE, key, start.getBytes(), end.getBytes());
   }
 
   public void zunionstore(final byte[] dstkey, final byte[]... sets) {

--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -763,6 +763,10 @@ public class BinaryClient extends Connection {
     sendCommand(ZREMRANGEBYRANK, key, toByteArray(start), toByteArray(end));
   }
 
+  public void zremrangeByScore(final byte[] key, final double start, final double end) {
+    sendCommand(ZREMRANGEBYSCORE, key, toByteArray(start), toByteArray(end));
+  }
+
   public void zremrangeByScore(final byte[] key, final byte[] start, final byte[] end) {
     sendCommand(ZREMRANGEBYSCORE, key, start, end);
   }

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -2319,7 +2319,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    */
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final double min, final double max) {
-    return zrangeByScore(key, toByteArray(min), toByteArray(max));
+    checkIsInMultiOrPipeline();
+    client.zrangeByScore(key, min, max);
+    return SetFromList.of(client.getBinaryMultiBulkReply());
   }
 
   @Override
@@ -2379,7 +2381,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final double min, final double max,
       final int offset, final int count) {
-    return zrangeByScore(key, toByteArray(min), toByteArray(max), offset, count);
+    checkIsInMultiOrPipeline();
+    client.zrangeByScore(key, min, max, offset, count);
+    return SetFromList.of(client.getBinaryMultiBulkReply());
   }
 
   @Override
@@ -2439,7 +2443,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    */
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final double min, final double max) {
-    return zrangeByScoreWithScores(key, toByteArray(min), toByteArray(max));
+    checkIsInMultiOrPipeline();
+    client.zrangeByScoreWithScores(key, min, max);
+    return getBinaryTupledSet();
   }
 
   @Override
@@ -2499,7 +2505,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final double min, final double max,
       final int offset, final int count) {
-    return zrangeByScoreWithScores(key, toByteArray(min), toByteArray(max), offset, count);
+    checkIsInMultiOrPipeline();
+    client.zrangeByScoreWithScores(key, min, max, offset, count);
+    return getBinaryTupledSet();
   }
 
   @Override
@@ -2525,7 +2533,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final double max, final double min) {
-    return zrevrangeByScore(key, toByteArray(max), toByteArray(min));
+    checkIsInMultiOrPipeline();
+    client.zrevrangeByScore(key, max, min);
+    return SetFromList.of(client.getBinaryMultiBulkReply());
   }
 
   @Override
@@ -2538,7 +2548,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final double max, final double min,
       final int offset, final int count) {
-    return zrevrangeByScore(key, toByteArray(max), toByteArray(min), offset, count);
+    checkIsInMultiOrPipeline();
+    client.zrevrangeByScore(key, max, min, offset, count);
+    return SetFromList.of(client.getBinaryMultiBulkReply());
   }
 
   @Override
@@ -2551,13 +2563,17 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final double max, final double min) {
-    return zrevrangeByScoreWithScores(key, toByteArray(max), toByteArray(min));
+    checkIsInMultiOrPipeline();
+    client.zrevrangeByScoreWithScores(key, max, min);
+    return getBinaryTupledSet();
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final double max,
       final double min, final int offset, final int count) {
-    return zrevrangeByScoreWithScores(key, toByteArray(max), toByteArray(min), offset, count);
+    checkIsInMultiOrPipeline();
+    client.zrevrangeByScoreWithScores(key, max, min, offset, count);
+    return getBinaryTupledSet();
   }
 
   @Override
@@ -2607,7 +2623,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    */
   @Override
   public Long zremrangeByScore(final byte[] key, final double start, final double end) {
-    return zremrangeByScore(key, toByteArray(start), toByteArray(end));
+    checkIsInMultiOrPipeline();
+    client.zremrangeByScore(key, start, end);
+    return client.getIntegerReply();
   }
 
   @Override


### PR DESCRIPTION
1. Using available `BinaryClient` methods for zrange operations from `BinaryJedis`. Currently, in `BinaryJedis`, those calls are forwarded to similar public methods. But other operations in `BinaryJedis` and even same operations in `Jedis` call client methods directly.

2. Removed `BinaryClient` methods having both `byte[]` and `String` as params. This does not go along with current project design. Moreover, these methods are not used anywhere in this project.