### PR TITLE
Start SSL Handshake at connect time

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -195,6 +195,7 @@ public class Connection implements Closeable {
                 "The connection to '%s' failed ssl/tls hostname verification.", host);
             throw new JedisConnectionException(message);
           }
+          ((SSLSocket) socket).startHandshake();
         }
 
         outputStream = new RedisOutputStream(socket.getOutputStream());


### PR DESCRIPTION
Explicitly initiate the SSL Handshake at the time of connection to avoid server side timeouts.