### PR TITLE
Move Jedis initialization in try block

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -36,8 +36,9 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
 
   private void initializeSlotsCache(Set<HostAndPort> startNodes, GenericObjectPoolConfig poolConfig, String password, String clientName) {
     for (HostAndPort hostAndPort : startNodes) {
-      Jedis jedis = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
+      Jedis jedis = null;
       try {
+        jedis = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
         if (password != null) {
           jedis.auth(password);
         }


### PR DESCRIPTION
There is a null checking in `finally` which is meaningless if object creation is outside `try`-block.