### PR TITLE
Unset data source while closing pool resource

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3424,6 +3424,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
       } else {
         this.dataSource.returnResource(this);
       }
+      this.dataSource = null;
     } else {
       client.close();
     }

--- a/src/main/java/redis/clients/jedis/ShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedis.java
@@ -822,6 +822,7 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands, C
       } else {
         dataSource.returnResource(this);
       }
+      this.dataSource = null;
 
     } else {
       disconnect();

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
@@ -361,6 +361,31 @@ public class JedisPoolTest {
   }
 
   @Test
+  public void closeResourceTwice() {
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
+    Jedis j = pool.getResource();
+    j.auth("foobared");
+    j.ping();
+    j.close();
+    j.close();
+  }
+
+  @Test
+  public void closeBrokenResourceTwice() {
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
+    Jedis j = pool.getResource();
+    try {
+      // make connection broken
+      j.getClient().getOne();
+      fail();
+    } catch (Exception e) {
+    }
+    assertTrue(j.getClient().isBroken());
+    j.close();
+    j.close();
+  }
+
+  @Test
   public void testCloseConnectionOnMakeObject() {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);


### PR DESCRIPTION
This prevents exception being thrown when pooled resource is being closed multiple times.

Some of probable causes of those exceptions:
- `java.lang.IllegalStateException: Object has already been returned to this pool or is invalid`
- `java.lang.IllegalStateException: Invalidated object not currently part of this pool`