### PR TITLE
Stop throwing some exceptions in JedisClusterCommand

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -11,8 +11,6 @@ import redis.clients.jedis.util.JedisClusterCRC16;
 
 public abstract class JedisClusterCommand<T> {
 
-  private static final String NO_DISPATCH_MESSAGE = "No way to dispatch this command to Redis Cluster.";
-
   private final JedisClusterConnectionHandler connectionHandler;
   private final int maxAttempts;
   private final ThreadLocal<Jedis> askConnection = new ThreadLocal<Jedis>();
@@ -25,18 +23,10 @@ public abstract class JedisClusterCommand<T> {
   public abstract T execute(Jedis connection);
 
   public T run(String key) {
-    if (key == null) {
-      throw new JedisClusterOperationException(NO_DISPATCH_MESSAGE);
-    }
-
     return runWithRetries(JedisClusterCRC16.getSlot(key), this.maxAttempts, false, false);
   }
 
   public T run(int keyCount, String... keys) {
-    if (keys == null || keys.length == 0) {
-      throw new JedisClusterOperationException(NO_DISPATCH_MESSAGE);
-    }
-
     // For multiple keys, only execute if they all share the same connection slot.
     int slot = JedisClusterCRC16.getSlot(keys[0]);
     if (keys.length > 1) {
@@ -53,18 +43,10 @@ public abstract class JedisClusterCommand<T> {
   }
 
   public T runBinary(byte[] key) {
-    if (key == null) {
-      throw new JedisClusterOperationException(NO_DISPATCH_MESSAGE);
-    }
-
     return runWithRetries(JedisClusterCRC16.getSlot(key), this.maxAttempts, false, false);
   }
 
   public T runBinary(int keyCount, byte[]... keys) {
-    if (keys == null || keys.length == 0) {
-      throw new JedisClusterOperationException(NO_DISPATCH_MESSAGE);
-    }
-
     // For multiple keys, only execute if they all share the same connection slot.
     int slot = JedisClusterCRC16.getSlot(keys[0]);
     if (keys.length > 1) {


### PR DESCRIPTION
In JedisClusterCommand, stop throwing custom exceptions when key is null or keys array is null or empty. This is not what is practised in other Jedis classes.