### PR TITLE
Stop returning JedisConnectionException at the last attempt of recursion

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -132,9 +132,6 @@ public abstract class JedisClusterCommand<T> {
         //TODO make tracking of successful/unsuccessful operations for node - do renewing only
         //if there were no successful responses from this node last few seconds
         this.connectionHandler.renewSlotCache();
-
-        //no more redirections left, throw original exception, not JedisClusterMaxRedirectionsException, because it's not MOVED situation
-        throw jce;
       }
 
       return runWithRetries(slot, attempts - 1, tryRandomNode, asking);


### PR DESCRIPTION
Currently, if JedisConnectionException occurs at the last attempt of recursion, it is returned ignoring all the exceptions occured in previous attempts.

But returning MaxRedirectionsException as usual seems more logical at this spot.