### PR TITLE
JedisPoolConfig should use softMinEvictableIdleTimeMillis instead of minEvictableIdleTimeMillis

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisPoolConfig.java
+++ b/src/main/java/redis/clients/jedis/JedisPoolConfig.java
@@ -6,7 +6,8 @@ public class JedisPoolConfig extends GenericObjectPoolConfig {
   public JedisPoolConfig() {
     // defaults to make your life with connection pool easier :)
     setTestWhileIdle(true);
-    setMinEvictableIdleTimeMillis(60000);
+    setSoftMinEvictableIdleTimeMillis(60000);
+    setMinEvictableIdleTimeMillis(-1);
     setTimeBetweenEvictionRunsMillis(30000);
     setNumTestsPerEvictionRun(-1);
   }


### PR DESCRIPTION
The JedisPoolConfig should have the "softMinEvictableIdleTimeMillis" (get and set) as the GenericObjectPool, to avoid destroying idle connections below the "minIdle" value. In this case, connections are dropped and immediately recreated with no reason. The "minEvictableIdleTimeMillis" should not be considered because there are ways to validate idle connections before they are used.

In other case, considered JVM heap, if youngGC happened frequently, maybe the idle connection will promote to old gen. If use minEvictableIdleTimeMillis, old gen will grow slowly.