### PR TITLE
Generic Support for RedisModules

### DIFF
--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -3,7 +3,6 @@ package redis.clients.jedis;
 import static redis.clients.jedis.Protocol.toByteArray;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,14 +44,11 @@ public class Client extends BinaryClient implements Commands {
   }
   
   @Override
-  public void sendGenericCmd(String... args) {
-	  if (args==null || args.length==0) 
+  public void sendGenericCmd(String cmdName,String... args) {
+	  if (cmdName==null || cmdName.length()==0) 
 		  throw new IllegalArgumentException("You need pass at least the custom command name. ");
 	  
-	  String[] argsWithoutCommandName = new String[args.length-1];
-	  System.arraycopy(args, 1, argsWithoutCommandName, 0, args.length-1);
-	  
-	  sendCommand(Protocol.GenericCommand.from(args[0]), argsWithoutCommandName);
+	  sendCommand(Protocol.GenericCommand.from(cmdName), args);
   }
   
   @Override

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -3,6 +3,7 @@ package redis.clients.jedis;
 import static redis.clients.jedis.Protocol.toByteArray;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +43,18 @@ public class Client extends BinaryClient implements Commands {
       final HostnameVerifier hostnameVerifier) {
     super(host, port, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
   }
-
+  
+  @Override
+  public void sendGenericCmd(String... args) {
+	  if (args==null || args.length==0) 
+		  throw new IllegalArgumentException("You need pass at least the custom command name. ");
+	  
+	  String[] argsWithoutCommandName = new String[args.length-1];
+	  System.arraycopy(args, 1, argsWithoutCommandName, 0, args.length-1);
+	  
+	  sendCommand(Protocol.GenericCommand.from(args[0]), argsWithoutCommandName);
+  }
+  
   @Override
   public void set(final String key, final String value) {
     set(SafeEncoder.encode(key), SafeEncoder.encode(value));

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -132,6 +132,19 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     return client.getBulkReply();
   }
 
+  @Override
+  public Object sendGenericCmdList(String... args) {
+    client.sendGenericCmd(args);
+    return BuilderFactory.STRING_SET.build( client.getRawObjectMultiBulkReply() );
+  }
+  
+  @Override
+  public String sendGenericCmdString(String... args) {
+    client.sendGenericCmd(args);
+    return client.getBulkReply();
+  }
+
+  
   /**
    * Set the string value as value of the key. The string can't be longer than 1073741824 bytes (1
    * GB).

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -133,20 +133,20 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
   }
 
   @Override
-  public Object sendGenericCmdList(String... args) {
-    client.sendGenericCmd(args);
+  public Object sendGenericCmdList(String cmdName,String... args) {
+    client.sendGenericCmd(cmdName,args);
     return BuilderFactory.STRING_SET.build( client.getRawObjectMultiBulkReply() );
   }
   
   @Override
-  public String sendGenericCmdString(String... args) {
-    client.sendGenericCmd(args);
+  public String sendGenericCmdString(String cmdName,String... args) {
+    client.sendGenericCmd(cmdName,args);
     return client.getBulkReply();
   }
   
   @Override
-  public Long sendGenericCmdInteger(String... args) {
-    client.sendGenericCmd(args);
+  public Long sendGenericCmdInteger(String cmdName,String... args) {
+    client.sendGenericCmd(cmdName,args);
     return client.getIntegerReply();
   }
 

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -143,6 +143,12 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     client.sendGenericCmd(args);
     return client.getBulkReply();
   }
+  
+  @Override
+  public Long sendGenericCmdInteger(String... args) {
+    client.sendGenericCmd(args);
+    return client.getIntegerReply();
+  }
 
   
   /**

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -240,6 +240,24 @@ public final class Protocol {
       return SafeEncoder.encode(String.valueOf(value));
     }
   }
+  
+  public static class GenericCommand implements ProtocolCommand { 
+	  
+	  private final byte[] raw;
+	  
+	  GenericCommand(String name) {
+	      raw = SafeEncoder.encode(name);
+	  }
+
+	  @Override
+	  public byte[] getRaw() {
+	     return raw;
+	  }
+	  
+	  public static GenericCommand from(String name) {
+		  return new GenericCommand(name);
+	  }
+  }
 
   public static enum Command implements ProtocolCommand {
     PING, SET, GET, QUIT, EXISTS, DEL, UNLINK, TYPE, FLUSHDB, KEYS, RANDOMKEY, RENAME, RENAMENX, RENAMEX, 

--- a/src/main/java/redis/clients/jedis/ShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedis.java
@@ -35,18 +35,18 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands, C
   }
   
   @Override
-  public String sendGenericCmdString(String... args) {
-	return "TODO: code here!";
+  public String sendGenericCmdString(String cmdName,String... args) {
+	throw new UnsupportedOperationException("sendGenericCmdString not supported on Sharded Redis");
   }
   
   @Override
-  public Object sendGenericCmdList(String... args) {
-	return "TODO: code here!";
+  public Object sendGenericCmdList(String cmdName,String... args) {
+	  throw new UnsupportedOperationException("sendGenericCmdList not supported on Sharded Redis");
   }
   
   @Override
-  public Long sendGenericCmdInteger(String... args) {
-	return 0L;
+  public Long sendGenericCmdInteger(String cmdName,String... args) {
+	  throw new UnsupportedOperationException("sendGenericCmdInteger not supported on Sharded Redis");
   }
 
   

--- a/src/main/java/redis/clients/jedis/ShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedis.java
@@ -45,6 +45,12 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands, C
   }
   
   @Override
+  public Long sendGenericCmdInteger(String... args) {
+	return 0L;
+  }
+
+  
+  @Override
   public String set(final String key, final String value) {
     Jedis j = getShard(key);
     return j.set(key, value);

--- a/src/main/java/redis/clients/jedis/ShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedis.java
@@ -33,7 +33,17 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands, C
   public ShardedJedis(List<JedisShardInfo> shards, Hashing algo, Pattern keyTagPattern) {
     super(shards, algo, keyTagPattern);
   }
-
+  
+  @Override
+  public String sendGenericCmdString(String... args) {
+	return "TODO: code here!";
+  }
+  
+  @Override
+  public Object sendGenericCmdList(String... args) {
+	return "TODO: code here!";
+  }
+  
   @Override
   public String set(final String key, final String value) {
     Jedis j = getShard(key);

--- a/src/main/java/redis/clients/jedis/commands/Commands.java
+++ b/src/main/java/redis/clients/jedis/commands/Commands.java
@@ -12,7 +12,9 @@ import redis.clients.jedis.params.sortedset.ZAddParams;
 import redis.clients.jedis.params.sortedset.ZIncrByParams;
 
 public interface Commands {
-
+  
+  void sendGenericCmd(String... args);	
+	
   void set(String key, String value);
 
   void set(String key, String value, SetParams params);

--- a/src/main/java/redis/clients/jedis/commands/Commands.java
+++ b/src/main/java/redis/clients/jedis/commands/Commands.java
@@ -13,7 +13,7 @@ import redis.clients.jedis.params.sortedset.ZIncrByParams;
 
 public interface Commands {
   
-  void sendGenericCmd(String... args);	
+  void sendGenericCmd(String cmdName,String... args);	
 	
   void set(String key, String value);
 

--- a/src/main/java/redis/clients/jedis/commands/JedisCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/JedisCommands.java
@@ -18,6 +18,8 @@ public interface JedisCommands {
   Object sendGenericCmdList(String ...args);
   
   String sendGenericCmdString(String ...args);
+  
+  Long sendGenericCmdInteger(String ...args);
 	
   String set(String key, String value);
 

--- a/src/main/java/redis/clients/jedis/commands/JedisCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/JedisCommands.java
@@ -15,11 +15,11 @@ import redis.clients.jedis.params.sortedset.ZIncrByParams;
  */
 public interface JedisCommands {
 	 
-  Object sendGenericCmdList(String ...args);
+  Object sendGenericCmdList(String cmdName,String ...args);
   
-  String sendGenericCmdString(String ...args);
+  String sendGenericCmdString(String cmdName,String ...args);
   
-  Long sendGenericCmdInteger(String ...args);
+  Long sendGenericCmdInteger(String cmdName,String ...args);
 	
   String set(String key, String value);
 

--- a/src/main/java/redis/clients/jedis/commands/JedisCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/JedisCommands.java
@@ -14,6 +14,11 @@ import redis.clients.jedis.params.sortedset.ZIncrByParams;
  * Common interface for sharded and non-sharded Jedis
  */
 public interface JedisCommands {
+	 
+  Object sendGenericCmdList(String ...args);
+  
+  String sendGenericCmdString(String ...args);
+	
   String set(String key, String value);
 
   String set(String key, String value, SetParams params);

--- a/src/test/java/redis/clients/jedis/tests/JedisMain.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisMain.java
@@ -1,0 +1,20 @@
+package redis.clients.jedis.tests;
+
+import redis.clients.jedis.Jedis;
+
+public class JedisMain {
+	public static void main(String[] args) {
+		
+		Jedis jedis = new Jedis("localhost");
+		jedis.set("foo", "bar");
+		jedis.hset("hSet1", "f1", "ha");
+		
+		Object result = jedis.sendGenericCmdList("KEYS","*");
+		System.out.println("Result Generic Command[keys]: " + result);
+		
+		result = jedis.sendGenericCmdString("GET","foo");
+		System.out.println("Result Generic Command[GET]: " + result);
+		
+		jedis.close();
+	}
+}

--- a/src/test/java/redis/clients/jedis/tests/JedisMain.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisMain.java
@@ -15,6 +15,12 @@ public class JedisMain {
 		result = jedis.sendGenericCmdString("GET","foo");
 		System.out.println("Result Generic Command[GET]: " + result);
 		
+		result = jedis.sendGenericCmdInteger("INCR","X");
+		System.out.println("Result Generic Command[INCR]: " + result);
+		
+		result = jedis.sendGenericCmdString("INFO");
+		System.out.println("Result Generic Command[INFO]: " + result);
+		
 		jedis.close();
 	}
 }


### PR DESCRIPTION
@xetorthio 

I'm working on custom redis module. Would like to add generic commands capability to Jedis. So basically you can pass a generic command name and var-args of arguments and them get the result to a specific type like Long, List<Object>, String.

Cheers,
Diego Pacheco