### PR TITLE
RedisCluster that can use ReadOnly slaves

### DIFF
--- a/src/main/java/redis/clients/jedis/AbstractJedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/AbstractJedisClusterInfoCache.java
@@ -1,0 +1,49 @@
+package redis.clients.jedis;
+
+import redis.clients.jedis.util.SafeEncoder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractJedisClusterInfoCache {
+  public abstract JedisPool setupNodeIfNotExist(HostAndPort hostAndPort);
+
+  public abstract Map<String, JedisPool> getNodes();
+
+  public abstract void discoverClusterNodesAndSlots(Jedis jedis);
+
+  public abstract void renewClusterSlots(Jedis jedis);
+
+  public abstract void reset();
+
+  public abstract List<JedisPool> getShuffledNodesPool(ReadFrom readFrom);
+
+  public abstract JedisPool getSlotPool(int slot, ReadFrom readFrom);
+
+  public static String getNodeKey(HostAndPort hnp) {
+    return hnp.getHost() + ":" + hnp.getPort();
+  }
+
+  public static String getNodeKey(Client client) {
+    return client.getHost() + ":" + client.getPort();
+  }
+
+  public static String getNodeKey(Jedis jedis) {
+    return getNodeKey(jedis.getClient());
+  }
+
+  protected HostAndPort generateHostAndPort(List<Object> hostInfos) {
+    return new HostAndPort(SafeEncoder.encode((byte[]) hostInfos.get(0)),
+        ((Long) hostInfos.get(1)).intValue());
+  }
+
+  protected List<Integer> getAssignedSlotArray(List<Object> slotInfo) {
+    List<Integer> slotNums = new ArrayList<Integer>();
+    for (int slot = ((Long) slotInfo.get(0)).intValue(); slot <= ((Long) slotInfo.get(1))
+        .intValue(); slot++) {
+      slotNums.add(slot);
+    }
+    return slotNums;
+  }
+}

--- a/src/main/java/redis/clients/jedis/AbstractJedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/AbstractJedisClusterInfoCache.java
@@ -11,6 +11,8 @@ public abstract class AbstractJedisClusterInfoCache {
 
   public abstract Map<String, JedisPool> getNodes();
 
+  public abstract Map<String, JedisPool> getNodes(ReadFrom readFrom);
+
   public abstract void discoverClusterNodesAndSlots(Jedis jedis);
 
   public abstract void renewClusterSlots(Jedis jedis);

--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -116,6 +116,10 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
     return connectionHandler.getNodes();
   }
 
