### PR TITLE
cleanup jedis client move get and ping from sendCommand to specific

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -22,7 +22,6 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
 
-import redis.clients.jedis.Protocol.Command;
 import redis.clients.jedis.Protocol.Keyword;
 import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.SetParams;

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -44,6 +44,11 @@ public class Client extends BinaryClient implements Commands {
   }
 
   @Override
+  public void ping(final String message) {
+    ping(SafeEncoder.encode(message));
+  }
+  
+  @Override
   public void set(final String key, final String value) {
     set(SafeEncoder.encode(key), SafeEncoder.encode(value));
   }

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -128,7 +128,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
    */
   public String ping(final String message) {
     checkIsInMultiOrPipeline();
-    client.sendCommand(Protocol.Command.PING, message);
+    client.ping(message);
     return client.getBulkReply();
   }
 
@@ -175,7 +175,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
   @Override
   public String get(final String key) {
     checkIsInMultiOrPipeline();
-    client.sendCommand(Protocol.Command.GET, key);
+    client.get(key);
     return client.getBulkReply();
   }
 

--- a/src/main/java/redis/clients/jedis/commands/Commands.java
+++ b/src/main/java/redis/clients/jedis/commands/Commands.java
@@ -13,6 +13,8 @@ import redis.clients.jedis.params.ZIncrByParams;
 
 public interface Commands {
 
+  void ping(String message);
+  
   void set(String key, String value);
 
   void set(String key, String value, SetParams params);


### PR DESCRIPTION
remove from jedis.java direct calls to client.sendCommand for GET and PING and move these methods to use the standard way like the rest of the commands