### PR TITLE
Add redis command listener

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -104,6 +104,16 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     client.setSoTimeout(soTimeout);
   }
 
+  public BinaryJedis(final String host, final int port, final int connectionTimeout,
+     final int soTimeout, final boolean ssl, final SSLSocketFactory sslSocketFactory,
+     final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier,
+     final JedisCommandListener listener) {
+    client = new Client(host, port, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
+    client.setConnectionTimeout(connectionTimeout);
+    client.setSoTimeout(soTimeout);
+    client.setListener(listener);
+  }
+
   public BinaryJedis(final JedisShardInfo shardInfo) {
     client = new Client(shardInfo.getHost(), shardInfo.getPort(), shardInfo.getSsl(),
         shardInfo.getSslSocketFactory(), shardInfo.getSslParameters(),

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -89,6 +89,13 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
         hostnameVerifier);
   }
 
+  public Jedis(final String host, final int port, final int connectionTimeout, final int soTimeout,
+      final boolean ssl, final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+      final HostnameVerifier hostnameVerifier, final JedisCommandListener listener) {
+    super(host, port, connectionTimeout, soTimeout, ssl, sslSocketFactory, sslParameters,
+        hostnameVerifier, listener);
+  }
+
   public Jedis(JedisShardInfo shardInfo) {
     super(shardInfo);
   }

--- a/src/main/java/redis/clients/jedis/JedisCommandListener.java
+++ b/src/main/java/redis/clients/jedis/JedisCommandListener.java
@@ -1,0 +1,44 @@
+package redis.clients.jedis;
+
+import redis.clients.jedis.commands.ProtocolCommand;
+
+/**
+ * A listener for command events.
+ * <p>
+ * All commands on the same connections are executed synchronously, however there the
+ * implementation must be thread safe because the listener might be invoked from
+ * different threads.
+ * <p>
+ * The listener is guaranteed to call {@link #commandStarted} and one of the
+ * {@link #commandFinished} or {@link #commandFailed} once for each command.
+ * <p>
+ * The listener implementation must be exception free or else none of the aforementioned
+ * contracts will be enforced.
+ */
+public interface JedisCommandListener {
+  /**
+   * Called for every command event that started execution
+   *
+   * @param connection the connection on which the command the executed
+   * @param event the executable command, see {@link Protocol.Command}
+   * @param args byte array of the command arguments
+   */
+  void commandStarted(Connection connection, ProtocolCommand event, byte[]... args);
+
+  /**
+   * Called for every successfully executed command
+   *
+   * @param connection the connection on which the command the executed
+   * @param event the executable command, see {@link Protocol.Command}
+   */
+  void commandFinished(Connection connection, ProtocolCommand event);
+
+  /**
+   * Called for every command that failed exceptionally
+   *
+   * @param connection the connection on which the command the executed
+   * @param event the executable command, see {@link Protocol.Command}
+   * @param t the triggered exception
+   */
+  void commandFailed(Connection connection, ProtocolCommand event, Throwable t);
+}

--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -40,17 +40,25 @@ public class JedisPool extends JedisPoolAbstract {
 
   public JedisPool(final String host, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
+    this(host, sslSocketFactory, sslParameters, hostnameVerifier, NoopJedisCommandListener.INSTANCE);
+  }
+
+  public JedisPool(final String host, final SSLSocketFactory sslSocketFactory,
+      final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier,
+      final JedisCommandListener listener) {
     URI uri = URI.create(host);
     if (JedisURIHelper.isValid(uri)) {
       this.internalPool = new GenericObjectPool<Jedis>(new JedisFactory(uri,
-          Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, null, sslSocketFactory, sslParameters,
-          hostnameVerifier), new GenericObjectPoolConfig());
+              Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, null, sslSocketFactory, sslParameters,
+              hostnameVerifier, listener), new GenericObjectPoolConfig());
     } else {
       this.internalPool = new GenericObjectPool<Jedis>(new JedisFactory(host,
-          Protocol.DEFAULT_PORT, Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, null,
-          Protocol.DEFAULT_DATABASE, null, false, null, null, null), new GenericObjectPoolConfig());
+              Protocol.DEFAULT_PORT, Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, null,
+              Protocol.DEFAULT_DATABASE, null, false, null, null, null,
+              listener), new GenericObjectPoolConfig());
     }
   }
+
 
   public JedisPool(final URI uri) {
     this(new GenericObjectPoolConfig(), uri);
@@ -164,7 +172,8 @@ public class JedisPool extends JedisPoolAbstract {
       final String clientName, final boolean ssl, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     super(poolConfig, new JedisFactory(host, port, connectionTimeout, soTimeout, password,
-        database, clientName, ssl, sslSocketFactory, sslParameters, hostnameVerifier));
+        database, clientName, ssl, sslSocketFactory, sslParameters, hostnameVerifier,
+            NoopJedisCommandListener.INSTANCE));
   }
 
   public JedisPool(final GenericObjectPoolConfig poolConfig) {
@@ -226,7 +235,7 @@ public class JedisPool extends JedisPoolAbstract {
       final int connectionTimeout, final int soTimeout, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     super(poolConfig, new JedisFactory(uri, connectionTimeout, soTimeout, null, sslSocketFactory,
-        sslParameters, hostnameVerifier));
+        sslParameters, hostnameVerifier, NoopJedisCommandListener.INSTANCE));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/NoopJedisCommandListener.java
+++ b/src/main/java/redis/clients/jedis/NoopJedisCommandListener.java
@@ -1,0 +1,22 @@
+package redis.clients.jedis;
+
+import redis.clients.jedis.commands.ProtocolCommand;
+
+class NoopJedisCommandListener implements JedisCommandListener {
+    public static final JedisCommandListener INSTANCE = new NoopJedisCommandListener();
+
+    private NoopJedisCommandListener() {
+    }
+
+    @Override
+    public void commandStarted(Connection connection, ProtocolCommand event, byte[]... args) {
+    }
+
+    @Override
+    public void commandFinished(Connection connection, ProtocolCommand event) {
+    }
+
+    @Override
+    public void commandFailed(Connection connection, ProtocolCommand event, Throwable t) {
+    }
+}


### PR DESCRIPTION
As per https://groups.google.com/forum/?fromgroups#!topic/jedis_redis/UaJubt42f_0,

This PR adds a command listener that allows for 
* sane integration with tracing libraries like http://opentracing.io/
* capturing metrics and integration with metric libraries like http://metrics.dropwizard.io/4.0.0/
* integration with logging libraries

None of the public signatures was changed, so the change should be fully backwards compatible.

