### PR TITLE
in Change Integer.value to Integer.parseInt

### DIFF
--- a/src/main/java/redis/clients/jedis/HostAndPort.java
+++ b/src/main/java/redis/clients/jedis/HostAndPort.java
@@ -83,7 +83,7 @@ public class HostAndPort implements Serializable {
     try {
       String[] parts = extractParts(from);
       String host = parts[0];
-      int port = Integer.valueOf(parts[1]);
+      int port = Integer.parseInt(parts[1]);
       return new HostAndPort(convertHost(host), port);
     } catch (NumberFormatException ex) {
       throw new IllegalArgumentException(ex);

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -117,7 +117,7 @@ public final class Protocol {
     } else if (message.startsWith(ASK_RESPONSE)) {
       String[] askInfo = parseTargetHostAndSlot(message);
       throw new JedisAskDataException(message, new HostAndPort(askInfo[1],
-          Integer.valueOf(askInfo[2])), Integer.valueOf(askInfo[0]));
+          Integer.parseInt(askInfo[2])), Integer.parseInt(askInfo[0]));
     } else if (message.startsWith(CLUSTERDOWN_RESPONSE)) {
       throw new JedisClusterException(message);
     } else if (message.startsWith(BUSY_RESPONSE)) {

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -113,7 +113,7 @@ public final class Protocol {
     if (message.startsWith(MOVED_RESPONSE)) {
       String[] movedInfo = parseTargetHostAndSlot(message);
       throw new JedisMovedDataException(message, new HostAndPort(movedInfo[1],
-          Integer.valueOf(movedInfo[2])), Integer.valueOf(movedInfo[0]));
+          Integer.parseInt(movedInfo[2])), Integer.parseInt(movedInfo[0]));
     } else if (message.startsWith(ASK_RESPONSE)) {
       String[] askInfo = parseTargetHostAndSlot(message);
       throw new JedisAskDataException(message, new HostAndPort(askInfo[1],


### PR DESCRIPTION
`Integer.valueOf(String)` returns a new Integer() object whereas `Integer.parseInt(String)` returns a primitive int,  in this scenario,it might be a better option 