### PR TITLE
Reduced encoding while creating Tuple

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -266,8 +266,7 @@ public final class BuilderFactory {
       final Set<Tuple> result = new LinkedHashSet<Tuple>(l.size()/2, 1);
       Iterator<byte[]> iterator = l.iterator();
       while (iterator.hasNext()) {
-        result.add(new Tuple(SafeEncoder.encode(iterator.next()), Double.valueOf(SafeEncoder
-            .encode(iterator.next()))));
+        result.add(new Tuple(iterator.next(), DOUBLE.build(iterator.next())));
       }
       return result;
     }
@@ -290,7 +289,7 @@ public final class BuilderFactory {
       final Set<Tuple> result = new LinkedHashSet<Tuple>(l.size()/2, 1);
       Iterator<byte[]> iterator = l.iterator();
       while (iterator.hasNext()) {
-        result.add(new Tuple(iterator.next(), Double.valueOf(SafeEncoder.encode(iterator.next()))));
+        result.add(new Tuple(iterator.next(), DOUBLE.build(iterator.next())));
       }
 
       return result;

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3256,8 +3256,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     List<byte[]> rawResults = (List<byte[]>) result.get(1);
     Iterator<byte[]> iterator = rawResults.iterator();
     while (iterator.hasNext()) {
-      results.add(new Tuple(SafeEncoder.encode(iterator.next()), Double.valueOf(SafeEncoder
-          .encode(iterator.next()))));
+      results.add(new Tuple(iterator.next(), BuilderFactory.DOUBLE.build(iterator.next())));
     }
     return new ScanResult<Tuple>(newcursor, results);
   }


### PR DESCRIPTION
In following code:
```
new Tuple(SafeEncoder.encode(iterator.next())
```
there are actually 2 conversions happening. First a byte[] to String. And then String to byte[] in Tuple constructor.

Changing the code to:
```
new Tuple(iterator.next())
```
reduces the number of conversions to 0.

Also, used available DOUBLE.build().