### PR TITLE
Removed touch(key) method from BinaryClient

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -181,10 +181,6 @@ public class BinaryClient extends Connection {
     sendCommand(TTL, key);
   }
 
-  public void touch(final byte[] key) {
-    sendCommand(TOUCH, key);
-  }
-
   public void touch(final byte[]... keys) {
     sendCommand(TOUCH, keys);
   }


### PR DESCRIPTION
Removed touch(key) method which can be served by touch(array_of_keys) method.

Similar to #1574 

Note: `touch(String key)` is already non-existent in Client and Commands.