### PR TITLE
assertEquals param order and other changes

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/HostAndPortTest.java
+++ b/src/test/java/redis/clients/jedis/tests/HostAndPortTest.java
@@ -6,40 +6,32 @@ import java.util.Arrays;
 
 import redis.clients.jedis.HostAndPort;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
-/**
- * Created by smagellan on 7/11/16.
- */
 public class HostAndPortTest {
   @Test
   public void checkExtractParts() throws Exception {
     String host = "2a11:1b1:0:111:e111:1f11:1111:1f1e:1999";
     String port = "6379";
 
-    assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
-            Arrays.asList(host, port));
+    assertArrayEquals(new String[]{host, port}, HostAndPort.extractParts(host + ":" + port));
 
     host = "";
     port = "";
-    assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
-            Arrays.asList(host, port));
+    assertArrayEquals(new String[]{host, port}, HostAndPort.extractParts(host + ":" + port));
 
     host = "localhost";
     port = "";
-    assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
-            Arrays.asList(host, port));
-
+    assertArrayEquals(new String[]{host, port}, HostAndPort.extractParts(host + ":" + port));
 
     host = "";
     port = "6379";
-    assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
-            Arrays.asList(host, port));
+    assertArrayEquals(new String[]{host, port}, HostAndPort.extractParts(host + ":" + port));
 
     host = "11:22:33:44:55";
     port = "";
-    assertEquals(Arrays.asList(HostAndPort.extractParts(host + ":" + port)),
-            Arrays.asList(host, port));
+    assertArrayEquals(new String[]{host, port}, HostAndPort.extractParts(host + ":" + port));
   }
 
   @Test
