### PR TITLE
bitOpNot should throw exception for multiple source keys

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -24,6 +24,7 @@ import javax.net.ssl.SSLSocketFactory;
 
 import redis.clients.jedis.Protocol.Command;
 import redis.clients.jedis.Protocol.Keyword;
+import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.params.geo.GeoRadiusParam;
 import redis.clients.jedis.params.set.SetParams;
 import redis.clients.jedis.params.sortedset.ZAddParams;
@@ -1077,7 +1078,7 @@ public class BinaryClient extends Connection {
       break;
     case NOT:
       kw = Keyword.NOT;
-      len = Math.min(1, len);
+      if (len > 1) throw new JedisDataException("BITOP NOT must be called with a single source key");
       break;
     }
 

--- a/src/test/java/redis/clients/jedis/tests/commands/BitCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/BitCommandsTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import redis.clients.jedis.BitOP;
 import redis.clients.jedis.BitPosParams;
 import redis.clients.jedis.Protocol;
+import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.util.SafeEncoder;
 
 import java.util.List;
@@ -183,6 +184,14 @@ public class BitCommandsTest extends JedisCommandTestBase {
 
     String resultNot = jedis.get("resultNot");
     assertEquals("\u0077", resultNot);
+  }
+
+  @Test(expected = JedisDataException.class)
+  public void bitOpNotShouldFailForMultipleSourceKeys() {
+    jedis.set("key1", "\u0060");
+    jedis.set("key2", "\u0044");
+
+    jedis.bitop(BitOP.NOT, "key3", "key1", "key2");
   }
 
   @Test


### PR DESCRIPTION
1. Modified bitOpNot to throw Data exception if there are multiple source keys
2. Wrote a new Unit test to verify that this exception is thrown