### PR TITLE
Move package util into jedis

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -28,8 +28,8 @@ import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.SetParams;
 import redis.clients.jedis.params.ZAddParams;
 import redis.clients.jedis.params.ZIncrByParams;
-import redis.clients.util.JedisByteHashMap;
-import redis.clients.util.JedisURIHelper;
+import redis.clients.jedis.util.JedisByteHashMap;
+import redis.clients.jedis.util.JedisURIHelper;
 
 public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKeyBinaryCommands,
     AdvancedBinaryJedisCommands, BinaryScriptingCommands, Closeable {

--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -7,8 +7,8 @@ import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.SetParams;
 import redis.clients.jedis.params.ZAddParams;
 import redis.clients.jedis.params.ZIncrByParams;
-import redis.clients.util.KeyMergeUtil;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.KeyMergeUtil;
+import redis.clients.jedis.util.SafeEncoder;
 
 import java.io.Closeable;
 import java.util.Collection;
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import redis.clients.util.JedisClusterHashTagUtil;
+import redis.clients.jedis.util.JedisClusterHashTagUtil;
 
 public class BinaryJedisCluster implements BinaryJedisClusterCommands,
     MultiKeyBinaryJedisClusterCommands, JedisClusterBinaryScriptingCommands, Closeable {

--- a/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
@@ -12,8 +12,8 @@ import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.SetParams;
 import redis.clients.jedis.params.ZAddParams;
 import redis.clients.jedis.params.ZIncrByParams;
-import redis.clients.util.Hashing;
-import redis.clients.util.Sharded;
+import redis.clients.jedis.util.Hashing;
+import redis.clients.jedis.util.Sharded;
 
 public class BinaryShardedJedis extends Sharded<Jedis, JedisShardInfo> implements
     BinaryJedisCommands {

--- a/src/main/java/redis/clients/jedis/BitOP.java
+++ b/src/main/java/redis/clients/jedis/BitOP.java
@@ -6,6 +6,6 @@ public enum BitOP {
   public final byte[] raw;
 
   private BitOP() {
-    this.raw = redis.clients.util.SafeEncoder.encode(name());
+    this.raw = redis.clients.jedis.util.SafeEncoder.encode(name());
   }
 }

--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import redis.clients.util.JedisByteHashMap;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.JedisByteHashMap;
+import redis.clients.jedis.util.SafeEncoder;
 
 public final class BuilderFactory {
   public static final Builder<Double> DOUBLE = new Builder<Double>() {

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -17,7 +17,7 @@ import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.SetParams;
 import redis.clients.jedis.params.ZAddParams;
 import redis.clients.jedis.params.ZIncrByParams;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class Client extends BinaryClient implements Commands {
 

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -16,10 +16,10 @@ import javax.net.ssl.SSLSocketFactory;
 import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
-import redis.clients.util.IOUtils;
-import redis.clients.util.RedisInputStream;
-import redis.clients.util.RedisOutputStream;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.IOUtils;
+import redis.clients.jedis.util.RedisInputStream;
+import redis.clients.jedis.util.RedisOutputStream;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class Connection implements Closeable {
 

--- a/src/main/java/redis/clients/jedis/GeoRadiusResponse.java
+++ b/src/main/java/redis/clients/jedis/GeoRadiusResponse.java
@@ -1,6 +1,6 @@
 package redis.clients.jedis;
 
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class GeoRadiusResponse {
   private byte[] member;

--- a/src/main/java/redis/clients/jedis/GeoUnit.java
+++ b/src/main/java/redis/clients/jedis/GeoUnit.java
@@ -1,6 +1,6 @@
 package redis.clients.jedis;
 
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public enum GeoUnit {
   M, KM, MI, FT;

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -25,8 +25,8 @@ import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.SetParams;
 import redis.clients.jedis.params.ZAddParams;
 import redis.clients.jedis.params.ZIncrByParams;
-import redis.clients.util.SafeEncoder;
-import redis.clients.util.Slowlog;
+import redis.clients.jedis.util.SafeEncoder;
+import redis.clients.jedis.util.Slowlog;
 
 public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommands,
     AdvancedJedisCommands, ScriptingCommands, BasicCommands, ClusterCommands, SentinelCommands, ModuleCommands {

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -6,7 +6,7 @@ import redis.clients.jedis.params.ZIncrByParams;
 import redis.clients.jedis.commands.JedisClusterCommands;
 import redis.clients.jedis.commands.JedisClusterScriptingCommands;
 import redis.clients.jedis.commands.MultiKeyJedisClusterCommands;
-import redis.clients.util.KeyMergeUtil;
+import redis.clients.jedis.util.KeyMergeUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -17,7 +17,7 @@ import java.util.Set;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
 import redis.clients.jedis.params.SetParams;
-import redis.clients.util.JedisClusterHashTagUtil;
+import redis.clients.jedis.util.JedisClusterHashTagUtil;
 
 public class JedisCluster extends BinaryJedisCluster implements JedisClusterCommands,
     MultiKeyJedisClusterCommands, JedisClusterScriptingCommands {

--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -7,7 +7,7 @@ import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisMovedDataException;
 import redis.clients.jedis.exceptions.JedisNoReachableClusterNodeException;
 import redis.clients.jedis.exceptions.JedisRedirectionException;
-import redis.clients.util.JedisClusterCRC16;
+import redis.clients.jedis.util.JedisClusterCRC16;
 
 public abstract class JedisClusterCommand<T> {
 

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -12,7 +12,7 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class JedisClusterInfoCache {
   private final Map<String, JedisPool> nodes = new HashMap<String, JedisPool>();

--- a/src/main/java/redis/clients/jedis/JedisFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisFactory.java
@@ -13,7 +13,7 @@ import org.apache.commons.pool2.impl.DefaultPooledObject;
 
 import redis.clients.jedis.exceptions.InvalidURIException;
 import redis.clients.jedis.exceptions.JedisException;
-import redis.clients.util.JedisURIHelper;
+import redis.clients.jedis.util.JedisURIHelper;
 
 /**
  * PoolableObjectFactory custom impl.

--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -10,7 +10,7 @@ import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
 import redis.clients.jedis.exceptions.JedisException;
-import redis.clients.util.JedisURIHelper;
+import redis.clients.jedis.util.JedisURIHelper;
 
 public class JedisPool extends JedisPoolAbstract {
 

--- a/src/main/java/redis/clients/jedis/JedisPoolAbstract.java
+++ b/src/main/java/redis/clients/jedis/JedisPoolAbstract.java
@@ -3,7 +3,7 @@ package redis.clients.jedis;
 import org.apache.commons.pool2.PooledObjectFactory;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
-import redis.clients.util.Pool;
+import redis.clients.jedis.util.Pool;
 
 public class JedisPoolAbstract extends Pool<Jedis> {
 

--- a/src/main/java/redis/clients/jedis/JedisPubSub.java
+++ b/src/main/java/redis/clients/jedis/JedisPubSub.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public abstract class JedisPubSub {
 

--- a/src/main/java/redis/clients/jedis/JedisShardInfo.java
+++ b/src/main/java/redis/clients/jedis/JedisShardInfo.java
@@ -7,9 +7,9 @@ import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
 
 import redis.clients.jedis.exceptions.InvalidURIException;
-import redis.clients.util.JedisURIHelper;
-import redis.clients.util.ShardInfo;
-import redis.clients.util.Sharded;
+import redis.clients.jedis.util.JedisURIHelper;
+import redis.clients.jedis.util.ShardInfo;
+import redis.clients.jedis.util.Sharded;
 
 public class JedisShardInfo extends ShardInfo<Jedis> {
 

--- a/src/main/java/redis/clients/jedis/ListPosition.java
+++ b/src/main/java/redis/clients/jedis/ListPosition.java
@@ -1,6 +1,6 @@
 package redis.clients.jedis;
 
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public enum ListPosition {
   BEFORE, AFTER;

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -13,9 +13,9 @@ import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.exceptions.JedisMovedDataException;
 import redis.clients.jedis.exceptions.JedisNoScriptException;
-import redis.clients.util.RedisInputStream;
-import redis.clients.util.RedisOutputStream;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.RedisInputStream;
+import redis.clients.jedis.util.RedisOutputStream;
+import redis.clients.jedis.util.SafeEncoder;
 
 public final class Protocol {
 

--- a/src/main/java/redis/clients/jedis/ScanParams.java
+++ b/src/main/java/redis/clients/jedis/ScanParams.java
@@ -13,7 +13,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class ScanParams {
 

--- a/src/main/java/redis/clients/jedis/ScanResult.java
+++ b/src/main/java/redis/clients/jedis/ScanResult.java
@@ -2,7 +2,7 @@ package redis.clients.jedis;
 
 import java.util.List;
 
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class ScanResult<T> {
   private byte[] cursor;

--- a/src/main/java/redis/clients/jedis/ShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedis.java
@@ -12,7 +12,7 @@ import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.SetParams;
 import redis.clients.jedis.params.ZAddParams;
 import redis.clients.jedis.params.ZIncrByParams;
-import redis.clients.util.Hashing;
+import redis.clients.jedis.util.Hashing;
 
 public class ShardedJedis extends BinaryShardedJedis implements JedisCommands, Closeable {
 

--- a/src/main/java/redis/clients/jedis/ShardedJedisPool.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedisPool.java
@@ -8,8 +8,8 @@ import org.apache.commons.pool2.PooledObjectFactory;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
-import redis.clients.util.Hashing;
-import redis.clients.util.Pool;
+import redis.clients.jedis.util.Hashing;
+import redis.clients.jedis.util.Pool;
 
 public class ShardedJedisPool extends Pool<ShardedJedis> {
   public ShardedJedisPool(final GenericObjectPoolConfig poolConfig, List<JedisShardInfo> shards) {

--- a/src/main/java/redis/clients/jedis/SortingParams.java
+++ b/src/main/java/redis/clients/jedis/SortingParams.java
@@ -13,7 +13,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 /**
  * Builder Class for {@link Jedis#sort(String, SortingParams) SORT} Parameters.

--- a/src/main/java/redis/clients/jedis/Tuple.java
+++ b/src/main/java/redis/clients/jedis/Tuple.java
@@ -3,8 +3,8 @@ package redis.clients.jedis;
 import java.util.Arrays;
 import java.util.Objects;
 
-import redis.clients.util.ByteArrayComparator;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.ByteArrayComparator;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class Tuple implements Comparable<Tuple> {
   private byte[] element;

--- a/src/main/java/redis/clients/jedis/ZParams.java
+++ b/src/main/java/redis/clients/jedis/ZParams.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class ZParams {
   public enum Aggregate {

--- a/src/main/java/redis/clients/jedis/commands/AdvancedJedisCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/AdvancedJedisCommands.java
@@ -2,7 +2,7 @@ package redis.clients.jedis.commands;
 
 import java.util.List;
 
-import redis.clients.util.Slowlog;
+import redis.clients.jedis.util.Slowlog;
 
 public interface AdvancedJedisCommands {
   List<String> configGet(String pattern);

--- a/src/main/java/redis/clients/jedis/params/GeoRadiusParam.java
+++ b/src/main/java/redis/clients/jedis/params/GeoRadiusParam.java
@@ -1,7 +1,7 @@
 package redis.clients.jedis.params;
 
 import redis.clients.jedis.Protocol;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 import java.util.ArrayList;
 

--- a/src/main/java/redis/clients/jedis/params/Params.java
+++ b/src/main/java/redis/clients/jedis/params/Params.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public abstract class Params {
 

--- a/src/main/java/redis/clients/jedis/params/SetParams.java
+++ b/src/main/java/redis/clients/jedis/params/SetParams.java
@@ -2,7 +2,7 @@ package redis.clients.jedis.params;
 
 import java.util.ArrayList;
 
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class SetParams extends Params {
 

--- a/src/main/java/redis/clients/jedis/params/ZAddParams.java
+++ b/src/main/java/redis/clients/jedis/params/ZAddParams.java
@@ -1,6 +1,6 @@
 package redis.clients.jedis.params;
 
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 import java.util.ArrayList;
 

--- a/src/main/java/redis/clients/jedis/params/ZIncrByParams.java
+++ b/src/main/java/redis/clients/jedis/params/ZIncrByParams.java
@@ -1,6 +1,6 @@
 package redis.clients.jedis.params;
 
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 import java.util.ArrayList;
 

--- a/src/main/java/redis/clients/jedis/util/ByteArrayComparator.java
+++ b/src/main/java/redis/clients/jedis/util/ByteArrayComparator.java
@@ -1,4 +1,4 @@
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 public final class ByteArrayComparator {
   private ByteArrayComparator() {

--- a/src/main/java/redis/clients/jedis/util/Hashing.java
+++ b/src/main/java/redis/clients/jedis/util/Hashing.java
@@ -1,4 +1,4 @@
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;

--- a/src/main/java/redis/clients/jedis/util/IOUtils.java
+++ b/src/main/java/redis/clients/jedis/util/IOUtils.java
@@ -1,4 +1,4 @@
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 import java.io.IOException;
 import java.net.Socket;

--- a/src/main/java/redis/clients/jedis/util/JedisByteHashMap.java
+++ b/src/main/java/redis/clients/jedis/util/JedisByteHashMap.java
@@ -1,4 +1,4 @@
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 import java.io.Serializable;
 import java.util.Arrays;

--- a/src/main/java/redis/clients/jedis/util/JedisClusterCRC16.java
+++ b/src/main/java/redis/clients/jedis/util/JedisClusterCRC16.java
@@ -1,4 +1,4 @@
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 /**
  * CRC16 Implementation according to CCITT standard Polynomial : 1021 (x^16 + x^12 + x^5 + 1) See <a

--- a/src/main/java/redis/clients/jedis/util/JedisClusterHashTagUtil.java
+++ b/src/main/java/redis/clients/jedis/util/JedisClusterHashTagUtil.java
@@ -1,4 +1,4 @@
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 /**
  * Holds various methods/utilities to manipualte and parse redis hash-tags. See <a

--- a/src/main/java/redis/clients/jedis/util/JedisURIHelper.java
+++ b/src/main/java/redis/clients/jedis/util/JedisURIHelper.java
@@ -1,4 +1,4 @@
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 import java.net.URI;
 

--- a/src/main/java/redis/clients/jedis/util/KeyMergeUtil.java
+++ b/src/main/java/redis/clients/jedis/util/KeyMergeUtil.java
@@ -1,4 +1,4 @@
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 public final class KeyMergeUtil {
   private KeyMergeUtil(){

--- a/src/main/java/redis/clients/jedis/util/MurmurHash.java
+++ b/src/main/java/redis/clients/jedis/util/MurmurHash.java
@@ -9,7 +9,7 @@
  * for the specific language governing permissions and limitations under the License.
  */
 
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;

--- a/src/main/java/redis/clients/jedis/util/Pool.java
+++ b/src/main/java/redis/clients/jedis/util/Pool.java
@@ -1,4 +1,4 @@
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 import java.io.Closeable;
 import java.util.NoSuchElementException;

--- a/src/main/java/redis/clients/jedis/util/RedisInputStream.java
+++ b/src/main/java/redis/clients/jedis/util/RedisInputStream.java
@@ -7,7 +7,7 @@
  * for the specific language governing permissions and limitations under the License.
  */
 
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 import java.io.*;
 

--- a/src/main/java/redis/clients/jedis/util/RedisOutputStream.java
+++ b/src/main/java/redis/clients/jedis/util/RedisOutputStream.java
@@ -1,4 +1,4 @@
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 import java.io.FilterOutputStream;
 import java.io.IOException;

--- a/src/main/java/redis/clients/jedis/util/SafeEncoder.java
+++ b/src/main/java/redis/clients/jedis/util/SafeEncoder.java
@@ -1,4 +1,4 @@
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 import java.io.UnsupportedEncodingException;
 

--- a/src/main/java/redis/clients/jedis/util/ShardInfo.java
+++ b/src/main/java/redis/clients/jedis/util/ShardInfo.java
@@ -1,4 +1,4 @@
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 public abstract class ShardInfo<T> {
   private int weight;

--- a/src/main/java/redis/clients/jedis/util/Sharded.java
+++ b/src/main/java/redis/clients/jedis/util/Sharded.java
@@ -1,4 +1,4 @@
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/src/main/java/redis/clients/jedis/util/Slowlog.java
+++ b/src/main/java/redis/clients/jedis/util/Slowlog.java
@@ -1,4 +1,4 @@
-package redis.clients.util;
+package redis.clients.jedis.util;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -41,7 +41,7 @@ import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.exceptions.*;
 import redis.clients.jedis.tests.utils.ClientKillerUtil;
 import redis.clients.jedis.tests.utils.JedisClusterTestUtil;
-import redis.clients.util.JedisClusterCRC16;
+import redis.clients.jedis.util.JedisClusterCRC16;
 
 public class JedisClusterTest {
   private static Jedis node1;

--- a/src/test/java/redis/clients/jedis/tests/JedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisTest.java
@@ -21,7 +21,7 @@ import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.tests.commands.JedisCommandTestBase;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class JedisTest extends JedisCommandTestBase {
   @Test

--- a/src/test/java/redis/clients/jedis/tests/KeyMergeUtilTest.java
+++ b/src/test/java/redis/clients/jedis/tests/KeyMergeUtilTest.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 
-import redis.clients.util.KeyMergeUtil;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.KeyMergeUtil;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class KeyMergeUtilTest {
 

--- a/src/test/java/redis/clients/jedis/tests/ModuleTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ModuleTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import redis.clients.jedis.Module;
 import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.tests.commands.JedisCommandTestBase;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class ModuleTest extends JedisCommandTestBase {
 

--- a/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/tests/PipeliningTest.java
@@ -32,7 +32,7 @@ import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.Response;
 import redis.clients.jedis.Tuple;
 import redis.clients.jedis.exceptions.JedisDataException;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class PipeliningTest {
   private static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);

--- a/src/test/java/redis/clients/jedis/tests/ProtocolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ProtocolTest.java
@@ -20,9 +20,9 @@ import org.junit.Test;
 
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.exceptions.JedisBusyException;
-import redis.clients.util.RedisInputStream;
-import redis.clients.util.RedisOutputStream;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.RedisInputStream;
+import redis.clients.jedis.util.RedisOutputStream;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class ProtocolTest {
   @Test

--- a/src/test/java/redis/clients/jedis/tests/ShardedJedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ShardedJedisTest.java
@@ -18,8 +18,8 @@ import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.ShardedJedis;
 import redis.clients.jedis.tests.utils.ClientKillerUtil;
-import redis.clients.util.Hashing;
-import redis.clients.util.Sharded;
+import redis.clients.jedis.util.Hashing;
+import redis.clients.jedis.util.Sharded;
 
 public class ShardedJedisTest {
   private static HostAndPort redis1 = HostAndPortUtil.getRedisServers().get(0);

--- a/src/test/java/redis/clients/jedis/tests/benchmark/CRC16Benchmark.java
+++ b/src/test/java/redis/clients/jedis/tests/benchmark/CRC16Benchmark.java
@@ -2,7 +2,7 @@ package redis.clients.jedis.tests.benchmark;
 
 import java.util.Calendar;
 
-import redis.clients.util.JedisClusterCRC16;
+import redis.clients.jedis.util.JedisClusterCRC16;
 
 public class CRC16Benchmark {
   private static final int TOTAL_OPERATIONS = 100000000;

--- a/src/test/java/redis/clients/jedis/tests/benchmark/ProtocolBenchmark.java
+++ b/src/test/java/redis/clients/jedis/tests/benchmark/ProtocolBenchmark.java
@@ -1,8 +1,8 @@
 package redis.clients.jedis.tests.benchmark;
 
 import redis.clients.jedis.Protocol;
-import redis.clients.util.RedisInputStream;
-import redis.clients.util.RedisOutputStream;
+import redis.clients.jedis.util.RedisInputStream;
+import redis.clients.jedis.util.RedisOutputStream;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/redis/clients/jedis/tests/benchmark/SafeEncoderBenchmark.java
+++ b/src/test/java/redis/clients/jedis/tests/benchmark/SafeEncoderBenchmark.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Calendar;
 
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class SafeEncoderBenchmark {
   private static final int TOTAL_OPERATIONS = 10000000;

--- a/src/test/java/redis/clients/jedis/tests/benchmark/ShardedBenchmark.java
+++ b/src/test/java/redis/clients/jedis/tests/benchmark/ShardedBenchmark.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Calendar;
 
-import redis.clients.util.Hashing;
+import redis.clients.jedis.util.Hashing;
 
 public class ShardedBenchmark {
   private static final int TOTAL_OPERATIONS = 10000000;

--- a/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 import redis.clients.jedis.Protocol.Keyword;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class AllKindOfValuesCommandsTest extends JedisCommandTestBase {
   final byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };

--- a/src/test/java/redis/clients/jedis/tests/commands/BitCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/BitCommandsTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import redis.clients.jedis.BitOP;
 import redis.clients.jedis.BitPosParams;
 import redis.clients.jedis.Protocol;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 import java.util.List;
 

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterBinaryJedisCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterBinaryJedisCommandsTest.java
@@ -20,7 +20,7 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.tests.HostAndPortUtil;
-import redis.clients.util.JedisClusterCRC16;
+import redis.clients.jedis.util.JedisClusterCRC16;
 
 public class ClusterBinaryJedisCommandsTest {
   private Jedis node1;

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterScriptingCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterScriptingCommandsTest.java
@@ -20,7 +20,7 @@ import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.exceptions.JedisClusterException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.tests.HostAndPortUtil;
-import redis.clients.util.JedisClusterCRC16;
+import redis.clients.jedis.util.JedisClusterCRC16;
 
 public class ClusterScriptingCommandsTest {
   private Jedis node1;

--- a/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
@@ -15,7 +15,7 @@ import redis.clients.jedis.GeoCoordinate;
 import redis.clients.jedis.GeoRadiusResponse;
 import redis.clients.jedis.GeoUnit;
 import redis.clients.jedis.params.GeoRadiusParam;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class GeoCommandsTest extends JedisCommandTestBase {
   final byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };

--- a/src/test/java/redis/clients/jedis/tests/commands/HyperLogLogCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/HyperLogLogCommandsTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class HyperLogLogCommandsTest extends JedisCommandTestBase {
 

--- a/src/test/java/redis/clients/jedis/tests/commands/ObjectCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ObjectCommandsTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class ObjectCommandsTest extends JedisCommandTestBase {
 

--- a/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
@@ -19,7 +19,7 @@ import redis.clients.jedis.BinaryJedisPubSub;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPubSub;
 import redis.clients.jedis.exceptions.JedisConnectionException;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class PublishSubscribeCommandsTest extends JedisCommandTestBase {
   private void publishOne(final String channel, final String message) {

--- a/src/test/java/redis/clients/jedis/tests/commands/ScriptingCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ScriptingCommandsTest.java
@@ -21,7 +21,7 @@ import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.exceptions.JedisNoScriptException;
 import redis.clients.jedis.tests.utils.ClientKillerUtil;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class ScriptingCommandsTest extends JedisCommandTestBase {
 

--- a/src/test/java/redis/clients/jedis/tests/commands/SlowlogCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/SlowlogCommandsTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import org.junit.Test;
 
-import redis.clients.util.Slowlog;
+import redis.clients.jedis.util.Slowlog;
 
 public class SlowlogCommandsTest extends JedisCommandTestBase {
 

--- a/src/test/java/redis/clients/jedis/tests/commands/SortedSetCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/SortedSetCommandsTest.java
@@ -22,7 +22,7 @@ import redis.clients.jedis.Tuple;
 import redis.clients.jedis.ZParams;
 import redis.clients.jedis.params.ZAddParams;
 import redis.clients.jedis.params.ZIncrByParams;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class SortedSetCommandsTest extends JedisCommandTestBase {
   final byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };

--- a/src/test/java/redis/clients/jedis/tests/utils/ByteArrayComparatorTest.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/ByteArrayComparatorTest.java
@@ -4,8 +4,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import redis.clients.util.ByteArrayComparator;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.ByteArrayComparator;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class ByteArrayComparatorTest {
 

--- a/src/test/java/redis/clients/jedis/tests/utils/JedisClusterCRC16Test.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/JedisClusterCRC16Test.java
@@ -8,8 +8,8 @@ import java.util.Map.Entry;
 
 import org.junit.Test;
 
-import redis.clients.util.JedisClusterCRC16;
-import redis.clients.util.SafeEncoder;
+import redis.clients.jedis.util.JedisClusterCRC16;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class JedisClusterCRC16Test {
 

--- a/src/test/java/redis/clients/jedis/tests/utils/JedisURIHelperTest.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/JedisURIHelperTest.java
@@ -9,7 +9,7 @@ import java.net.URISyntaxException;
 
 import org.junit.Test;
 
-import redis.clients.util.JedisURIHelper;
+import redis.clients.jedis.util.JedisURIHelper;
 
 public class JedisURIHelperTest {
 


### PR DESCRIPTION
In `util` package:
- Some classes contain the name `Jedis`
- Some classes are dependant on elements in package `jedis` (e.g. `exceptions`)

IMHO, both of these should be avoided. A simple solution for this is to move entire `util` into `jedis`.