### PR TITLE
Remove configSet timeout in JedisCommandTestBase

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/commands/JedisCommandTestBase.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/JedisCommandTestBase.java
@@ -30,7 +30,6 @@ public abstract class JedisCommandTestBase {
     jedis = new Jedis(hnp.getHost(), hnp.getPort(), 500);
     jedis.connect();
     jedis.auth("foobared");
-    jedis.configSet("timeout", "300");
     jedis.flushAll();
   }
 


### PR DESCRIPTION
It was added in https://github.com/xetorthio/jedis/commit/cd9e17a70976a8d5093703206da4b2ab0d1bb770#diff-fc3c922202222a7dce6ca86f63e2ef07R31 without any explanation.