### PR TITLE
Update commons-pool2 to version 2.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-pool2</artifactId>
-			<version>2.6.0</version>
+			<version>2.6.1</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>


### PR DESCRIPTION
Resolve a critical regression issue by commons-pool2 2.4.3's fix. 
See the followings in detail. 
- https://issues.apache.org/jira/browse/POOL-347
- https://github.com/xetorthio/jedis/pull/1685#issuecomment-406796805

Attention : POOL-347 has already resolved and commons-pool2 `2.6.1` was released on Feb 14, 2019.