+  public Map<String, JedisPool> getClusterNodes(ReadFrom readFrom) {
+    return connectionHandler.getNodes(readFrom);
+  }
+
   public Jedis getConnectionFromSlot(int slot) {
     // since I don't know who will call this method, so this method only return MASTER nodes
     return this.connectionHandler.getConnectionFromSlot(slot, ReadFrom.MASTER);

--- a/src/main/java/redis/clients/jedis/EnhancedJedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/EnhancedJedisClusterInfoCache.java
@@ -178,10 +178,21 @@ public class EnhancedJedisClusterInfoCache extends AbstractJedisClusterInfoCache
   }
 
   public Map<String, JedisPool> getNodes() {
+    return getNodes(ReadFrom.BOTH);
+  }
+
+  public Map<String, JedisPool> getNodes(ReadFrom readFrom) {
     r.lock();
     try {
-      Map<String, JedisPool> nodes = new HashMap<String, JedisPool>(slaveNodes);
-      nodes.putAll(masterNodes);
+      Map<String, JedisPool> nodes;
+      if (ReadFrom.SLAVE == readFrom) {
+        nodes = new HashMap<String, JedisPool>(slaveNodes);
+      } else if (ReadFrom.MASTER == readFrom) {
+        nodes = new HashMap<String, JedisPool>(masterNodes);
+      } else {
+        nodes = new HashMap<String, JedisPool>(slaveNodes);
+        nodes.putAll(masterNodes);
+      }
       return nodes;
     } finally {
       r.unlock();

--- a/src/main/java/redis/clients/jedis/EnhancedJedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/EnhancedJedisClusterInfoCache.java
@@ -1,0 +1,298 @@
+package redis.clients.jedis;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisException;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class EnhancedJedisClusterInfoCache extends AbstractJedisClusterInfoCache {
+  private final Map<String, JedisPool> masterNodes = new HashMap<String, JedisPool>();
+  private final Map<Integer, JedisPool> masterSlots = new HashMap<Integer, JedisPool>();
+
+  private final Map<String, JedisPool> slaveNodes = new HashMap<String, JedisPool>();
+  private final Map<Integer, List<JedisPool>> slaveSlots = new HashMap<Integer, List<JedisPool>>();
+
+  private final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();
+  private final Lock r = rwl.readLock();
+  private final Lock w = rwl.writeLock();
+  private volatile boolean rediscovering;
+  private final GenericObjectPoolConfig poolConfig;
+
+  private int connectionTimeout;
+  private int soTimeout;
+  private String password;
+  private String clientName;
+
+  private static final int MASTER_NODE_INDEX = 2;
+
+  public EnhancedJedisClusterInfoCache(final GenericObjectPoolConfig poolConfig, int timeout) {
+    this(poolConfig, timeout, timeout, null, null);
+  }
+
+  public EnhancedJedisClusterInfoCache(final GenericObjectPoolConfig poolConfig,
+      final int connectionTimeout, final int soTimeout, final String password,
+      final String clientName) {
+    this.poolConfig = poolConfig;
+    this.connectionTimeout = connectionTimeout;
+    this.soTimeout = soTimeout;
+    this.password = password;
+    this.clientName = clientName;
+  }
+
+  public void renewClusterSlots(Jedis jedis) {
+    // If rediscovering is already in process - no need to start one more same rediscovering, just
+    // return
+    if (!rediscovering) {
+      try {
+        w.lock();
+        rediscovering = true;
+
+        if (jedis != null) {
+          try {
+            discoverClusterNodesAndSlots(jedis);
+            return;
+          } catch (JedisException e) {
+            // try nodes from all pools
+          }
+        }
+        List<JedisPool> pools = getShuffledNodesPool(ReadFrom.BOTH);
+        for (JedisPool jp : pools) {
+          Jedis j = null;
+          try {
+            j = jp.getResource();
+            discoverClusterNodesAndSlots(j);
+            return;
+          } catch (JedisConnectionException e) {
+            // try next nodes
+          } finally {
+            if (j != null) {
+              j.close();
+            }
+          }
+        }
+      } finally {
+        rediscovering = false;
+        w.unlock();
+      }
+    }
+  }
+
+  public void discoverClusterNodesAndSlots(Jedis jedis) {
+    w.lock();
+
+    try {
+      reset();
+      List<Object> slots = jedis.clusterSlots();
+
+      for (Object slotInfoObj : slots) {
+        List<Object> slotInfo = (List<Object>) slotInfoObj;
+
+        if (slotInfo.size() <= MASTER_NODE_INDEX) {
+          continue;
+        }
+
+        List<Integer> slotNums = getAssignedSlotArray(slotInfo);
+
+        // hostInfos
+        int size = slotInfo.size();
+        for (int i = MASTER_NODE_INDEX; i < size; i++) {
+          List<Object> hostInfos = (List<Object>) slotInfo.get(i);
+          if (hostInfos.isEmpty()) {
+            continue;
+          }
+
+          HostAndPort targetNode = generateHostAndPort(hostInfos);
+          setupNodeIfNotExist(targetNode, i == MASTER_NODE_INDEX);
+          assignSlotsToNode(slotNums, targetNode, i == MASTER_NODE_INDEX);
+        }
+      }
+    } finally {
+      w.unlock();
+    }
+  }
+
+  public JedisPool setupNodeIfNotExist(HostAndPort node) {
+    return setupNodeIfNotExist(node, true);
+  }
+
+  public JedisPool setupNodeIfNotExist(HostAndPort node, boolean isMaster) {
+    w.lock();
+    try {
+      Map<String, JedisPool> targetNodesMap = isMaster ? masterNodes : slaveNodes;
+
+      String nodeKey = getNodeKey(node);
+      JedisPool existingPool = targetNodesMap.get(nodeKey);
+      if (existingPool != null) {
+        return existingPool;
+      }
+
+      JedisPool nodePool = new JedisPool(poolConfig, node.getHost(), node.getPort(),
+          connectionTimeout, soTimeout, password, 0, clientName, false, null, null, null, !isMaster);
+      targetNodesMap.put(nodeKey, nodePool);
+      removeOldJedisPool(nodeKey, !isMaster);
+
+      return nodePool;
+    } finally {
+      w.unlock();
+    }
+  }
+
+  public JedisPool getSlotPool(int slot, ReadFrom readFrom) {
+    r.lock();
+    try {
+      if (ReadFrom.MASTER == readFrom || slaveSlots.get(slot) == null
+          || slaveSlots.get(slot).isEmpty()) {
+        return masterSlots.get(slot);
+      }
+
+      if (ReadFrom.SLAVE == readFrom) {
+        if (slaveSlots.get(slot).size() == 1) {
+          return slaveSlots.get(slot).get(0);
+        } else if (slaveSlots.get(slot).size() > 1) {
+          ArrayList<JedisPool> pools = new ArrayList<JedisPool>(slaveSlots.get(slot));
+          Collections.shuffle(pools);
+          return pools.get(0);
+        }
+      }
+
+      if (ReadFrom.BOTH == readFrom) {
+        ArrayList<JedisPool> pools = new ArrayList<JedisPool>(slaveSlots.get(slot));
+        pools.add(masterSlots.get(slot));
+        Collections.shuffle(pools);
+        return pools.get(0);
+      }
+
+      // DEFAULT, this line should not be reached.
+      return masterSlots.get(slot);
+    } finally {
+      r.unlock();
+    }
+  }
+
+  public Map<String, JedisPool> getNodes() {
+    r.lock();
+    try {
+      Map<String, JedisPool> nodes = new HashMap<String, JedisPool>(slaveNodes);
+      nodes.putAll(masterNodes);
+      return nodes;
+    } finally {
+      r.unlock();
+    }
+  }
+
+  public List<JedisPool> getShuffledNodesPool(ReadFrom readFrom) {
+    r.lock();
+    try {
+      Collection<JedisPool> targetList;
+      if (ReadFrom.MASTER == readFrom) {
+        targetList = masterNodes.values();
+      } else if (ReadFrom.SLAVE == readFrom) {
+        targetList = slaveNodes.values();
+      } else {
+        targetList = new ArrayList<JedisPool>(masterNodes.size() + slaveNodes.size());
+        targetList.addAll(masterNodes.values());
+        targetList.addAll(slaveNodes.values());
+      }
+
+      List<JedisPool> pools = new ArrayList<JedisPool>(targetList);
+      Collections.shuffle(pools);
+      return pools;
+    } finally {
+      r.unlock();
+    }
+  }
+
+  /**
+   * Clear discovered nodes collections and gently release allocated resources
+   */
+  public void reset() {
+    w.lock();
+    try {
+      List<JedisPool> pools = new ArrayList<JedisPool>(masterNodes.size() + slaveNodes.size());
+      pools.addAll(masterNodes.values());
+      pools.addAll(slaveNodes.values());
+      for (JedisPool pool : pools) {
+        try {
+          if (pool != null) {
+            pool.destroy();
+          }
+        } catch (Exception e) {
+          // pass
+        }
+      }
+      masterNodes.clear();
+      masterSlots.clear();
+      slaveNodes.clear();
+      slaveSlots.clear();
+    } finally {
+      w.unlock();
+    }
+  }
+
+  private void assignSlotsToNode(List<Integer> targetSlots, HostAndPort targetNode, boolean isMaster) {
+    w.lock();
+    try {
+      JedisPool targetPool = setupNodeIfNotExist(targetNode, isMaster);
+      for (Integer slot : targetSlots) {
+        if (isMaster) {
+          masterSlots.put(slot, targetPool);
+        } else {
+          List<JedisPool> pools = slaveSlots.get(slot);
+          if (pools == null) {
+            pools = new ArrayList<JedisPool>();
+            slaveSlots.put(slot, pools);
+          }
+          if (!pools.contains(targetPool)) {
+            pools.add(targetPool);
+          }
+        }
+      }
+    } finally {
+      w.unlock();
+    }
+  }
+
+  private void removeOldJedisPool(String nodeKey, boolean isMaster) {
+    JedisPool toBeRemoved = isMaster ? masterNodes.remove(nodeKey) : slaveNodes.remove(nodeKey);
+    if (toBeRemoved != null) {
+      if (isMaster) {
+        removeMasterJedisPool(toBeRemoved);
+      } else {
+        removeSlaveJedisPool(toBeRemoved);
+      }
+      try {
+        toBeRemoved.destroy();
+      } catch (Exception e) {
+        // pass
+      }
+    }
+  }
+
+  private void removeMasterJedisPool(JedisPool toBeRemoved) {
+    List<Integer> slotsToBeRemoved = new ArrayList<Integer>();
+    for (Map.Entry<Integer, JedisPool> e : masterSlots.entrySet()) {
+      if (toBeRemoved == e.getValue()) {
+        slotsToBeRemoved.add(e.getKey());
+      }
+    }
+    for (Integer i : slotsToBeRemoved) {
+      masterSlots.remove(i);
+    }
+  }
+
+  private void removeSlaveJedisPool(JedisPool toBeRemoved) {
+    for (List<JedisPool> listInSlot : slaveSlots.values()) {
+      if (listInSlot != null && listInSlot.contains(toBeRemoved)) {
+        listInSlot.remove(toBeRemoved);
+      }
+    }
+  }
+}

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -51,24 +51,27 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
     this(Collections.singleton(node), timeout, maxAttempts, poolConfig);
   }
 
-  public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout,
-      int maxAttempts, final GenericObjectPoolConfig poolConfig) {
+  public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout, int maxAttempts,
+      final GenericObjectPoolConfig poolConfig) {
     this(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, poolConfig);
   }
 
-  public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout,
-      int maxAttempts, String password, final GenericObjectPoolConfig poolConfig) {
-    this(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, password, poolConfig);
+  public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout, int maxAttempts,
+      String password, final GenericObjectPoolConfig poolConfig) {
+    this(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, password,
+        poolConfig);
   }
 
-  public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout,
-      int maxAttempts, String password, String clientName, final GenericObjectPoolConfig poolConfig) {
-    this(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, password, clientName, poolConfig);
+  public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout, int maxAttempts,
+      String password, String clientName, final GenericObjectPoolConfig poolConfig) {
+    this(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, password,
+        clientName, poolConfig);
   }
 
-  public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout,
-                      int maxAttempts, final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
-    this(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, poolConfig, readFrom);
+  public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout, int maxAttempts,
+      final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
+    this(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, poolConfig,
+        readFrom);
   }
 
   public JedisCluster(Set<HostAndPort> nodes) {
@@ -101,7 +104,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   }
 
   public JedisCluster(Set<HostAndPort> nodes, int timeout, int maxAttempts,
-                      final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
+      final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
     super(nodes, timeout, maxAttempts, poolConfig, readFrom);
   }
 
