### PR TITLE
Add Unix domain socket support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,19 @@ cluster-enabled yes
 cluster-config-file /tmp/redis_cluster_node5.conf
 endef
 
+# UDS REDIS NODES
+define REDIS_UDS
+daemonize yes
+protected-mode no
+port 0
+pidfile /tmp/redis_uds.pid
+logfile /tmp/redis_uds.log
+unixsocket /tmp/redis_6379.sock
+unixsocketperm 777
+save ""
+appendonly no
+endef
+
 #STUNNEL
 define STUNNEL_CONF
 cert = src/test/resources/private.pem
@@ -236,6 +249,7 @@ export REDIS_CLUSTER_NODE2_CONF
 export REDIS_CLUSTER_NODE3_CONF
 export REDIS_CLUSTER_NODE4_CONF
 export REDIS_CLUSTER_NODE5_CONF
+export REDIS_UDS
 export STUNNEL_CONF
 export STUNNEL_BIN
 
@@ -265,6 +279,7 @@ start: stunnel cleanup
 	echo "$$REDIS_CLUSTER_NODE3_CONF" | redis-server -
 	echo "$$REDIS_CLUSTER_NODE4_CONF" | redis-server -
 	echo "$$REDIS_CLUSTER_NODE5_CONF" | redis-server -
+	echo "$$REDIS_UDS" | redis-server -
 
 cleanup:
 	- rm -vf /tmp/redis_cluster_node*.conf 2>/dev/null
@@ -291,6 +306,7 @@ stop:
 	kill `cat /tmp/redis_cluster_node3.pid` || true
 	kill `cat /tmp/redis_cluster_node4.pid` || true
 	kill `cat /tmp/redis_cluster_node5.pid` || true
+	kill `cat /tmp/redis_uds.pid` || true
 	kill `cat /tmp/stunnel.pid` || true
 	rm -f /tmp/sentinel1.conf
 	rm -f /tmp/sentinel2.conf

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 		<redis-hosts>localhost:6379,localhost:6380,localhost:6381,localhost:6382,localhost:6383,localhost:6384,localhost:6385</redis-hosts>
 		<sentinel-hosts>localhost:26379,localhost:26380,localhost:26381</sentinel-hosts>
 		<cluster-hosts>localhost:7379,localhost:7380,localhost:7381,localhost:7382,localhost:7383,localhost:7384,localhost:7385</cluster-hosts>
+		<uds-hosts>/tmp/redis_6379.sock</uds-hosts>
     	<github.global.server>github</github.global.server>
 	</properties>
 
@@ -63,6 +64,11 @@
 			<version>2.6.0</version>
 			<type>jar</type>
 			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.kohlschutter.junixsocket</groupId>
