### PR TITLE
Modify BITOP NOT to fail with multiple sources keys

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -1073,7 +1073,6 @@ public class BinaryClient extends Connection {
       break;
     case NOT:
       kw = Keyword.NOT;
-      len = Math.min(1, len);
       break;
     }
 

--- a/src/test/java/redis/clients/jedis/tests/commands/BitCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/BitCommandsTest.java
@@ -185,6 +185,11 @@ public class BitCommandsTest extends JedisCommandTestBase {
     assertEquals("\u0077", resultNot);
   }
 
+  @Test(expected = redis.clients.jedis.exceptions.JedisDataException.class)
+  public void bitOpNotMultiSourceShouldFail() {
+    jedis.bitop(BitOP.NOT, "dest", "src1", "src2");
+  }
+
   @Test
   public void testBitfield() {
     List<Long> responses = jedis.bitfield("mykey", "INCRBY","i5","100","1", "GET", "u4", "0");


### PR DESCRIPTION
This fixes #1635 in a backward compatible way.