@@ -111,29 +114,30 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   }
 
   public JedisCluster(Set<HostAndPort> nodes, int connectionTimeout, int soTimeout,
-                      int maxAttempts, String password, final GenericObjectPoolConfig poolConfig) {
+      int maxAttempts, String password, final GenericObjectPoolConfig poolConfig) {
     super(nodes, connectionTimeout, soTimeout, maxAttempts, password, poolConfig);
   }
 
   public JedisCluster(Set<HostAndPort> nodes, int connectionTimeout, int soTimeout,
-          int maxAttempts, String password, String clientName, final GenericObjectPoolConfig poolConfig) {
+      int maxAttempts, String password, String clientName, final GenericObjectPoolConfig poolConfig) {
     super(nodes, connectionTimeout, soTimeout, maxAttempts, password, clientName, poolConfig);
   }
 
   public JedisCluster(Set<HostAndPort> nodes, int connectionTimeout, int soTimeout,
-                      int maxAttempts, final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
+      int maxAttempts, final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
     super(nodes, connectionTimeout, soTimeout, maxAttempts, poolConfig, readFrom);
   }
 
   public JedisCluster(Set<HostAndPort> nodes, int connectionTimeout, int soTimeout,
-                      int maxAttempts, String password, final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
+      int maxAttempts, String password, final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
     super(nodes, connectionTimeout, soTimeout, maxAttempts, password, poolConfig, readFrom);
   }
 
   public JedisCluster(Set<HostAndPort> nodes, int connectionTimeout, int soTimeout,
-                      int maxAttempts, String password, String clientName, final GenericObjectPoolConfig poolConfig,
-                      ReadFrom readFrom) {
-    super(nodes, connectionTimeout, soTimeout, maxAttempts, password, clientName, poolConfig, readFrom);
+      int maxAttempts, String password, String clientName,
+      final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
+    super(nodes, connectionTimeout, soTimeout, maxAttempts, password, clientName, poolConfig,
+        readFrom);
   }
 
   @Override
@@ -1347,8 +1351,9 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
           + " only supports KEYS commands with non-empty patterns");
     }
     if (!JedisClusterHashTagUtil.isClusterCompliantMatchPattern(pattern)) {
-      throw new IllegalArgumentException(this.getClass().getSimpleName()
-          + " only supports KEYS commands with patterns containing hash-tags ( curly-brackets enclosed strings )");
+      throw new IllegalArgumentException(
+          this.getClass().getSimpleName()
+              + " only supports KEYS commands with patterns containing hash-tags ( curly-brackets enclosed strings )");
     }
     return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
@@ -1369,22 +1374,23 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
     }
 
     if (JedisClusterHashTagUtil.isClusterCompliantMatchPattern(matchPattern)) {
-      throw new IllegalArgumentException(JedisCluster.class.getSimpleName()
-          + " only supports SCAN commands with MATCH patterns containing hash-tags ( curly-brackets enclosed strings )");
+      throw new IllegalArgumentException(
+          JedisCluster.class.getSimpleName()
+              + " only supports SCAN commands with MATCH patterns containing hash-tags ( curly-brackets enclosed strings )");
     }
 
-    return new JedisClusterCommand< ScanResult<String>>(connectionHandler, maxAttempts, readFrom) {
+    return new JedisClusterCommand<ScanResult<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public ScanResult<String> execute(Jedis connection) {
         return connection.scan(cursor, params);
       }
     }.run(matchPattern);
   }
-  
+
   @Override
   public ScanResult<Entry<String, String>> hscan(final String key, final String cursor) {
     return new JedisClusterCommand<ScanResult<Entry<String, String>>>(connectionHandler,
-                                                                      maxAttempts, readFrom) {
+        maxAttempts, readFrom) {
       @Override
       public ScanResult<Entry<String, String>> execute(Jedis connection) {
         return connection.hscan(key, cursor);

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -34,6 +34,10 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
     this(Collections.singleton(node), timeout, maxAttempts);
   }
 
+  public JedisCluster(HostAndPort node, int timeout, int maxAttempts, ReadFrom readFrom) {
+    this(Collections.singleton(node), timeout, maxAttempts, readFrom);
+  }
+
   public JedisCluster(HostAndPort node, final GenericObjectPoolConfig poolConfig) {
     this(Collections.singleton(node), poolConfig);
   }
@@ -62,6 +66,11 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
     this(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, password, clientName, poolConfig);
   }
 
+  public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout,
+                      int maxAttempts, final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
+    this(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, poolConfig, readFrom);
+  }
+
   public JedisCluster(Set<HostAndPort> nodes) {
     this(nodes, DEFAULT_TIMEOUT);
   }
@@ -74,6 +83,10 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
     this(nodes, timeout, maxAttempts, new GenericObjectPoolConfig());
   }
 
+  public JedisCluster(Set<HostAndPort> nodes, int timeout, int maxAttempts, ReadFrom readFrom) {
+    this(nodes, timeout, maxAttempts, new GenericObjectPoolConfig(), readFrom);
+  }
+
   public JedisCluster(Set<HostAndPort> nodes, final GenericObjectPoolConfig poolConfig) {
     this(nodes, DEFAULT_TIMEOUT, DEFAULT_MAX_ATTEMPTS, poolConfig);
   }
@@ -82,25 +95,46 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
     this(nodes, timeout, DEFAULT_MAX_ATTEMPTS, poolConfig);
   }
 
