### PR TITLE
Add proxy support using `java.net.Proxy`

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -3,6 +3,7 @@ package redis.clients.jedis;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.Socket;
 import java.net.SocketException;
 import java.util.ArrayList;
@@ -28,6 +29,7 @@ public class Connection implements Closeable {
   private String host = Protocol.DEFAULT_HOST;
   private int port = Protocol.DEFAULT_PORT;
   private Socket socket;
+  private Proxy proxy;
   private RedisOutputStream outputStream;
   private RedisInputStream inputStream;
   private int connectionTimeout = Protocol.DEFAULT_TIMEOUT;
@@ -79,12 +81,20 @@ public class Connection implements Closeable {
     return soTimeout;
   }
 
+  public Proxy getProxy() {
+    return proxy;
+  }
+
   public void setConnectionTimeout(int connectionTimeout) {
     this.connectionTimeout = connectionTimeout;
   }
 
   public void setSoTimeout(int soTimeout) {
     this.soTimeout = soTimeout;
+  }
+
+  public void setProxy(Proxy proxy) {
+    this.proxy = proxy;
   }
 
   public void setTimeoutInfinite() {
@@ -167,7 +177,7 @@ public class Connection implements Closeable {
   public void connect() {
     if (!isConnected()) {
       try {
-        socket = new Socket();
+        socket = this.proxy != null? new Socket(proxy) :new Socket();
         // ->@wjw_add
         socket.setReuseAddress(true);
         socket.setKeepAlive(true); // Will monitor the TCP connection is

--- a/src/main/java/redis/clients/jedis/JedisFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisFactory.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis;
 
+import java.net.Proxy;
 import java.net.URI;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -27,6 +28,7 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
   private final String clientName;
   private final boolean ssl;
   private final SSLSocketFactory sslSocketFactory;
+  private final Proxy proxy;
   private SSLParameters sslParameters;
   private HostnameVerifier hostnameVerifier;
 
@@ -44,6 +46,24 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
     this.sslSocketFactory = sslSocketFactory;
     this.sslParameters = sslParameters;
     this.hostnameVerifier = hostnameVerifier;
+    this.proxy = null;
+  }
+
+  public JedisFactory(final String host, final int port, final int connectionTimeout,
+      final int soTimeout, final String password, final int database, final String clientName,
+      final boolean ssl, final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier, final Proxy proxy) {
+    this.hostAndPort.set(new HostAndPort(host, port));
+    this.connectionTimeout = connectionTimeout;
+    this.soTimeout = soTimeout;
+    this.password = password;
+    this.database = database;
+    this.clientName = clientName;
+    this.ssl = ssl;
+    this.sslSocketFactory = sslSocketFactory;
+    this.sslParameters = sslParameters;
+    this.hostnameVerifier = hostnameVerifier;
+    this.proxy = proxy;
   }
 
   public JedisFactory(final URI uri, final int connectionTimeout, final int soTimeout,
@@ -64,6 +84,7 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
     this.sslSocketFactory = sslSocketFactory;
     this.sslParameters = sslParameters;
     this.hostnameVerifier = hostnameVerifier;
+    this.proxy = null;
   }
 
   public void setHostAndPort(final HostAndPort hostAndPort) {
@@ -99,8 +120,10 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
   @Override
   public PooledObject<Jedis> makeObject() throws Exception {
     final HostAndPort hostAndPort = this.hostAndPort.get();
+
     final Jedis jedis = new Jedis(hostAndPort.getHost(), hostAndPort.getPort(), connectionTimeout,
         soTimeout, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
+    jedis.getClient().setProxy(proxy);
 
     try {
       jedis.connect();

--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis;
 
+import java.net.Proxy;
 import java.net.URI;
 
 import javax.net.ssl.HostnameVerifier;
@@ -28,6 +29,11 @@ public class JedisPool extends JedisPoolAbstract {
   public JedisPool(String host, int port) {
     this(new GenericObjectPoolConfig(), host, port, Protocol.DEFAULT_TIMEOUT, null,
         Protocol.DEFAULT_DATABASE, null);
+  }
+
+  public JedisPool(String host, int port, Proxy proxy) {
+    this(new GenericObjectPoolConfig(), host, port, Protocol.DEFAULT_TIMEOUT, null,
+        Protocol.DEFAULT_DATABASE, null, proxy);
   }
 
   public JedisPool(final String host) {
@@ -165,6 +171,12 @@ public class JedisPool extends JedisPoolAbstract {
   }
 
   public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
+      int timeout, final String password, final int database, final String clientName, final Proxy proxy) {
+    this(poolConfig, host, port, timeout, timeout, password, database, clientName, false,
+        null, null, null, proxy);
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
       int timeout, final String password, final int database, final String clientName,
       final boolean ssl) {
     this(poolConfig, host, port, timeout, timeout, password, database, clientName, ssl,
@@ -183,8 +195,16 @@ public class JedisPool extends JedisPoolAbstract {
       final int connectionTimeout, final int soTimeout, final String password, final int database,
       final String clientName, final boolean ssl, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+    this(poolConfig, host, port, connectionTimeout, soTimeout, password, database, clientName, ssl,
+            sslSocketFactory, sslParameters, hostnameVerifier, null);
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
+      final int connectionTimeout, final int soTimeout, final String password, final int database,
+      final String clientName, final boolean ssl, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier, final Proxy proxy) {
     super(poolConfig, new JedisFactory(host, port, connectionTimeout, soTimeout, password,
-        database, clientName, ssl, sslSocketFactory, sslParameters, hostnameVerifier));
+        database, clientName, ssl, sslSocketFactory, sslParameters, hostnameVerifier, proxy));
   }
 
   public JedisPool(final GenericObjectPoolConfig poolConfig, final URI uri) {

--- a/src/test/java/redis/clients/jedis/tests/ConnectionTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ConnectionTest.java
@@ -12,6 +12,9 @@ import redis.clients.jedis.Protocol.Command;
 import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
 public class ConnectionTest {
   private Connection client;
 
@@ -43,6 +46,17 @@ public class ConnectionTest {
     client.setHost("localhost");
     client.setPort(6379);
     client.setTimeoutInfinite();
+  }
+
+  // Need to set up a proxy server first.
+  @Test
+  public void connectViaSocksProxy() {
+    Proxy proxy = new Proxy(Proxy.Type.SOCKS, new InetSocketAddress("localhost", 7788));
+    client.setProxy(proxy);
+    client.setHost("localhost");
+    client.setPort(6379);
+    client.connect();
+    client.close();
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -44,6 +46,19 @@ public class JedisPoolTest {
     JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
     Jedis jedis = pool.getResource();
     jedis.auth("foobared");
+    jedis.set("foo", "bar");
+    assertEquals("bar", jedis.get("foo"));
+    jedis.close();
+    pool.close();
+    assertTrue(pool.isClosed());
+  }
+
+  // Need to set up a proxy server first.
+  @Test
+  public void checkCloseableConnectionsViaSocksProxy() throws Exception {
+    Proxy proxy = new Proxy(Proxy.Type.SOCKS, new InetSocketAddress("localhost", 7788));
+    JedisPool pool = new JedisPool("localhost", 6379, proxy);
+    Jedis jedis = pool.getResource();
     jedis.set("foo", "bar");
     assertEquals("bar", jedis.get("foo"));
     jedis.close();


### PR DESCRIPTION
This PR adds a feature of specifying different proxies for different `JedisPool` instances.

Unit test won't pass unless set up a proxy server first.