+			<artifactId>junixsocket-native-common</artifactId>
+			<version>2.0.4</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -13,6 +13,7 @@ import static redis.clients.jedis.Protocol.Keyword.RESET;
 import static redis.clients.jedis.Protocol.Keyword.STORE;
 import static redis.clients.jedis.Protocol.Keyword.WITHSCORES;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,10 @@ public class BinaryClient extends Connection {
 
   public BinaryClient(final String host) {
     super(host);
+  }
+
+  public BinaryClient(final File unixDomainSocket) {
+    super(unixDomainSocket);
   }
 
   public BinaryClient(final String host, final int port) {

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -3,6 +3,7 @@ package redis.clients.jedis;
 import static redis.clients.jedis.Protocol.toByteArray;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.AbstractMap;
@@ -54,6 +55,10 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     } else {
       client = new Client(host);
     }
+  }
+
+  public BinaryJedis(final File unixDomainSocket) {
+    client = new Client(unixDomainSocket);
   }
 
   public BinaryJedis(final HostAndPort hp) {

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -2,6 +2,7 @@ package redis.clients.jedis;
 
 import static redis.clients.jedis.Protocol.toByteArray;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +29,10 @@ public class Client extends BinaryClient implements Commands {
 
   public Client(final String host) {
     super(host);
+  }
+
+  public Client(final File unixDomainSocket) {
+    super(unixDomainSocket);
   }
 
   public Client(final String host, final int port) {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis;
 
+import java.io.File;
 import java.net.URI;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -40,6 +41,10 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
 
   public Jedis(final String host) {
     super(host);
+  }
+
+  public Jedis(final File unixDomainSocket) {
+    super(unixDomainSocket);
   }
 
   public Jedis(final HostAndPort hp) {

--- a/src/test/java/redis/clients/jedis/tests/HostAndPortUtil.java
+++ b/src/test/java/redis/clients/jedis/tests/HostAndPortUtil.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis.tests;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,6 +11,7 @@ public final class HostAndPortUtil {
   private static List<HostAndPort> redisHostAndPortList = new ArrayList<HostAndPort>();
   private static List<HostAndPort> sentinelHostAndPortList = new ArrayList<HostAndPort>();
   private static List<HostAndPort> clusterHostAndPortList = new ArrayList<HostAndPort>();
+  private static List<File> redisUDSList = new ArrayList<File>();
 
   private HostAndPortUtil(){
     throw new InstantiationError( "Must not instantiate this class" );
@@ -36,13 +38,17 @@ public final class HostAndPortUtil {
     clusterHostAndPortList.add(new HostAndPort("localhost", 7383));
     clusterHostAndPortList.add(new HostAndPort("localhost", 7384));
 
+    redisUDSList.add(new File("/tmp/redis_6379.sock"));
+
     String envRedisHosts = System.getProperty("redis-hosts");
     String envSentinelHosts = System.getProperty("sentinel-hosts");
     String envClusterHosts = System.getProperty("cluster-hosts");
+    String envUDSHosts = System.getProperty("uds-hosts");
 
     redisHostAndPortList = parseHosts(envRedisHosts, redisHostAndPortList);
     sentinelHostAndPortList = parseHosts(envSentinelHosts, sentinelHostAndPortList);
     clusterHostAndPortList = parseHosts(envClusterHosts, clusterHostAndPortList);
+    redisUDSList = parseUDSHosts(envUDSHosts, redisUDSList);
   }
 
   public static List<HostAndPort> parseHosts(String envHosts,
@@ -80,6 +86,19 @@ public final class HostAndPortUtil {
     return existingHostsAndPorts;
   }
 
+  public static List<File> parseUDSHosts(String envHosts, List<File> existingUDSHosts) {
+    if (null != envHosts && 0 < envHosts.length()) {
+
+      String[] hostDefs = envHosts.split(",");
+
+      List<File> envUDSHosts = new ArrayList<>();
+      for (String hostDef : hostDefs) {
+        envUDSHosts.add(new File(hostDef));
+      }
+    }
+    return existingUDSHosts;
+  }
+
   public static List<HostAndPort> getRedisServers() {
     return redisHostAndPortList;
   }
@@ -90,5 +109,9 @@ public final class HostAndPortUtil {
 
   public static List<HostAndPort> getClusterServers() {
     return clusterHostAndPortList;
+  }
+
+  public static List<File> getUDSServers() {
+    return redisUDSList;
   }
 }

--- a/src/test/java/redis/clients/jedis/tests/UDSTest.java
+++ b/src/test/java/redis/clients/jedis/tests/UDSTest.java
@@ -1,0 +1,18 @@
+package redis.clients.jedis.tests;
+
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+public class UDSTest {
+    protected static File udsHost = HostAndPortUtil.getUDSServers().get(0);
+    @Test
+    public void testCompareTo() {
+        Jedis jedis = new Jedis(udsHost);
+        assertEquals("PONG", jedis.ping());
+        jedis.close();
+    }
+}


### PR DESCRIPTION
Fixes issue https://github.com/xetorthio/jedis/issues/492, and revives pull request https://github.com/xetorthio/jedis/pull/1132

The code is mostly based on the previous pull request with one main modification: exposing the unix domain socket file in the constructor. This makes the interface more clear from a Jedis client point of view.

Note: Tests were already failing due to latest Redis unstable version, but the test for this commit is working fine, and all tests pass on Redis 5.0 branch.