-  public JedisCluster(Set<HostAndPort> jedisClusterNode, int timeout, int maxAttempts,
+  public JedisCluster(Set<HostAndPort> nodes, int timeout, int maxAttempts,
       final GenericObjectPoolConfig poolConfig) {
-    super(jedisClusterNode, timeout, maxAttempts, poolConfig);
+    super(nodes, timeout, maxAttempts, poolConfig);
   }
 
-  public JedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout,
+  public JedisCluster(Set<HostAndPort> nodes, int timeout, int maxAttempts,
+                      final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
+    super(nodes, timeout, maxAttempts, poolConfig, readFrom);
+  }
+
+  public JedisCluster(Set<HostAndPort> nodes, int connectionTimeout, int soTimeout,
       int maxAttempts, final GenericObjectPoolConfig poolConfig) {
-    super(jedisClusterNode, connectionTimeout, soTimeout, maxAttempts, poolConfig);
+    super(nodes, connectionTimeout, soTimeout, maxAttempts, poolConfig);
   }
 
-  public JedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout,
+  public JedisCluster(Set<HostAndPort> nodes, int connectionTimeout, int soTimeout,
                       int maxAttempts, String password, final GenericObjectPoolConfig poolConfig) {
-    super(jedisClusterNode, connectionTimeout, soTimeout, maxAttempts, password, poolConfig);
+    super(nodes, connectionTimeout, soTimeout, maxAttempts, password, poolConfig);
   }
 
-  public JedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout,
+  public JedisCluster(Set<HostAndPort> nodes, int connectionTimeout, int soTimeout,
           int maxAttempts, String password, String clientName, final GenericObjectPoolConfig poolConfig) {
-    super(jedisClusterNode, connectionTimeout, soTimeout, maxAttempts, password, clientName, poolConfig);
-}
+    super(nodes, connectionTimeout, soTimeout, maxAttempts, password, clientName, poolConfig);
+  }
+
+  public JedisCluster(Set<HostAndPort> nodes, int connectionTimeout, int soTimeout,
+                      int maxAttempts, final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
+    super(nodes, connectionTimeout, soTimeout, maxAttempts, poolConfig, readFrom);
+  }
+
+  public JedisCluster(Set<HostAndPort> nodes, int connectionTimeout, int soTimeout,
+                      int maxAttempts, String password, final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
+    super(nodes, connectionTimeout, soTimeout, maxAttempts, password, poolConfig, readFrom);
+  }
+
+  public JedisCluster(Set<HostAndPort> nodes, int connectionTimeout, int soTimeout,
+                      int maxAttempts, String password, String clientName, final GenericObjectPoolConfig poolConfig,
+                      ReadFrom readFrom) {
+    super(nodes, connectionTimeout, soTimeout, maxAttempts, password, clientName, poolConfig, readFrom);
+  }
 
   @Override
   public String set(final String key, final String value) {
@@ -124,7 +158,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String get(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public String execute(Jedis connection) {
         return connection.get(key);
@@ -134,7 +168,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean exists(final String key) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.exists(key);
@@ -144,7 +178,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long exists(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.exists(keys);
@@ -164,7 +198,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String type(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public String execute(Jedis connection) {
         return connection.type(key);
@@ -294,7 +328,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean getbit(final String key, final long offset) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.getbit(key, offset);
@@ -314,7 +348,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String getrange(final String key, final long startOffset, final long endOffset) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public String execute(Jedis connection) {
         return connection.getrange(key, startOffset, endOffset);
@@ -454,7 +488,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String hget(final String key, final String field) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public String execute(Jedis connection) {
         return connection.hget(key, field);
@@ -484,7 +518,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> hmget(final String key, final String... fields) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.hmget(key, fields);
@@ -504,7 +538,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean hexists(final String key, final String field) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.hexists(key, field);
@@ -524,7 +558,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long hlen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hlen(key);
@@ -534,7 +568,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> hkeys(final String key) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.hkeys(key);
@@ -544,7 +578,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> hvals(final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.hvals(key);
@@ -554,7 +588,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Map<String, String> hgetAll(final String key) {
-    return new JedisClusterCommand<Map<String, String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Map<String, String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Map<String, String> execute(Jedis connection) {
         return connection.hgetAll(key);
@@ -584,7 +618,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long llen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.llen(key);
@@ -594,7 +628,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> lrange(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.lrange(key, start, stop);
@@ -614,7 +648,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String lindex(final String key, final long index) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public String execute(Jedis connection) {
         return connection.lindex(key, index);
@@ -674,7 +708,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> smembers(final String key) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.smembers(key);
@@ -714,7 +748,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long scard(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.scard(key);
@@ -724,7 +758,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean sismember(final String key, final String member) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.sismember(key, member);
@@ -734,7 +768,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String srandmember(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public String execute(Jedis connection) {
         return connection.srandmember(key);
@@ -744,7 +778,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> srandmember(final String key, final int count) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.srandmember(key, count);
@@ -754,7 +788,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long strlen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.strlen(key);
@@ -805,7 +839,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrange(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrange(key, start, stop);
@@ -846,7 +880,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zrank(final String key, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zrank(key, member);
@@ -856,7 +890,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zrevrank(final String key, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zrevrank(key, member);
@@ -866,7 +900,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrevrange(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrange(key, start, stop);
@@ -876,7 +910,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrangeWithScores(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeWithScores(key, start, stop);
@@ -886,7 +920,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrevrangeWithScores(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeWithScores(key, start, stop);
@@ -896,7 +930,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zcard(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcard(key);
@@ -906,7 +940,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Double zscore(final String key, final String member) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Double execute(Jedis connection) {
         return connection.zscore(key, member);
@@ -936,7 +970,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zcount(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcount(key, min, max);
@@ -946,7 +980,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zcount(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcount(key, min, max);
@@ -956,7 +990,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrangeByScore(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max);
@@ -966,7 +1000,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrangeByScore(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max);
@@ -976,7 +1010,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final double max, final double min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min);
@@ -987,7 +1021,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrangeByScore(final String key, final double min, final double max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max, offset, count);
@@ -997,7 +1031,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min);
@@ -1008,7 +1042,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrangeByScore(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max, offset, count);
@@ -1019,7 +1053,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrevrangeByScore(final String key, final double max, final double min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min, offset, count);
@@ -1029,7 +1063,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max);
@@ -1039,7 +1073,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final double max, final double min) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min);
@@ -1050,7 +1084,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final double min, final double max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max, offset, count);
@@ -1061,7 +1095,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrevrangeByScore(final String key, final String max, final String min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min, offset, count);
@@ -1071,7 +1105,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max);
@@ -1081,7 +1115,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min);
@@ -1092,7 +1126,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max, offset, count);
@@ -1103,7 +1137,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final double max,
       final double min, final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min, offset, count);
@@ -1114,7 +1148,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final String max,
       final String min, final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min, offset, count);
@@ -1154,7 +1188,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zlexcount(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zlexcount(key, min, max);
@@ -1164,7 +1198,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrangeByLex(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByLex(key, min, max);
@@ -1175,7 +1209,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrangeByLex(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByLex(key, min, max, offset, count);
@@ -1185,7 +1219,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrevrangeByLex(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByLex(key, max, min);
@@ -1196,7 +1230,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrevrangeByLex(final String key, final String max, final String min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByLex(key, max, min, offset, count);
@@ -1278,7 +1312,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public String echo(final String string) {
     // note that it'll be run from arbitary node
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public String execute(Jedis connection) {
         return connection.echo(string);
@@ -1288,7 +1322,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long bitcount(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.bitcount(key);
@@ -1298,7 +1332,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long bitcount(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.bitcount(key, start, end);
@@ -1316,7 +1350,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       throw new IllegalArgumentException(this.getClass().getSimpleName()
           + " only supports KEYS commands with patterns containing hash-tags ( curly-brackets enclosed strings )");
     }
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.keys(pattern);
@@ -1339,7 +1373,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
           + " only supports SCAN commands with MATCH patterns containing hash-tags ( curly-brackets enclosed strings )");
     }
 
-    return new JedisClusterCommand< ScanResult<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand< ScanResult<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public ScanResult<String> execute(Jedis connection) {
         return connection.scan(cursor, params);
@@ -1350,7 +1384,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public ScanResult<Entry<String, String>> hscan(final String key, final String cursor) {
     return new JedisClusterCommand<ScanResult<Entry<String, String>>>(connectionHandler,
-                                                                      maxAttempts) {
+                                                                      maxAttempts, readFrom) {
       @Override
       public ScanResult<Entry<String, String>> execute(Jedis connection) {
         return connection.hscan(key, cursor);
@@ -1360,7 +1394,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public ScanResult<String> sscan(final String key, final String cursor) {
-    return new JedisClusterCommand<ScanResult<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<ScanResult<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public ScanResult<String> execute(Jedis connection) {
         return connection.sscan(key, cursor);
@@ -1370,7 +1404,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public ScanResult<Tuple> zscan(final String key, final String cursor) {
-    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public ScanResult<Tuple> execute(Jedis connection) {
         return connection.zscan(key, cursor);
@@ -1390,7 +1424,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public long pfcount(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pfcount(key);
@@ -1451,7 +1485,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> mget(final String... keys) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.mget(keys);
@@ -1733,7 +1767,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public long pfcount(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pfcount(keys);
@@ -1969,7 +2003,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long hstrlen(final String key, final String field) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, readFrom) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hstrlen(key, field);

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -69,6 +69,12 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   }
 
   public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout, int maxAttempts,
+      String password, String clientName, final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
+    this(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, password,
+            clientName, poolConfig, readFrom);
+  }
+
+  public JedisCluster(HostAndPort node, int connectionTimeout, int soTimeout, int maxAttempts,
       final GenericObjectPoolConfig poolConfig, ReadFrom readFrom) {
     this(Collections.singleton(node), connectionTimeout, soTimeout, maxAttempts, poolConfig,
         readFrom);

--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -22,14 +22,11 @@ public abstract class JedisClusterCommand<T> {
     this(connectionHandler, maxAttempts, ReadFrom.MASTER);
   }
 
-  public JedisClusterCommand(JedisClusterConnectionHandler connectionHandler, int maxAttempts, ReadFrom readFrom) {
+  public JedisClusterCommand(JedisClusterConnectionHandler connectionHandler, int maxAttempts,
+      ReadFrom readFrom) {
     this.connectionHandler = connectionHandler;
     this.maxAttempts = maxAttempts;
-    if (readFrom != null) {
-      this.readFrom = readFrom;
-    } else {
-      this.readFrom = ReadFrom.MASTER;
-    }
+    this.readFrom = readFrom != null ? readFrom : ReadFrom.MASTER;
   }
 
   public abstract T execute(Jedis connection);
@@ -136,11 +133,12 @@ public abstract class JedisClusterCommand<T> {
       connection = null;
 
       if (attempts <= 1) {
-        //We need this because if node is not reachable anymore - we need to finally initiate slots renewing,
-        //or we can stuck with cluster state without one node in opposite case.
-        //But now if maxAttempts = 1 or 2 we will do it too often. For each time-outed request.
-        //TODO make tracking of successful/unsuccessful operations for node - do renewing only
-        //if there were no successful responses from this node last few seconds
+        // We need this because if node is not reachable anymore - we need to finally initiate slots
+        // renewing,
+        // or we can stuck with cluster state without one node in opposite case.
+        // But now if maxAttempts = 1 or 2 we will do it too often. For each time-outed request.
+        // TODO make tracking of successful/unsuccessful operations for node - do renewing only
+        // if there were no successful responses from this node last few seconds
         this.connectionHandler.renewSlotCache();
       }
 

--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -25,7 +25,11 @@ public abstract class JedisClusterCommand<T> {
   public JedisClusterCommand(JedisClusterConnectionHandler connectionHandler, int maxAttempts, ReadFrom readFrom) {
     this.connectionHandler = connectionHandler;
     this.maxAttempts = maxAttempts;
-    this.readFrom = readFrom;
+    if (readFrom != null) {
+      this.readFrom = readFrom;
+    } else {
+      this.readFrom = ReadFrom.MASTER;
+    }
   }
 
   public abstract T execute(Jedis connection);

--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -20,12 +20,12 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
   public JedisClusterConnectionHandler(Set<HostAndPort> nodes,
       final GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout,
       String password, String clientName, ReadFrom readFrom) {
-    if (readFrom != ReadFrom.MASTER) {
-      this.cache = new EnhancedJedisClusterInfoCache(poolConfig, connectionTimeout, soTimeout,
-          password, clientName);
-    } else {
+    if (readFrom == null || readFrom == ReadFrom.MASTER) {
       this.cache = new JedisClusterInfoCache(poolConfig, connectionTimeout, soTimeout, password,
-          clientName);
+              clientName);
+    } else {
+      this.cache = new EnhancedJedisClusterInfoCache(poolConfig, connectionTimeout, soTimeout,
+              password, clientName);
     }
     initializeSlotsCache(nodes, poolConfig, connectionTimeout, soTimeout, password, clientName);
   }

--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -9,42 +9,47 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
 public abstract class JedisClusterConnectionHandler implements Closeable {
-  protected final JedisClusterInfoCache cache;
+  protected final AbstractJedisClusterInfoCache cache;
 
   public JedisClusterConnectionHandler(Set<HostAndPort> nodes,
-                                       final GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password) {
-    this(nodes, poolConfig, connectionTimeout, soTimeout, password, null);
+      final GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout,
+      String password, ReadFrom readFrom) {
+    this(nodes, poolConfig, connectionTimeout, soTimeout, password, null, readFrom);
   }
 
   public JedisClusterConnectionHandler(Set<HostAndPort> nodes,
-          final GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password, String clientName) {
-    this.cache = new JedisClusterInfoCache(poolConfig, connectionTimeout, soTimeout, password, clientName);
+      final GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout,
+      String password, String clientName, ReadFrom readFrom) {
+    if (readFrom != ReadFrom.MASTER) {
+      this.cache = new EnhancedJedisClusterInfoCache(poolConfig, connectionTimeout, soTimeout,
+          password, clientName);
+    } else {
+      this.cache = new JedisClusterInfoCache(poolConfig, connectionTimeout, soTimeout, password,
+          clientName);
+    }
     initializeSlotsCache(nodes, poolConfig, connectionTimeout, soTimeout, password, clientName);
-}
+  }
 
   abstract Jedis getConnection(ReadFrom readFrom);
 
   abstract Jedis getConnectionFromSlot(int slot, ReadFrom readFrom);
 
   public Jedis getConnectionFromNode(HostAndPort node) {
-    // this method is used for ASK response, MASTER is ok
-    return cache.setupNodeIfNotExist(node, true).getResource();
+    return cache.setupNodeIfNotExist(node).getResource();
   }
-  
+
   public Map<String, JedisPool> getNodes() {
-    return cache.getAllNodes();
+    return cache.getNodes();
   }
 
-  public Map<String, JedisPool> getMasterNodes() {
-    return cache.getMasterNodes();
-  }
-
-  private void initializeSlotsCache(Set<HostAndPort> startNodes, GenericObjectPoolConfig poolConfig,
-                                    int connectionTimeout, int soTimeout, String password, String clientName) {
+  private void initializeSlotsCache(Set<HostAndPort> startNodes,
+      GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password,
+      String clientName) {
     for (HostAndPort hostAndPort : startNodes) {
       Jedis jedis = null;
       try {
-        jedis = new Jedis(hostAndPort.getHost(), hostAndPort.getPort(), connectionTimeout, soTimeout);
+        jedis = new Jedis(hostAndPort.getHost(), hostAndPort.getPort(), connectionTimeout,
+            soTimeout);
         if (password != null) {
           jedis.auth(password);
         }

--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -42,6 +42,10 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
     return cache.getNodes();
   }
 
+  public Map<String, JedisPool> getNodes(ReadFrom readFrom) {
+    return cache.getNodes(readFrom);
+  }
+
   private void initializeSlotsCache(Set<HostAndPort> startNodes,
       GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password,
       String clientName) {

--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -22,16 +22,21 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
     initializeSlotsCache(nodes, poolConfig, connectionTimeout, soTimeout, password, clientName);
 }
 
-  abstract Jedis getConnection();
+  abstract Jedis getConnection(ReadFrom readFrom);
 
-  abstract Jedis getConnectionFromSlot(int slot);
+  abstract Jedis getConnectionFromSlot(int slot, ReadFrom readFrom);
 
   public Jedis getConnectionFromNode(HostAndPort node) {
-    return cache.setupNodeIfNotExist(node).getResource();
+    // this method is used for ASK response, MASTER is ok
+    return cache.setupNodeIfNotExist(node, true).getResource();
   }
   
   public Map<String, JedisPool> getNodes() {
-    return cache.getNodes();
+    return cache.getAllNodes();
+  }
+
+  public Map<String, JedisPool> getMasterNodes() {
+    return cache.getMasterNodes();
   }
 
   private void initializeSlotsCache(Set<HostAndPort> startNodes, GenericObjectPoolConfig poolConfig,

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -208,6 +208,13 @@ public class JedisClusterInfoCache extends AbstractJedisClusterInfoCache {
     }
   }
 
+  public Map<String, JedisPool> getNodes(ReadFrom readFrom) {
+    if (ReadFrom.BOTH != readFrom) {
+      throw new UnsupportedOperationException("Maybe you should use EnhancedJedisClusterInfoCache");
+    }
+    return getNodes();
+  }
+
   public List<JedisPool> getShuffledNodesPool(ReadFrom readFrom) {
     r.lock();
     try {

--- a/src/main/java/redis/clients/jedis/JedisFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisFactory.java
@@ -29,6 +29,7 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
   private final SSLSocketFactory sslSocketFactory;
   private final SSLParameters sslParameters;
   private final HostnameVerifier hostnameVerifier;
+  private final boolean readOnly;  // only used for redis cluster salve node
 
   JedisFactory(final String host, final int port, final int connectionTimeout,
       final int soTimeout, final String password, final int database, final String clientName) {
@@ -37,9 +38,17 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
   }
 
   JedisFactory(final String host, final int port, final int connectionTimeout,
+               final int soTimeout, final String password, final int database, final String clientName,
+               final boolean ssl, final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+               final HostnameVerifier hostnameVerifier) {
+    this(host, port, connectionTimeout, soTimeout, password, database, clientName,
+            false, null, null, null, false);
+  }
+
+  JedisFactory(final String host, final int port, final int connectionTimeout,
       final int soTimeout, final String password, final int database, final String clientName,
       final boolean ssl, final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
-      final HostnameVerifier hostnameVerifier) {
+      final HostnameVerifier hostnameVerifier, final boolean readOnly) {
     this.hostAndPort.set(new HostAndPort(host, port));
     this.connectionTimeout = connectionTimeout;
     this.soTimeout = soTimeout;
@@ -50,6 +59,7 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
     this.sslSocketFactory = sslSocketFactory;
     this.sslParameters = sslParameters;
     this.hostnameVerifier = hostnameVerifier;
+    this.readOnly = readOnly;
   }
 
   JedisFactory(final URI uri, final int connectionTimeout, final int soTimeout,
@@ -58,8 +68,14 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
   }
 
   JedisFactory(final URI uri, final int connectionTimeout, final int soTimeout,
+               final String clientName, final SSLSocketFactory sslSocketFactory,
+               final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+    this(uri, connectionTimeout, soTimeout, clientName, null, null, null, false);
+  }
+
+  JedisFactory(final URI uri, final int connectionTimeout, final int soTimeout,
       final String clientName, final SSLSocketFactory sslSocketFactory,
-      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier, final boolean readOnly) {
     if (!JedisURIHelper.isValid(uri)) {
       throw new InvalidURIException(String.format(
         "Cannot open Redis connection due invalid URI. %s", uri.toString()));
@@ -75,6 +91,7 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
     this.sslSocketFactory = sslSocketFactory;
     this.sslParameters = sslParameters;
     this.hostnameVerifier = hostnameVerifier;
+    this.readOnly = readOnly;
   }
 
   public void setHostAndPort(final HostAndPort hostAndPort) {
@@ -123,6 +140,10 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
       }
       if (clientName != null) {
         jedis.clientSetname(clientName);
+      }
+      if (readOnly) {
+        // only used for redis cluster slave node
+        jedis.readonly();
       }
     } catch (JedisException je) {
       jedis.close();

--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -167,6 +167,15 @@ public class JedisPool extends JedisPoolAbstract {
         database, clientName, ssl, sslSocketFactory, sslParameters, hostnameVerifier));
   }
 
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
+                   final int connectionTimeout, final int soTimeout, final String password, final int database,
+                   final String clientName, final boolean ssl, final SSLSocketFactory sslSocketFactory,
+                   final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier,
+                   final boolean readOnly) {
+    super(poolConfig, new JedisFactory(host, port, connectionTimeout, soTimeout, password,
+            database, clientName, ssl, sslSocketFactory, sslParameters, hostnameVerifier, readOnly));
+  }
+
   public JedisPool(final GenericObjectPoolConfig poolConfig) {
     this(poolConfig, Protocol.DEFAULT_HOST, Protocol.DEFAULT_PORT);
   }

--- a/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisSlotBasedConnectionHandler.java
@@ -11,21 +11,26 @@ import redis.clients.jedis.exceptions.JedisNoReachableClusterNodeException;
 public class JedisSlotBasedConnectionHandler extends JedisClusterConnectionHandler {
 
   public JedisSlotBasedConnectionHandler(Set<HostAndPort> nodes,
-      final GenericObjectPoolConfig poolConfig, int timeout) {
-    this(nodes, poolConfig, timeout, timeout);
+      final GenericObjectPoolConfig poolConfig, int timeout, ReadFrom readFrom) {
+    this(nodes, poolConfig, timeout, timeout, readFrom);
   }
 
   public JedisSlotBasedConnectionHandler(Set<HostAndPort> nodes,
-      final GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout) {
-    super(nodes, poolConfig, connectionTimeout, soTimeout, null);
+      final GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout,
+      ReadFrom readFrom) {
+    super(nodes, poolConfig, connectionTimeout, soTimeout, null, readFrom);
   }
 
-  public JedisSlotBasedConnectionHandler(Set<HostAndPort> nodes, GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password) {
-    super(nodes, poolConfig, connectionTimeout, soTimeout, password);
+  public JedisSlotBasedConnectionHandler(Set<HostAndPort> nodes,
+      GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password,
+      ReadFrom readFrom) {
+    super(nodes, poolConfig, connectionTimeout, soTimeout, password, readFrom);
   }
 
-  public JedisSlotBasedConnectionHandler(Set<HostAndPort> nodes, GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password, String clientName) {
-    super(nodes, poolConfig, connectionTimeout, soTimeout, password, clientName);
+  public JedisSlotBasedConnectionHandler(Set<HostAndPort> nodes,
+      GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password,
+      String clientName, ReadFrom readFrom) {
+    super(nodes, poolConfig, connectionTimeout, soTimeout, password, clientName, readFrom);
   }
 
   @Override
@@ -68,12 +73,13 @@ public class JedisSlotBasedConnectionHandler extends JedisClusterConnectionHandl
       // assignment
       return connectionPool.getResource();
     } else {
-      renewSlotCache(); //It's abnormal situation for cluster mode, that we have just nothing for slot, try to rediscover state
+      renewSlotCache(); // It's abnormal situation for cluster mode, that we have just nothing for
+                        // slot, try to rediscover state
       connectionPool = cache.getSlotPool(slot, readFrom);
       if (connectionPool != null) {
         return connectionPool.getResource();
       } else {
-        //no choice, fallback to new connection to random node
+        // no choice, fallback to new connection to random node
         return getConnection(readFrom);
       }
     }

--- a/src/main/java/redis/clients/jedis/ReadFrom.java
+++ b/src/main/java/redis/clients/jedis/ReadFrom.java
@@ -1,5 +1,5 @@
 package redis.clients.jedis;
 
 public enum ReadFrom {
-    MASTER, SLAVE, BOTH
+  MASTER, SLAVE, BOTH
 }

--- a/src/main/java/redis/clients/jedis/ReadFrom.java
+++ b/src/main/java/redis/clients/jedis/ReadFrom.java
@@ -1,0 +1,5 @@
+package redis.clients.jedis;
+
+public enum ReadFrom {
+    MASTER, SLAVE, BOTH
+}

--- a/src/test/java/redis/clients/jedis/tests/HostAndPortUtil.java
+++ b/src/test/java/redis/clients/jedis/tests/HostAndPortUtil.java
@@ -11,8 +11,8 @@ public final class HostAndPortUtil {
   private static List<HostAndPort> sentinelHostAndPortList = new ArrayList<HostAndPort>();
   private static List<HostAndPort> clusterHostAndPortList = new ArrayList<HostAndPort>();
 
-  private HostAndPortUtil(){
-    throw new InstantiationError( "Must not instantiate this class" );
+  private HostAndPortUtil() {
+    throw new InstantiationError("Must not instantiate this class");
   }
 
   static {
@@ -29,12 +29,12 @@ public final class HostAndPortUtil {
     sentinelHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 2));
     sentinelHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 3));
 
-    clusterHostAndPortList.add(new HostAndPort("localhost", 7379));
-    clusterHostAndPortList.add(new HostAndPort("localhost", 7380));
-    clusterHostAndPortList.add(new HostAndPort("localhost", 7381));
-    clusterHostAndPortList.add(new HostAndPort("localhost", 7382));
-    clusterHostAndPortList.add(new HostAndPort("localhost", 7383));
-    clusterHostAndPortList.add(new HostAndPort("localhost", 7384));
+    clusterHostAndPortList.add(new HostAndPort("127.0.0.1", 7379));
+    clusterHostAndPortList.add(new HostAndPort("127.0.0.1", 7380));
+    clusterHostAndPortList.add(new HostAndPort("127.0.0.1", 7381));
+    clusterHostAndPortList.add(new HostAndPort("127.0.0.1", 7382));
+    clusterHostAndPortList.add(new HostAndPort("127.0.0.1", 7383));
+    clusterHostAndPortList.add(new HostAndPort("127.0.0.1", 7384));
 
     String envRedisHosts = System.getProperty("redis-hosts");
     String envSentinelHosts = System.getProperty("sentinel-hosts");

--- a/src/test/java/redis/clients/jedis/tests/MasterSlaveJedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/MasterSlaveJedisClusterTest.java
@@ -1,0 +1,293 @@
+package redis.clients.jedis.tests;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.BinaryJedisCluster;
+import redis.clients.jedis.ClusterReset;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.JedisSlotBasedConnectionHandler;
+import redis.clients.jedis.ReadFrom;
+import redis.clients.jedis.tests.utils.JedisClusterTestUtil;
+import redis.clients.jedis.util.JedisClusterCRC16;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class MasterSlaveJedisClusterTest {
+  private static Jedis node1;
+  private static Jedis node2;
+  private static Jedis node3;
+  private static Jedis nodeSlave1;
+  private static Jedis nodeSlave2;
+  private static Jedis nodeSlave3;
+  private String localHost = "127.0.0.1";
+
+  private static final String PASSWORD = "cluster";
+  private static final int DEFAULT_TIMEOUT = 2000;
+  private static final int DEFAULT_REDIRECTIONS = 5;
+  private static final JedisPoolConfig DEFAULT_CONFIG = new JedisPoolConfig();
+
+  private HostAndPort nodeInfo1 = HostAndPortUtil.getClusterServers().get(0);
+  private HostAndPort nodeInfo2 = HostAndPortUtil.getClusterServers().get(1);
+  private HostAndPort nodeInfo3 = HostAndPortUtil.getClusterServers().get(2);
+  private HostAndPort nodeInfoSlave1 = HostAndPortUtil.getClusterServers().get(3);
+  private HostAndPort nodeInfoSlave2 = HostAndPortUtil.getClusterServers().get(4);
+  private HostAndPort nodeInfoSlave3 = HostAndPortUtil.getClusterServers().get(5);
+
+  protected Logger log = LoggerFactory.getLogger(getClass().getName());
+
+  @Before
+  public void setUp() throws InterruptedException {
+    node1 = new Jedis(nodeInfo1);
+    node1.auth(PASSWORD);
+    node1.flushAll();
+
+    node2 = new Jedis(nodeInfo2);
+    node2.auth(PASSWORD);
+    node2.flushAll();
+
+    node3 = new Jedis(nodeInfo3);
+    node3.auth(PASSWORD);
+    node3.flushAll();
+
+    nodeSlave1 = new Jedis(nodeInfoSlave1);
+    nodeSlave1.auth(PASSWORD);
+    nodeSlave1.flushAll();
+
+    nodeSlave2 = new Jedis(nodeInfoSlave2);
+    nodeSlave2.auth(PASSWORD);
+    nodeSlave2.flushAll();
+
+    nodeSlave3 = new Jedis(nodeInfoSlave3);
+    nodeSlave3.auth(PASSWORD);
+    nodeSlave3.flushAll();
+
+    // ---- configure cluster
+
+    // add nodes to cluster
+    node1.clusterMeet(localHost, nodeInfo2.getPort());
+    node1.clusterMeet(localHost, nodeInfo3.getPort());
+    node1.clusterMeet(localHost, nodeInfoSlave1.getPort());
+    node1.clusterMeet(localHost, nodeInfoSlave2.getPort());
+    node1.clusterMeet(localHost, nodeInfoSlave3.getPort());
+
+    // split available slots across the three nodes
+    int slotsPerNode = JedisCluster.HASHSLOTS / 3;
+    int[] node1Slots = new int[slotsPerNode];
+    int[] node2Slots = new int[slotsPerNode + 1];
+    int[] node3Slots = new int[slotsPerNode];
+    for (int i = 0, slot1 = 0, slot2 = 0, slot3 = 0; i < JedisCluster.HASHSLOTS; i++) {
+      if (i < slotsPerNode) {
+        node1Slots[slot1++] = i;
+      } else if (i > slotsPerNode * 2) {
+        node3Slots[slot3++] = i;
+      } else {
+        node2Slots[slot2++] = i;
+      }
+    }
+
+    node1.clusterAddSlots(node1Slots);
+    node2.clusterAddSlots(node2Slots);
+    node3.clusterAddSlots(node3Slots);
+
+    JedisClusterTestUtil.waitForClusterReady(node1, node2, node3);
+
+    // setting replica
+    String nodes = node1.clusterNodes();
+    nodeSlave1.clusterReplicate(JedisClusterTestUtil.getNodeId(nodes, nodeInfo1));
+    nodeSlave2.clusterReplicate(JedisClusterTestUtil.getNodeId(nodes, nodeInfo2));
+    nodeSlave3.clusterReplicate(JedisClusterTestUtil.getNodeId(nodes, nodeInfo3));
+
+    JedisClusterTestUtil.waitForReplicaReady(node1, 3);
+  }
+
+  @After
+  public void tearDown() throws InterruptedException {
+    node1 = new Jedis(nodeInfo1);
+    node1.auth(PASSWORD);
+    try {
+      node1.flushAll();
+    } catch (Exception e) {
+      // ignore
+    }
+    node1.clusterReset(ClusterReset.SOFT);
+
+    node2 = new Jedis(nodeInfo2);
+    node2.auth(PASSWORD);
+    try {
+      node2.flushAll();
+    } catch (Exception e) {
+      // ignore
+    }
+    node2.clusterReset(ClusterReset.SOFT);
+
+    node3 = new Jedis(nodeInfo3);
+    node3.auth(PASSWORD);
+    try {
+      node3.flushAll();
+    } catch (Exception e) {
+      // ignore
+    }
+    node3.clusterReset(ClusterReset.SOFT);
+
+    nodeSlave1 = new Jedis(nodeInfoSlave1);
+    nodeSlave1.auth(PASSWORD);
+    try {
+      nodeSlave1.flushAll();
+    } catch (Exception e) {
+      // ignore
+    }
+    nodeSlave1.clusterReset(ClusterReset.SOFT);
+
+    nodeSlave2 = new Jedis(nodeInfoSlave2);
+    nodeSlave2.auth(PASSWORD);
+    try {
+      nodeSlave2.flushAll();
+    } catch (Exception e) {
+      // ignore
+    }
+    nodeSlave2.clusterReset(ClusterReset.SOFT);
+
+    nodeSlave3 = new Jedis(nodeInfoSlave3);
+    nodeSlave3.auth(PASSWORD);
+    try {
+      nodeSlave3.flushAll();
+    } catch (Exception e) {
+      // ignore
+    }
+    nodeSlave3.clusterReset(ClusterReset.SOFT);
+  }
+
+  @Test
+  public void testSetupJedisClusterInfo() {
+    JedisCluster jc = new JedisCluster(nodeInfo1, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT,
+        DEFAULT_REDIRECTIONS, PASSWORD, "test", DEFAULT_CONFIG, ReadFrom.BOTH);
+    assertEquals(6, jc.getClusterNodes(ReadFrom.BOTH).size());
+    assertEquals(3, jc.getClusterNodes(ReadFrom.MASTER).size());
+    assertEquals(3, jc.getClusterNodes(ReadFrom.SLAVE).size());
+
+    List<String> nodes = Arrays.asList(nodeInfo1.toString(), nodeInfo2.toString(),
+      nodeInfo3.toString());
+    for (String node : nodes) {
+      assertTrue(jc.getClusterNodes(ReadFrom.MASTER).containsKey(node));
+    }
+    nodes = Arrays.asList(nodeInfoSlave1.toString(), nodeInfoSlave2.toString(),
+      nodeInfoSlave3.toString());
+    for (String node : nodes) {
+      assertTrue(jc.getClusterNodes(ReadFrom.SLAVE).containsKey(node));
+    }
+
+    jc = new JedisCluster(nodeInfo1, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT, DEFAULT_REDIRECTIONS,
+        PASSWORD, "test", DEFAULT_CONFIG, ReadFrom.MASTER);
+    assertEquals(6, jc.getClusterNodes(ReadFrom.BOTH).size());
+    try {
+      jc.getClusterNodes(ReadFrom.MASTER);
+    } catch (UnsupportedOperationException e) {
+      // ignore
+    }
+    try {
+      jc.getClusterNodes(ReadFrom.SLAVE);
+    } catch (UnsupportedOperationException e) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testGetConnection() {
+    JedisCluster jc = new JedisCluster(nodeInfo1, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT,
+        DEFAULT_REDIRECTIONS, PASSWORD, "test", DEFAULT_CONFIG, ReadFrom.SLAVE);
+    JedisSlotBasedConnectionHandler handler = getHandlerFromJedis(jc);
+
+    Jedis jedis = handler.getConnection(ReadFrom.MASTER);
+    assertTrue(isMasterPort(jedis.getClient().getPort()));
+
+    jedis = handler.getConnection(ReadFrom.SLAVE);
+    assertTrue(isSlavePort(jedis.getClient().getPort()));
+
+    jedis = handler.getConnectionFromSlot(10, ReadFrom.BOTH);
+    Jedis master = handler.getConnectionFromSlot(10, ReadFrom.MASTER);
+    Jedis slave = handler.getConnectionFromSlot(10, ReadFrom.SLAVE);
+    assertEquals(3, slave.getClient().getPort() - master.getClient().getPort());
+    assertTrue(jedis.getClient().getPort() == master.getClient().getPort()
+        || jedis.getClient().getPort() == slave.getClient().getPort());
+  }
+
+  @Test
+  public void testSetAndGet() {
+    JedisCluster jc1 = new JedisCluster(nodeInfo1, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT,
+        DEFAULT_REDIRECTIONS, PASSWORD, "test", DEFAULT_CONFIG, ReadFrom.MASTER);
+    JedisCluster jc2 = new JedisCluster(nodeInfo1, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT,
+        DEFAULT_REDIRECTIONS, PASSWORD, "test", DEFAULT_CONFIG, ReadFrom.SLAVE);
+
+    assertEquals("OK", jc1.set("foo", "bar"));
+    assertEquals("bar", jc1.get("foo"));
+    assertEquals("bar", jc2.get("foo"));
+  }
+
+  @Test
+  public void testMigrate() throws InterruptedException {
+    JedisCluster jc = new JedisCluster(nodeInfo1, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT,
+        DEFAULT_REDIRECTIONS, PASSWORD, "test", DEFAULT_CONFIG, ReadFrom.SLAVE);
+    JedisSlotBasedConnectionHandler handler = getHandlerFromJedis(jc);
+    int slot = JedisClusterCRC16.getSlot("foo");
+
+    Jedis master = handler.getConnectionFromSlot(slot, ReadFrom.MASTER);
+    Jedis slave = handler.getConnectionFromSlot(slot, ReadFrom.SLAVE);
+
+    int oldMasterPort = master.getClient().getPort();
+    int oldSlavePort = slave.getClient().getPort();
+    assertEquals(3, oldSlavePort - oldMasterPort);
+    assertEquals(oldMasterPort, node3.getClient().getPort());
+
+    jc.del("foo");
+    node2.clusterSetSlotImporting(slot, JedisClusterTestUtil.getNodeId(node3.clusterNodes()));
+    node3.clusterSetSlotMigrating(slot, JedisClusterTestUtil.getNodeId(node2.clusterNodes()));
+    node1.clusterSetSlotNode(slot, JedisClusterTestUtil.getNodeId(node2.clusterNodes()));
+    node2.clusterSetSlotNode(slot, JedisClusterTestUtil.getNodeId(node2.clusterNodes()));
+    node3.clusterSetSlotNode(slot, JedisClusterTestUtil.getNodeId(node2.clusterNodes()));
+    int i = 0;
+    while (node3.clusterSlots().size() < 5 && i++ < 1000) {
+      Thread.sleep(100);
+    }
+    jc.set("foo", "bar");
+    master = handler.getConnectionFromSlot(slot, ReadFrom.MASTER);
+    slave = handler.getConnectionFromSlot(slot, ReadFrom.SLAVE);
+    assertEquals(nodeInfo2.getPort(), master.getClient().getPort());
+    assertEquals(nodeInfoSlave2.getPort(), slave.getClient().getPort());
+  }
+
+  private JedisSlotBasedConnectionHandler getHandlerFromJedis(JedisCluster jc) {
+    JedisSlotBasedConnectionHandler handler = null;
+    try {
+      Field field = BinaryJedisCluster.class.getDeclaredField("connectionHandler");
+      field.setAccessible(true);
+      handler = (JedisSlotBasedConnectionHandler) field.get(jc);
+    } catch (Exception e) {
+      log.error("can not obtain handler", e);
+      // ignore
+    }
+    assertNotNull(handler);
+    return handler;
+  }
+
+  private boolean isMasterPort(int port) {
+    return port == nodeInfo1.getPort() || port == nodeInfo2.getPort()
+        || port == nodeInfo3.getPort();
+  }
+
+  private boolean isSlavePort(int port) {
+    return port == nodeInfoSlave1.getPort() || port == nodeInfoSlave2.getPort()
+        || port == nodeInfoSlave3.getPort();
+  }
+}

--- a/src/test/java/redis/clients/jedis/tests/utils/JedisClusterTestUtil.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/JedisClusterTestUtil.java
@@ -24,6 +24,12 @@ public class JedisClusterTestUtil {
     }
   }
 
+  public static void waitForReplicaReady(Jedis node, int slaveCount) throws InterruptedException {
+    while (node.clusterNodes().split("slave").length < slaveCount + 1) {
+      Thread.sleep(50);
+    }
+  }
+
   public static String getNodeId(String infoOutput) {
     for (String infoLine : infoOutput.split("\n")) {
       if (infoLine.contains("myself")) {


### PR DESCRIPTION
JedisCluster uses only Master nodes in the cluster, all the Slave nodes are only standby nodes. In many situation this is a waste of resources.

So I write an EnhancedJedisClusterInfoCache besides the original JedisClusterInfoCache. 
When we want to read only from Master, JedisCluster will use JedisClusterInfoCache, nearly nothing changed. But if we want to read from Slave or both Master and Slave nodes, JedisClusterConnectionHandler will create an EnhancedJedisClusterInfoCache.

In the new cache class, there are two maps, one for master nodes and the other for slave nodes. 
All the Jedis instances in the slave pool have been sent a ReadOnly command when they were created.

When renewing the slot cache (master goes down or slot migration), both of the two maps will be reset, the JedisPool will be destroyed. So we don't need to worry about writing to a ReadOnly node.

Thanks for reviewing my codes.

P.S.
I've read #790 #830 and some other posts and issues about ReadOnly slaves. And my thought is definitely same with @marcosnils mentioned in #1522 .