### PR TITLE
Jedis.close() should call super.close()

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3425,7 +3425,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
         this.dataSource.returnResource(this);
       }
     } else {
-      client.close();
+      super.close();
     }
   }
 


### PR DESCRIPTION
Because there could be something more happening in BinaryJedis.close()