### PR TITLE
Modify ConnectionHandlingCommandsTest

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/commands/ConnectionHandlingCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ConnectionHandlingCommandsTest.java
@@ -5,20 +5,19 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import redis.clients.jedis.BinaryJedis;
-import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.tests.HostAndPortUtil;
+import redis.clients.jedis.Jedis;
 
-public class ConnectionHandlingCommandsTest extends JedisCommandTestBase {
-  protected static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
+public class ConnectionHandlingCommandsTest {
 
   @Test
   public void quit() {
+    Jedis jedis = new Jedis();
     assertEquals("OK", jedis.quit());
   }
 
   @Test
   public void binary_quit() {
-    BinaryJedis bj = new BinaryJedis(hnp.getHost());
+    BinaryJedis bj = new BinaryJedis();
     assertEquals("OK", bj.quit());
   }
 }

--- a/src/test/java/redis/clients/jedis/tests/commands/ConnectionHandlingCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ConnectionHandlingCommandsTest.java
@@ -5,19 +5,22 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import redis.clients.jedis.BinaryJedis;
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.tests.HostAndPortUtil;
 
 public class ConnectionHandlingCommandsTest {
+  private static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
 
   @Test
   public void quit() {
-    Jedis jedis = new Jedis();
+    Jedis jedis = new Jedis(hnp);
     assertEquals("OK", jedis.quit());
   }
 
   @Test
   public void binary_quit() {
-    BinaryJedis bj = new BinaryJedis();
+    BinaryJedis bj = new BinaryJedis(hnp);
     assertEquals("OK", bj.quit());
   }
 }


### PR DESCRIPTION
* Remove extending JedisCommandTestBase. This saves unnecessary setUp, tearDown.

* <strike>Remove reading from getRedisServers.</strike> Provide HostAndPort for Jedis and BinaryJedis. Only host (evidently `localhost`) is read which doesn't make complete sense. Either both host and port or none should be read.