@@ -60,6 +52,6 @@ public class HostAndPortTest {
   @Test
   public void checkConvertHost() {
     String host = "2a11:1b1:0:111:e111:1f11:1111:1f1e";
-    assertEquals(HostAndPort.convertHost(host), host);
+    assertEquals(host, HostAndPort.convertHost(host));
   }
 }

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -378,11 +378,12 @@ public class JedisClusterTest {
 
   @Test
   public void testRedisHashtag() {
-    assertEquals(JedisClusterCRC16.getSlot("{bar"), JedisClusterCRC16.getSlot("foo{{bar}}zap"));
     assertEquals(JedisClusterCRC16.getSlot("{user1000}.following"),
       JedisClusterCRC16.getSlot("{user1000}.followers"));
-    assertNotEquals(JedisClusterCRC16.getSlot("foo{}{bar}"), JedisClusterCRC16.getSlot("bar"));
-    assertEquals(JedisClusterCRC16.getSlot("foo{bar}{zap}"), JedisClusterCRC16.getSlot("bar"));
+    assertEquals(JedisClusterCRC16.getSlot("bar"), JedisClusterCRC16.getSlot("foo{bar}{zap}"));
+    assertNotEquals(JedisClusterCRC16.getSlot("bar"), JedisClusterCRC16.getSlot("foo{}{bar}"));
+    assertNotEquals(JedisClusterCRC16.getSlot(""), JedisClusterCRC16.getSlot("foo{}{bar}"));
+    assertEquals(JedisClusterCRC16.getSlot("{bar"), JedisClusterCRC16.getSlot("foo{{bar}}zap"));
   }
 
   @Test
@@ -443,10 +444,14 @@ public class JedisClusterTest {
   @Test
   public void testClusterKeySlot() {
     // It assumes JedisClusterCRC16 is correctly implemented
-    assertEquals(node1.clusterKeySlot("foo{bar}zap}").intValue(),
-      JedisClusterCRC16.getSlot("foo{bar}zap"));
-    assertEquals(node1.clusterKeySlot("{user1000}.following").intValue(),
-      JedisClusterCRC16.getSlot("{user1000}.following"));
+    assertEquals(JedisClusterCRC16.getSlot("{user1000}.following"),
+        node1.clusterKeySlot("{user1000}.following").intValue());
+    assertEquals(JedisClusterCRC16.getSlot("foo{bar}{zap}"),
+        node1.clusterKeySlot("foo{bar}{zap}").intValue());
+    assertEquals(JedisClusterCRC16.getSlot("foo{}{bar}"),
+        node1.clusterKeySlot("foo{}{bar}").intValue());
+    assertEquals(JedisClusterCRC16.getSlot("foo{{bar}}zap"),
+        node1.clusterKeySlot("foo{{bar}}zap").intValue());
   }
 
   @Test
@@ -456,12 +461,13 @@ public class JedisClusterTest {
     JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT,
         DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
 
-    for (int index = 0; index < 5; index++) {
+    int count = 5;
+    for (int index = 0; index < count; index++) {
       jc.set("foo{bar}" + index, "hello");
     }
 
     int slot = JedisClusterCRC16.getSlot("foo{bar}");
-    assertEquals(DEFAULT_REDIRECTIONS, node1.clusterCountKeysInSlot(slot).intValue());
+    assertEquals(count, node1.clusterCountKeysInSlot(slot).intValue());
   }
 
   @Test
@@ -537,11 +543,10 @@ public class JedisClusterTest {
 
     for (JedisPool pool : jc.getClusterNodes().values()) {
       Jedis jedis = pool.getResource();
-      assertEquals(jedis.getClient().getConnectionTimeout(), 4000);
-      assertEquals(jedis.getClient().getSoTimeout(), 4000);
+      assertEquals(4000, jedis.getClient().getConnectionTimeout());
+      assertEquals(4000, jedis.getClient().getSoTimeout());
       jedis.close();
     }
-
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
@@ -263,7 +263,7 @@ public class JedisPoolTest {
     } catch (Exception ignored) {
     }
 
-    assertEquals(destroyed.get(), 1);
+    assertEquals(1, destroyed.get());
   }
 
   @Test
@@ -355,9 +355,8 @@ public class JedisPoolTest {
   public void testAddObject() {
     JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
     pool.addObjects(1);
-    assertEquals(pool.getNumIdle(), 1);
+    assertEquals(1, pool.getNumIdle());
     pool.destroy();
-
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/tests/JedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisTest.java
@@ -129,15 +129,15 @@ public class JedisTest extends JedisCommandTestBase {
   public void allowUrlWithNoDBAndNoPassword() {
     Jedis jedis = new Jedis("redis://localhost:6380");
     jedis.auth("foobared");
-    assertEquals(jedis.getClient().getHost(), "localhost");
-    assertEquals(jedis.getClient().getPort(), 6380);
-    assertEquals(jedis.getDB(), 0);
+    assertEquals("localhost", jedis.getClient().getHost());
+    assertEquals(6380, jedis.getClient().getPort());
+    assertEquals(0, jedis.getDB());
 
     jedis = new Jedis("redis://localhost:6380/");
     jedis.auth("foobared");
-    assertEquals(jedis.getClient().getHost(), "localhost");
-    assertEquals(jedis.getClient().getPort(), 6380);
-    assertEquals(jedis.getDB(), 0);
+    assertEquals("localhost", jedis.getClient().getHost());
+    assertEquals(6380, jedis.getClient().getPort());
+    assertEquals(0, jedis.getDB());
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/tests/ModuleTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ModuleTest.java
@@ -32,18 +32,18 @@ public class ModuleTest extends JedisCommandTestBase {
   @Test
   public void testModules() {
     String res = jedis.moduleLoad("/tmp/testmodule.so");
-    assertEquals(res, "OK");
+    assertEquals("OK", res);
 
     List<Module> modules = jedis.moduleList();
 
-    assertEquals(modules.get(0).getName(), "testmodule");
+    assertEquals("testmodule", modules.get(0).getName());
 
     jedis.getClient().sendCommand(ModuleCommand.SIMPLE);
     Long out = jedis.getClient().getIntegerReply();
     assertTrue(out > 0);
 
     res = jedis.moduleUnload("testmodule");
-    assertEquals(res, "OK");
+    assertEquals("OK", res);
   }
 
 }

--- a/src/test/java/redis/clients/jedis/tests/SSLJedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/SSLJedisTest.java
@@ -1,6 +1,8 @@
 package redis.clients.jedis.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -24,7 +26,6 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -40,7 +41,7 @@ public class SSLJedisTest {
   }
 
   private static void setJvmTrustStore(String trustStoreFilePath, String trustStoreType) {
-    Assert.assertTrue(String.format("Could not find trust store at '%s'.", trustStoreFilePath),
+    assertTrue(String.format("Could not find trust store at '%s'.", trustStoreFilePath),
         new File(trustStoreFilePath).exists());
     System.setProperty("javax.net.ssl.trustStore", trustStoreFilePath);
     System.setProperty("javax.net.ssl.trustStoreType", trustStoreType);
@@ -121,11 +122,11 @@ public class SSLJedisTest {
     Jedis jedis = new Jedis(shardInfo);
     try {
       assertEquals("PONG", jedis.ping());
-      Assert.fail("The code did not throw the expected JedisConnectionException.");
+      fail("The code did not throw the expected JedisConnectionException.");
     } catch (JedisConnectionException e) {
-      Assert.assertEquals("Unexpected first inner exception.",
+      assertEquals("Unexpected first inner exception.",
           SSLHandshakeException.class, e.getCause().getClass());
-      Assert.assertEquals("Unexpected second inner exception.",
+      assertEquals("Unexpected second inner exception.",
           CertificateException.class, e.getCause().getCause().getClass());
     }
 
@@ -194,9 +195,9 @@ public class SSLJedisTest {
     Jedis jedis = new Jedis(shardInfo);
     try {
       assertEquals("PONG", jedis.ping());
-      Assert.fail("The code did not throw the expected JedisConnectionException.");
+      fail("The code did not throw the expected JedisConnectionException.");
     } catch (JedisConnectionException e) {
-      Assert.assertEquals("The JedisConnectionException does not contain the expected message.",
+      assertEquals("The JedisConnectionException does not contain the expected message.",
           "The connection to '127.0.0.1' failed ssl/tls hostname verification.", e.getMessage());
     }
 
@@ -226,14 +227,14 @@ public class SSLJedisTest {
     Jedis jedis = new Jedis(shardInfo);
     try {
       assertEquals("PONG", jedis.ping());
-      Assert.fail("The code did not throw the expected JedisConnectionException.");
+      fail("The code did not throw the expected JedisConnectionException.");
     } catch (JedisConnectionException e) {
-      Assert.assertEquals("Unexpected first inner exception.",
-          SSLException.class, e.getCause().getClass());
-      Assert.assertEquals("Unexpected second inner exception.",
-          RuntimeException.class, e.getCause().getCause().getClass());
-      Assert.assertEquals("Unexpected third inner exception.",
-          InvalidAlgorithmParameterException.class, e.getCause().getCause().getCause().getClass());
+      assertEquals("Unexpected first inner exception.", SSLException.class,
+          e.getCause().getClass());
+      assertEquals("Unexpected second inner exception.", RuntimeException.class,
+          e.getCause().getCause().getClass());
+      assertEquals("Unexpected third inner exception.", InvalidAlgorithmParameterException.class,
+          e.getCause().getCause().getCause().getClass());
     }
 
     try {

--- a/src/test/java/redis/clients/jedis/tests/ShardedJedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ShardedJedisPoolTest.java
@@ -167,8 +167,8 @@ public class ShardedJedisPoolTest {
     shards.set(1, new JedisShardInfo("localhost", 1234));
     pool = new ShardedJedisPool(redisConfig, shards);
     jedis = pool.getResource();
-    Long actual = Long.valueOf(0);
-    Long fails = Long.valueOf(0);
+    long actual = 0;
+    long fails = 0;
     for (int i = 0; i < 1000; i++) {
       try {
         jedis.get("a-test-" + i);
@@ -179,8 +179,8 @@ public class ShardedJedisPoolTest {
     }
     jedis.close();
     pool.destroy();
-    assertEquals(actual, c1);
-    assertEquals(fails, c2);
+    assertEquals(Long.valueOf(actual), c1);
+    assertEquals(Long.valueOf(fails), c2);
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/tests/ShardedJedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ShardedJedisTest.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -165,14 +166,11 @@ public class ShardedJedisTest {
     shards.add(new JedisShardInfo(redis2));
     ShardedJedis jedis = new ShardedJedis(shards, ShardedJedis.DEFAULT_KEY_TAG_PATTERN);
 
-    assertEquals(jedis.getKeyTag("foo"), "foo");
-    assertEquals(jedis.getKeyTag("foo{bar}"), "bar");
-    assertEquals(jedis.getKeyTag("foo{bar}}"), "bar"); // default pattern is
-    // non greedy
-    assertEquals(jedis.getKeyTag("{bar}foo"), "bar"); // Key tag may appear
-    // anywhere
-    assertEquals(jedis.getKeyTag("f{bar}oo"), "bar"); // Key tag may appear
-    // anywhere
+    assertEquals("foo", jedis.getKeyTag("foo"));
+    assertEquals("bar", jedis.getKeyTag("foo{bar}"));
+    assertEquals("bar", jedis.getKeyTag("foo{bar}}")); // Default pattern is non greedy
+    assertEquals("bar", jedis.getKeyTag("{bar}foo")); // Key tag may appear anywhere
+    assertEquals("bar", jedis.getKeyTag("f{bar}oo")); // Key tag may appear anywhere
 
     JedisShardInfo s1 = jedis.getShardInfo("abc{bar}");
     JedisShardInfo s2 = jedis.getShardInfo("foo{bar}");
@@ -185,8 +183,8 @@ public class ShardedJedisTest {
 
     ShardedJedis jedis2 = new ShardedJedis(shards);
 
-    assertEquals(jedis2.getKeyTag("foo"), "foo");
-    assertNotSame(jedis2.getKeyTag("foo{bar}"), "bar");
+    assertEquals("foo", jedis2.getKeyTag("foo"));
+    assertNotEquals("bar", jedis2.getKeyTag("foo{bar}"));
 
     JedisShardInfo s5 = jedis2.getShardInfo(keys.get(0) + "{bar}");
     JedisShardInfo s6 = jedis2.getShardInfo(keys.get(1) + "{bar}");

--- a/src/test/java/redis/clients/jedis/tests/commands/BitCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/BitCommandsTest.java
@@ -136,7 +136,7 @@ public class BitCommandsTest extends JedisCommandTestBase {
     long reply = jedis.setrange("key1", 6, "Jedis");
     assertEquals(11, reply);
 
-    assertEquals(jedis.get("key1"), "Hello Jedis");
+    assertEquals("Hello Jedis", jedis.get("key1"));
 
     assertEquals("Hello", jedis.getrange("key1", 0, 4));
     assertEquals("Jedis", jedis.getrange("key1", 6, 11));

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterBinaryJedisCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterBinaryJedisCommandsTest.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis.tests.commands;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -107,7 +108,7 @@ public class ClusterBinaryJedisCommandsTest {
     byte[] byteKey = "foo".getBytes();
     byte[] byteValue = "2".getBytes();
     jedisCluster.set(byteKey, byteValue);
-    assertEquals(new String(jedisCluster.get(byteKey)), "2");
+    assertArrayEquals(byteValue, jedisCluster.get(byteKey));
   }
 
   @SuppressWarnings("unchecked")
@@ -117,7 +118,7 @@ public class ClusterBinaryJedisCommandsTest {
     byte[] byteValue = "2".getBytes();
     jedisCluster.set(byteKey, byteValue);
     jedisCluster.incr(byteKey);
-    assertEquals(new String(jedisCluster.get(byteKey)), "3");
+    assertArrayEquals("3".getBytes(), jedisCluster.get(byteKey));
   }
 
   @SuppressWarnings("unchecked")
@@ -140,15 +141,15 @@ public class ClusterBinaryJedisCommandsTest {
   @SuppressWarnings("unchecked")
   @Test
   public void testHmset() {
-    byte[] byteKey = "language".getBytes();
-    byte[] language = "java".getBytes();
+    byte[] key = "jedis".getBytes();
+    byte[] field = "language".getBytes();
+    byte[] value = "java".getBytes();
     HashMap<byte[], byte[]> map = new HashMap();
-    map.put(byteKey, language);
-    jedisCluster.hmset(byteKey, map);
-    List<byte[]> listResults = jedisCluster.hmget(byteKey, byteKey);
+    map.put(field, value);
+    jedisCluster.hmset(key, map);
+    List<byte[]> listResults = jedisCluster.hmget(key, field);
     for (byte[] result : listResults) {
-      String resultString = new String(result);
-      assertEquals(resultString, "java");
+      assertArrayEquals(value, result);
     }
   }
 
@@ -181,13 +182,16 @@ public class ClusterBinaryJedisCommandsTest {
 
   @Test
   public void testGetSlot() {
-    assertEquals(JedisClusterCRC16.getSlot("{bar".getBytes()), JedisClusterCRC16.getSlot("{bar"));
     assertEquals(JedisClusterCRC16.getSlot("{user1000}.following".getBytes()),
       JedisClusterCRC16.getSlot("{user1000}.followers".getBytes()));
-    assertNotEquals(JedisClusterCRC16.getSlot("foo{}{bar}".getBytes()),
-      JedisClusterCRC16.getSlot("bar".getBytes()));
-    assertEquals(JedisClusterCRC16.getSlot("foo{bar}{zap}".getBytes()),
-      JedisClusterCRC16.getSlot("bar".getBytes()));
+    assertEquals(JedisClusterCRC16.getSlot("bar".getBytes()),
+        JedisClusterCRC16.getSlot("foo{bar}{zap}".getBytes()));
+    assertNotEquals(JedisClusterCRC16.getSlot("bar".getBytes()),
+        JedisClusterCRC16.getSlot("foo{}{bar}".getBytes()));
+    assertNotEquals(JedisClusterCRC16.getSlot(new byte[0]),
+        JedisClusterCRC16.getSlot("foo{}{bar}".getBytes()));
+    assertEquals(JedisClusterCRC16.getSlot("{bar".getBytes()),
+        JedisClusterCRC16.getSlot("foo{{bar}}zap".getBytes()));
   }
 
   private static String getNodeId(String infoOutput) {

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterScriptingCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterScriptingCommandsTest.java
@@ -122,7 +122,7 @@ public class ClusterScriptingCommandsTest {
     int numKeys = 1;
     String[] args = { "foo" };
     jedisCluster.eval(script, numKeys, args);
-    assertEquals(jedisCluster.get("foo"), "bar");
+    assertEquals("bar", jedisCluster.get("foo"));
   }
 
   @SuppressWarnings("unchecked")
@@ -160,7 +160,7 @@ public class ClusterScriptingCommandsTest {
     byte[] script = "return redis.call('set',KEYS[1],'bar')".getBytes();
     byte[] args = "foo".getBytes();
     jedisCluster.eval(script, 1, args);
-    assertEquals(jedisCluster.get("foo"), "bar");
+    assertEquals("bar", jedisCluster.get("foo"));
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
@@ -60,29 +60,29 @@ public class GeoCommandsTest extends JedisCommandTestBase {
     prepareGeoData();
 
     Double dist = jedis.geodist("foo", "a", "b");
-    assertEquals(dist.intValue(), 157149);
+    assertEquals(157149, dist.intValue());
 
     dist = jedis.geodist("foo", "a", "b", GeoUnit.KM);
-    assertEquals(dist.intValue(), 157);
+    assertEquals(157, dist.intValue());
 
     dist = jedis.geodist("foo", "a", "b", GeoUnit.MI);
-    assertEquals(dist.intValue(), 97);
+    assertEquals(97, dist.intValue());
 
     dist = jedis.geodist("foo", "a", "b", GeoUnit.FT);
-    assertEquals(dist.intValue(), 515583);
+    assertEquals(515583, dist.intValue());
 
     // binary
     dist = jedis.geodist(bfoo, bA, bB);
-    assertEquals(dist.intValue(), 157149);
+    assertEquals(157149, dist.intValue());
 
     dist = jedis.geodist(bfoo, bA, bB, GeoUnit.KM);
-    assertEquals(dist.intValue(), 157);
+    assertEquals(157, dist.intValue());
 
     dist = jedis.geodist(bfoo, bA, bB, GeoUnit.MI);
-    assertEquals(dist.intValue(), 97);
+    assertEquals(97, dist.intValue());
 
     dist = jedis.geodist(bfoo, bA, bB, GeoUnit.FT);
-    assertEquals(dist.intValue(), 515583);
+    assertEquals(515583, dist.intValue());
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/tests/commands/HashesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/HashesCommandsTest.java
@@ -190,15 +190,15 @@ public class HashesCommandsTest extends JedisCommandTestBase {
     value = jedis.hincrByFloat("foo", "bar", -1.5d);
     assertEquals((Double) 0d, value);
     value = jedis.hincrByFloat("foo", "bar", -10.7d);
-    assertEquals(Double.compare(-10.7d, value), 0);
+    assertEquals(Double.valueOf(-10.7d), value);
 
     // Binary
     double bvalue = jedis.hincrByFloat(bfoo, bbar, 1.5d);
-    assertEquals(Double.compare(1.5d, bvalue), 0);
+    assertEquals(1.5d, bvalue, 0d);
     bvalue = jedis.hincrByFloat(bfoo, bbar, -1.5d);
-    assertEquals(Double.compare(0d, bvalue), 0);
+    assertEquals(0d, bvalue, 0d);
     bvalue = jedis.hincrByFloat(bfoo, bbar, -10.7d);
-    assertEquals(Double.compare(-10.7d, value), 0);
+    assertEquals(-10.7d, bvalue, 0d);
 
   }
 


### PR DESCRIPTION
- assertEquals usages are changed to have expected value first and actual one later.
- In HostAndPortTest, assertArrayEquals is used instead of converting array to list.
- Added/modified tests in JedisClusterTest.testRedisHashtag(), JedisClusterTest.testClusterKeySlot() and
- assertArrayEquals is used in case of byte array operations instead of converting to string.
- Other changes, only in tests.