### PR TITLE
Remove inner packages of params

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -24,10 +24,10 @@ import javax.net.ssl.SSLSocketFactory;
 
 import redis.clients.jedis.Protocol.Command;
 import redis.clients.jedis.Protocol.Keyword;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.set.SetParams;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 
 public class BinaryClient extends Connection {
 

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -24,10 +24,10 @@ import redis.clients.jedis.commands.*;
 import redis.clients.jedis.exceptions.InvalidURIException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.exceptions.JedisException;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.set.SetParams;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 import redis.clients.util.JedisByteHashMap;
 import redis.clients.util.JedisURIHelper;
 

--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -3,10 +3,10 @@ package redis.clients.jedis;
 import redis.clients.jedis.commands.BinaryJedisClusterCommands;
 import redis.clients.jedis.commands.JedisClusterBinaryScriptingCommands;
 import redis.clients.jedis.commands.MultiKeyBinaryJedisClusterCommands;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.set.SetParams;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 import redis.clients.util.KeyMergeUtil;
 import redis.clients.util.SafeEncoder;
 

--- a/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
@@ -8,10 +8,10 @@ import java.util.regex.Pattern;
 
 import redis.clients.jedis.commands.BinaryJedisCommands;
 import redis.clients.jedis.exceptions.JedisConnectionException;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.set.SetParams;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 import redis.clients.util.Hashing;
 import redis.clients.util.Sharded;
 

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -13,10 +13,10 @@ import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
 
 import redis.clients.jedis.commands.Commands;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.set.SetParams;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 import redis.clients.util.SafeEncoder;
 
 public class Client extends BinaryClient implements Commands {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -21,10 +21,10 @@ import redis.clients.jedis.commands.ModuleCommands;
 import redis.clients.jedis.commands.MultiKeyCommands;
 import redis.clients.jedis.commands.ScriptingCommands;
 import redis.clients.jedis.commands.SentinelCommands;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.set.SetParams;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 import redis.clients.util.SafeEncoder;
 import redis.clients.util.Slowlog;
 

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -1,8 +1,8 @@
 package redis.clients.jedis;
 
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 import redis.clients.jedis.commands.JedisClusterCommands;
 import redis.clients.jedis.commands.JedisClusterScriptingCommands;
 import redis.clients.jedis.commands.MultiKeyJedisClusterCommands;
@@ -16,7 +16,7 @@ import java.util.Set;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
-import redis.clients.jedis.params.set.SetParams;
+import redis.clients.jedis.params.SetParams;
 import redis.clients.util.JedisClusterHashTagUtil;
 
 public class JedisCluster extends BinaryJedisCluster implements JedisClusterCommands,

--- a/src/main/java/redis/clients/jedis/PipelineBase.java
+++ b/src/main/java/redis/clients/jedis/PipelineBase.java
@@ -6,10 +6,10 @@ import java.util.Set;
 
 import redis.clients.jedis.commands.BinaryRedisPipeline;
 import redis.clients.jedis.commands.RedisPipeline;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.set.SetParams;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 
 public abstract class PipelineBase extends Queable implements BinaryRedisPipeline, RedisPipeline {
 

--- a/src/main/java/redis/clients/jedis/ShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedis.java
@@ -8,10 +8,10 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import redis.clients.jedis.commands.JedisCommands;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.set.SetParams;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 import redis.clients.util.Hashing;
 
 public class ShardedJedis extends BinaryShardedJedis implements JedisCommands, Closeable {

--- a/src/main/java/redis/clients/jedis/commands/BinaryJedisClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/BinaryJedisClusterCommands.java
@@ -1,10 +1,10 @@
 package redis.clients.jedis.commands;
 
 import redis.clients.jedis.*;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.set.SetParams;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/redis/clients/jedis/commands/BinaryJedisCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/BinaryJedisCommands.java
@@ -6,10 +6,10 @@ import java.util.Map;
 import java.util.Set;
 
 import redis.clients.jedis.*;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.set.SetParams;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 
 /**
  * Common interface for sharded and non-sharded BinaryJedis

--- a/src/main/java/redis/clients/jedis/commands/BinaryRedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/commands/BinaryRedisPipeline.java
@@ -2,9 +2,9 @@ package redis.clients.jedis.commands;
 
 import redis.clients.jedis.*;
 
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/redis/clients/jedis/commands/Commands.java
+++ b/src/main/java/redis/clients/jedis/commands/Commands.java
@@ -7,9 +7,9 @@ import redis.clients.jedis.ListPosition;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.SortingParams;
 import redis.clients.jedis.ZParams;
-import redis.clients.jedis.params.set.SetParams;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 
 public interface Commands {
 

--- a/src/main/java/redis/clients/jedis/commands/JedisClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/JedisClusterCommands.java
@@ -1,10 +1,10 @@
 package redis.clients.jedis.commands;
 
 import redis.clients.jedis.*;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.set.SetParams;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/redis/clients/jedis/commands/JedisCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/JedisCommands.java
@@ -5,10 +5,10 @@ import java.util.Map;
 import java.util.Set;
 
 import redis.clients.jedis.*;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.set.SetParams;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.SetParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 
 /**
  * Common interface for sharded and non-sharded Jedis

--- a/src/main/java/redis/clients/jedis/commands/RedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/commands/RedisPipeline.java
@@ -1,9 +1,9 @@
 package redis.clients.jedis.commands;
 
 import redis.clients.jedis.*;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.GeoRadiusParam;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/redis/clients/jedis/params/GeoRadiusParam.java
+++ b/src/main/java/redis/clients/jedis/params/GeoRadiusParam.java
@@ -1,7 +1,6 @@
-package redis.clients.jedis.params.geo;
+package redis.clients.jedis.params;
 
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.params.Params;
 import redis.clients.util.SafeEncoder;
 
 import java.util.ArrayList;
@@ -17,7 +16,7 @@ public class GeoRadiusParam extends Params {
   private static final String DESC = "desc";
   private static final String COUNT = "count";
 
-  private GeoRadiusParam() {
+  public GeoRadiusParam() {
   }
 
   public static GeoRadiusParam geoRadiusParam() {

--- a/src/main/java/redis/clients/jedis/params/SetParams.java
+++ b/src/main/java/redis/clients/jedis/params/SetParams.java
@@ -1,8 +1,7 @@
-package redis.clients.jedis.params.set;
+package redis.clients.jedis.params;
 
 import java.util.ArrayList;
 
-import redis.clients.jedis.params.Params;
 import redis.clients.util.SafeEncoder;
 
 public class SetParams extends Params {
@@ -12,7 +11,7 @@ public class SetParams extends Params {
   private static final String PX = "px";
   private static final String EX = "ex";
 
-  private SetParams() {
+  public SetParams() {
   }
 
   public static SetParams setParams() {

--- a/src/main/java/redis/clients/jedis/params/ZAddParams.java
+++ b/src/main/java/redis/clients/jedis/params/ZAddParams.java
@@ -1,6 +1,5 @@
-package redis.clients.jedis.params.sortedset;
+package redis.clients.jedis.params;
 
-import redis.clients.jedis.params.Params;
 import redis.clients.util.SafeEncoder;
 
 import java.util.ArrayList;
@@ -11,7 +10,7 @@ public class ZAddParams extends Params {
   private static final String NX = "nx";
   private static final String CH = "ch";
 
-  private ZAddParams() {
+  public ZAddParams() {
   }
 
   public static ZAddParams zAddParams() {

--- a/src/main/java/redis/clients/jedis/params/ZIncrByParams.java
+++ b/src/main/java/redis/clients/jedis/params/ZIncrByParams.java
@@ -1,6 +1,5 @@
-package redis.clients.jedis.params.sortedset;
+package redis.clients.jedis.params;
 
-import redis.clients.jedis.params.Params;
 import redis.clients.util.SafeEncoder;
 
 import java.util.ArrayList;
@@ -25,7 +24,7 @@ public class ZIncrByParams extends Params {
   private static final String NX = "nx";
   private static final String INCR = "incr";
 
-  private ZIncrByParams() {
+  public ZIncrByParams() {
   }
 
   public static ZIncrByParams zIncrByParams() {

--- a/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/AllKindOfValuesCommandsTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static redis.clients.jedis.ScanParams.SCAN_POINTER_START;
 import static redis.clients.jedis.ScanParams.SCAN_POINTER_START_BINARY;
-import static redis.clients.jedis.params.set.SetParams.setParams;
+import static redis.clients.jedis.params.SetParams.setParams;
 
 import java.util.Arrays;
 import java.util.HashSet;

--- a/src/test/java/redis/clients/jedis/tests/commands/BinaryValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/BinaryValuesCommandsTest.java
@@ -3,7 +3,7 @@ package redis.clients.jedis.tests.commands;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static redis.clients.jedis.params.set.SetParams.setParams;
+import static redis.clients.jedis.params.SetParams.setParams;
 import static redis.clients.jedis.tests.utils.AssertUtil.assertByteArrayListEquals;
 
 import java.util.ArrayList;

--- a/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import redis.clients.jedis.GeoCoordinate;
 import redis.clients.jedis.GeoRadiusResponse;
 import redis.clients.jedis.GeoUnit;
-import redis.clients.jedis.params.geo.GeoRadiusParam;
+import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.util.SafeEncoder;
 
 public class GeoCommandsTest extends JedisCommandTestBase {

--- a/src/test/java/redis/clients/jedis/tests/commands/SortedSetCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/SortedSetCommandsTest.java
@@ -20,8 +20,8 @@ import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 import redis.clients.jedis.Tuple;
 import redis.clients.jedis.ZParams;
-import redis.clients.jedis.params.sortedset.ZAddParams;
-import redis.clients.jedis.params.sortedset.ZIncrByParams;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZIncrByParams;
 import redis.clients.util.SafeEncoder;
 
 public class SortedSetCommandsTest extends JedisCommandTestBase {


### PR DESCRIPTION
- It doesn't seem necessary to have inner packages, containing 1 (may be 2) classes, inside params package. So those classes are moved in params package.
- Constructors of Params classes are made public. There isn't seem any extra benefit of keeping those private.