### PR TITLE
tuning socket i/o buffer size upto 16384 to get more throughputs

### DIFF
--- a/src/main/java/redis/clients/jedis/util/RedisInputStream.java
+++ b/src/main/java/redis/clients/jedis/util/RedisInputStream.java
@@ -36,7 +36,7 @@ public class RedisInputStream extends FilterInputStream {
   }
 
   public RedisInputStream(InputStream in) {
-    this(in, 8192);
+    this(in, 16384);
   }
 
   public byte readByte() throws JedisConnectionException {

--- a/src/main/java/redis/clients/jedis/util/RedisOutputStream.java
+++ b/src/main/java/redis/clients/jedis/util/RedisOutputStream.java
@@ -36,7 +36,7 @@ public final class RedisOutputStream extends FilterOutputStream {
           't', 'u', 'v', 'w', 'x', 'y', 'z' };
 
   public RedisOutputStream(final OutputStream out) {
-    this(out, 8192);
+    this(out, 16384);
   }
 
   public RedisOutputStream(final OutputStream out, final int size) {


### PR DESCRIPTION
in my user cases there are numbers of requests (around 200) pipelined, and the total size of such responses is much more than 8192 bytes, so in the lower tier it called a bit more times of the syscal 'recvfrom', and the outputs from strace is below:
_12207 17:02:03.556594 sendto(289, "*5\r\n$9\r\nZREVRANGE\r\n$21\r\nfeed:user:*****:posts\r\n$1\r\n0\r\n$4\r\n1001\r\n$10\r\nwithscores\r\n", 81, 0, NULL, 0 <unfinished ...>
12207 17:02:03.560635 recvfrom(289,  <unfinished ...>
12207 17:02:03.561209 <... recvfrom resumed> "*2000\r\n$24\r\n ..., 8192, MSG_DONTWAIT, NULL, NULL) = 8192 <0.000559>
12207 17:02:03.562899 recvfrom(289,  <unfinished ...>
12207 17:02:03.563336 <... recvfrom resumed> "a70 ..., 8192, MSG_DONTWAIT, NULL, NULL) = 8192 <0.000432>
12207 17:02:03.565026 recvfrom(289,  <unfinished ...>
12207 17:02:03.565464 <... recvfrom resumed> "bf5 ..., 8192, MSG_DONTWAIT, NULL, NULL) = 8192 <0.000433>
12207 17:02:03.567184 recvfrom(289,  <unfinished ...>
12207 17:02:03.567765 <... recvfrom resumed> "459 ..., 8192, MSG_DONTWAIT, NULL, NULL) = 8192 <0.000577>
12207 17:02:03.569528 recvfrom(289,  <unfinished ...>
12207 17:02:03.570149 <... recvfrom resumed> "32b ..., 8192, MSG_DONTWAIT, NULL, NULL) = 8192 <0.000617>
12207 17:02:03.572850 <... recvfrom resumed> "f89 ..., 8192, MSG_DONTWAIT, NULL, NULL) = 8192 <0.000681>
12207 17:02:03.574861 recvfrom(289,  <unfinished ...>
12207 17:02:03.575534 <... recvfrom resumed> "a0- ..., 8192, MSG_DONTWAIT, NULL, NULL) = 8192 <0.000669>
12207 17:02:03.577385 recvfrom(289,  <unfinished ...>
12207 17:02:03.577878 <... recvfrom resumed> "-f98 ..., 8192, MSG_DONTWAIT, NULL, NULL) = 1247 <0.000488>_

and the hiredis is using the read buffer size hardcoded as 16384
https://github.com/antirez/redis/blob/unstable/deps/hiredis/hiredis.c
so this PR
 
