### PR TITLE
Add volatile for localhost in HostAndPort.java

### DIFF
--- a/src/main/java/redis/clients/jedis/HostAndPort.java
+++ b/src/main/java/redis/clients/jedis/HostAndPort.java
@@ -10,7 +10,7 @@ public class HostAndPort implements Serializable {
   private static final long serialVersionUID = -519876229978427751L;
 
   protected static Logger log = LoggerFactory.getLogger(HostAndPort.class.getName());
-  public static String localhost;
+  public static volatile String localhost;
 
 
   private String host;


### PR DESCRIPTION
The method `getLocalhost()` in HostAndPort.java uses a double check lock, but `localhost` is not a `volatile` variable. 