### PR TITLE
Using available BinaryClient methods for zrange operations from BinaryJedis

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -763,6 +763,10 @@ public class BinaryClient extends Connection {
     sendCommand(ZREMRANGEBYRANK, key, toByteArray(start), toByteArray(stop));
   }
 
+  public void zremrangeByScore(final byte[] key, final double min, final double max) {
+    sendCommand(ZREMRANGEBYSCORE, key, toByteArray(min), toByteArray(max));
+  }
+
   public void zremrangeByScore(final byte[] key, final byte[] min, final byte[] max) {
     sendCommand(ZREMRANGEBYSCORE, key, min, max);
   }

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -2319,7 +2319,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    */
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final double min, final double max) {
-    return zrangeByScore(key, toByteArray(min), toByteArray(max));
+    checkIsInMultiOrPipeline();
+    client.zrangeByScore(key, min, max);
+    return SetFromList.of(client.getBinaryMultiBulkReply());
   }
 
   @Override
@@ -2379,7 +2381,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final double min, final double max,
       final int offset, final int count) {
-    return zrangeByScore(key, toByteArray(min), toByteArray(max), offset, count);
+    checkIsInMultiOrPipeline();
+    client.zrangeByScore(key, min, max, offset, count);
+    return SetFromList.of(client.getBinaryMultiBulkReply());
   }
 
   @Override
@@ -2439,7 +2443,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    */
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final double min, final double max) {
-    return zrangeByScoreWithScores(key, toByteArray(min), toByteArray(max));
+    checkIsInMultiOrPipeline();
+    client.zrangeByScoreWithScores(key, min, max);
+    return getBinaryTupledSet();
   }
 
   @Override
@@ -2499,7 +2505,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final double min, final double max,
       final int offset, final int count) {
-    return zrangeByScoreWithScores(key, toByteArray(min), toByteArray(max), offset, count);
+    checkIsInMultiOrPipeline();
+    client.zrangeByScoreWithScores(key, min, max, offset, count);
+    return getBinaryTupledSet();
   }
 
   @Override
@@ -2525,7 +2533,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final double max, final double min) {
-    return zrevrangeByScore(key, toByteArray(max), toByteArray(min));
+    checkIsInMultiOrPipeline();
+    client.zrevrangeByScore(key, max, min);
+    return SetFromList.of(client.getBinaryMultiBulkReply());
   }
 
   @Override
@@ -2538,7 +2548,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final double max, final double min,
       final int offset, final int count) {
-    return zrevrangeByScore(key, toByteArray(max), toByteArray(min), offset, count);
+    checkIsInMultiOrPipeline();
+    client.zrevrangeByScore(key, max, min, offset, count);
+    return SetFromList.of(client.getBinaryMultiBulkReply());
   }
 
   @Override
@@ -2551,13 +2563,17 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final double max, final double min) {
-    return zrevrangeByScoreWithScores(key, toByteArray(max), toByteArray(min));
+    checkIsInMultiOrPipeline();
+    client.zrevrangeByScoreWithScores(key, max, min);
+    return getBinaryTupledSet();
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final double max,
       final double min, final int offset, final int count) {
-    return zrevrangeByScoreWithScores(key, toByteArray(max), toByteArray(min), offset, count);
+    checkIsInMultiOrPipeline();
+    client.zrevrangeByScoreWithScores(key, max, min, offset, count);
+    return getBinaryTupledSet();
   }
 
   @Override
@@ -2607,7 +2623,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    */
   @Override
   public Long zremrangeByScore(final byte[] key, final double min, final double max) {
-    return zremrangeByScore(key, toByteArray(min), toByteArray(max));
+    checkIsInMultiOrPipeline();
+    client.zremrangeByScore(key, min, max);
+    return client.getIntegerReply();
   }
 
   @Override


### PR DESCRIPTION
Currently, in BinaryJedis, those calls are forwarded to similar public methods. But in Jedis, similar operations are done other way.

Only zremrangeByScore was not in BinaryJedis and it is added.