### PR TITLE
[Refactor] Make equals() methods consistent

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -3872,13 +3872,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 
     @Override
     public boolean equals(Object o) {
-      if (o == this) {
-        return true;
-      }
-
-      if (!(o instanceof Set)) {
-        return false;
-      }
+      if (o == null) return false;
+      if (o == this) return true;
+      if (!(o instanceof Set)) return false;
 
       Collection<?> c = (Collection<?>) o;
       if (c.size() != size()) {

--- a/src/main/java/redis/clients/jedis/GeoCoordinate.java
+++ b/src/main/java/redis/clients/jedis/GeoCoordinate.java
@@ -19,7 +19,8 @@ public class GeoCoordinate {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
+    if (o == null) return false;
+    if (o == this) return true;
     if (!(o instanceof GeoCoordinate)) return false;
 
     GeoCoordinate that = (GeoCoordinate) o;

--- a/src/main/java/redis/clients/jedis/HostAndPort.java
+++ b/src/main/java/redis/clients/jedis/HostAndPort.java
@@ -31,16 +31,15 @@ public class HostAndPort implements Serializable {
 
   @Override
   public boolean equals(Object obj) {
-    if (obj instanceof HostAndPort) {
-      HostAndPort hp = (HostAndPort) obj;
+    if (obj == null) return false;
+    if (obj == this) return true;
+    if (!(obj instanceof HostAndPort)) return false;
 
-      String thisHost = convertHost(host);
-      String hpHost = convertHost(hp.host);
-      return port == hp.port && thisHost.equals(hpHost);
+    HostAndPort hp = (HostAndPort) obj;
 
-    }
-
-    return false;
+    String thisHost = convertHost(host);
+    String hpHost = convertHost(hp.host);
+    return port == hp.port && thisHost.equals(hpHost);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/Module.java
+++ b/src/main/java/redis/clients/jedis/Module.java
@@ -20,8 +20,9 @@ public class Module {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (o == null) return false;
+    if (o == this) return true;
+    if (!(o instanceof Module)) return false;
 
     Module module = (Module) o;
 

--- a/src/main/java/redis/clients/jedis/Tuple.java
+++ b/src/main/java/redis/clients/jedis/Tuple.java
@@ -37,9 +37,10 @@ public class Tuple implements Comparable<Tuple> {
 
   @Override
   public boolean equals(Object obj) {
-    if (this == obj) return true;
     if (obj == null) return false;
-    if (getClass() != obj.getClass()) return false;
+    if (obj == this) return true;
+    if (!(obj instanceof Tuple)) return false;
+
     Tuple other = (Tuple) obj;
     if (!Arrays.equals(element, other.element)) return false;
     return Objects.equals(score, other.score);

--- a/src/main/java/redis/clients/jedis/util/JedisByteHashMap.java
+++ b/src/main/java/redis/clients/jedis/util/JedisByteHashMap.java
@@ -106,9 +106,10 @@ public class JedisByteHashMap implements Map<byte[], byte[]>, Cloneable, Seriali
 
     @Override
     public boolean equals(Object other) {
-      if (!(other instanceof ByteArrayWrapper)) {
-        return false;
-      }
+      if (other == null) return false;
+      if (other == this) return true;
+      if (!(other instanceof ByteArrayWrapper)) return false;
+
       return Arrays.equals(data, ((ByteArrayWrapper) other).data);
     }
 


### PR DESCRIPTION
Description:
* makes equals() implementations across the codebase similar.

Testing:
* ran ```make test``` locally, observed 0 test failures.