### PR TITLE
Reduced encoding while creating Tuple and kept only one Set<Tuple> builder

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -266,8 +266,7 @@ public final class BuilderFactory {
       final Set<Tuple> result = new LinkedHashSet<Tuple>(l.size()/2, 1);
       Iterator<byte[]> iterator = l.iterator();
       while (iterator.hasNext()) {
-        result.add(new Tuple(SafeEncoder.encode(iterator.next()), Double.valueOf(SafeEncoder
-            .encode(iterator.next()))));
+        result.add(new Tuple(iterator.next(), Double.valueOf(SafeEncoder.encode(iterator.next()))));
       }
       return result;
     }

--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -278,30 +278,6 @@ public final class BuilderFactory {
 
   };
 
-  public static final Builder<Set<Tuple>> TUPLE_ZSET_BINARY = new Builder<Set<Tuple>>() {
-    @Override
-    @SuppressWarnings("unchecked")
-    public Set<Tuple> build(Object data) {
-      if (null == data) {
-        return null;
-      }
-      List<byte[]> l = (List<byte[]>) data;
-      final Set<Tuple> result = new LinkedHashSet<Tuple>(l.size()/2, 1);
-      Iterator<byte[]> iterator = l.iterator();
-      while (iterator.hasNext()) {
-        result.add(new Tuple(iterator.next(), Double.valueOf(SafeEncoder.encode(iterator.next()))));
-      }
-
-      return result;
-
-    }
-
-    @Override
-    public String toString() {
-      return "ZSet<Tuple>";
-    }
-  };
-
   public static final Builder<Object> EVAL_RESULT = new Builder<Object>() {
 
     @Override

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3256,8 +3256,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     List<byte[]> rawResults = (List<byte[]>) result.get(1);
     Iterator<byte[]> iterator = rawResults.iterator();
     while (iterator.hasNext()) {
-      results.add(new Tuple(SafeEncoder.encode(iterator.next()), Double.valueOf(SafeEncoder
-          .encode(iterator.next()))));
+      results.add(new Tuple(iterator.next(), Double.valueOf(SafeEncoder.encode(iterator.next()))));
     }
     return new ScanResult<Tuple>(newcursor, results);
   }

--- a/src/main/java/redis/clients/jedis/PipelineBase.java
+++ b/src/main/java/redis/clients/jedis/PipelineBase.java
@@ -1020,7 +1020,7 @@ public abstract class PipelineBase extends Queable implements BinaryRedisPipelin
   @Override
   public Response<Set<Tuple>> zrangeByScoreWithScores(final byte[] key, final byte[] min, final byte[] max) {
     getClient(key).zrangeByScoreWithScores(key, min, max);
-    return getResponse(BuilderFactory.TUPLE_ZSET_BINARY);
+    return getResponse(BuilderFactory.TUPLE_ZSET);
   }
 
   @Override
@@ -1040,14 +1040,14 @@ public abstract class PipelineBase extends Queable implements BinaryRedisPipelin
   public Response<Set<Tuple>> zrangeByScoreWithScores(final byte[] key, final double min, final double max,
       final int offset, final int count) {
     getClient(key).zrangeByScoreWithScores(key, toByteArray(min), toByteArray(max), offset, count);
-    return getResponse(BuilderFactory.TUPLE_ZSET_BINARY);
+    return getResponse(BuilderFactory.TUPLE_ZSET);
   }
 
   @Override
   public Response<Set<Tuple>> zrangeByScoreWithScores(final byte[] key, final byte[] min, final byte[] max,
       final int offset, final int count) {
     getClient(key).zrangeByScoreWithScores(key, min, max, offset, count);
-    return getResponse(BuilderFactory.TUPLE_ZSET_BINARY);
+    return getResponse(BuilderFactory.TUPLE_ZSET);
   }
 
   @Override
@@ -1115,13 +1115,13 @@ public abstract class PipelineBase extends Queable implements BinaryRedisPipelin
   @Override
   public Response<Set<Tuple>> zrevrangeByScoreWithScores(final byte[] key, final double max, final double min) {
     getClient(key).zrevrangeByScoreWithScores(key, toByteArray(max), toByteArray(min));
-    return getResponse(BuilderFactory.TUPLE_ZSET_BINARY);
+    return getResponse(BuilderFactory.TUPLE_ZSET);
   }
 
   @Override
   public Response<Set<Tuple>> zrevrangeByScoreWithScores(final byte[] key, final byte[] max, final byte[] min) {
     getClient(key).zrevrangeByScoreWithScores(key, max, min);
-    return getResponse(BuilderFactory.TUPLE_ZSET_BINARY);
+    return getResponse(BuilderFactory.TUPLE_ZSET);
   }
 
   @Override
@@ -1142,14 +1142,14 @@ public abstract class PipelineBase extends Queable implements BinaryRedisPipelin
       final int offset, final int count) {
     getClient(key).zrevrangeByScoreWithScores(key, toByteArray(max), toByteArray(min), offset,
       count);
-    return getResponse(BuilderFactory.TUPLE_ZSET_BINARY);
+    return getResponse(BuilderFactory.TUPLE_ZSET);
   }
 
   @Override
   public Response<Set<Tuple>> zrevrangeByScoreWithScores(final byte[] key, final byte[] max, final byte[] min,
       final int offset, final int count) {
     getClient(key).zrevrangeByScoreWithScores(key, max, min, offset, count);
-    return getResponse(BuilderFactory.TUPLE_ZSET_BINARY);
+    return getResponse(BuilderFactory.TUPLE_ZSET);
   }
 
   @Override
@@ -1161,7 +1161,7 @@ public abstract class PipelineBase extends Queable implements BinaryRedisPipelin
   @Override
   public Response<Set<Tuple>> zrangeWithScores(final byte[] key, final long start, final long end) {
     getClient(key).zrangeWithScores(key, start, end);
-    return getResponse(BuilderFactory.TUPLE_ZSET_BINARY);
+    return getResponse(BuilderFactory.TUPLE_ZSET);
   }
 
   @Override


### PR DESCRIPTION
1. In following block of code
```
result.add(new Tuple(SafeEncoder.encode(iterator.next()), Double.valueOf(SafeEncoder
    .encode(iterator.next()))));
```
there are actually 2 conversions happening. First a byte[] to String within the block.
And then String to byte[] conversion in Tuple constructor.

Changing the block to
```
result.add(new Tuple(iterator.next(), Double.valueOf(SafeEncoder.encode(iterator.next()))));
```
reduces to 0 conversions.

2. As Tuple supports both byte[] and String at once, there is no need to have two separate
TUPLE_ZSET and TUPLE_ZSET_BINARY.