### PR TITLE
Stop closing Jedis object from caller

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -97,15 +97,16 @@ public class JedisClusterInfoCache {
         }
 
         for (JedisPool jp : getShuffledNodesPool()) {
+          Jedis j = null;
           try {
-            jedis = jp.getResource();
-            discoverClusterSlots(jedis);
+            j = jp.getResource();
+            discoverClusterSlots(j);
             return;
           } catch (JedisConnectionException e) {
             // try next nodes
           } finally {
-            if (jedis != null) {
-              jedis.close();
+            if (j != null) {
+              j.close();
             }
           }
         }


### PR DESCRIPTION
When there is no exception from getResource, only inner Jedis objects are closed. But if there is exception in very first iteration of loop, Jedis passed by caller gets closed.
This change closes only the inner objects.