### PR TITLE
Javadocs minor

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -2351,6 +2351,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    * @param key
    * @param min
    * @param max
+   * @param offset
+   * @param count
    * @return Multi bulk reply specifically a list of elements in the specified score range.
    */
   @Override
@@ -2475,6 +2477,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    * @param key
    * @param min
    * @param max
+   * @param offset
+   * @param count
    * @return Multi bulk reply specifically a list of elements in the specified score range.
    */
   @Override
@@ -2575,6 +2579,10 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    * <p>
    * <b>Time complexity:</b> O(log(N))+O(M) with N being the number of elements in the sorted set
    * and M the number of elements removed by the operation
+   * @param key
+   * @param start
+   * @param stop
+   * @return
    */
   @Override
   public Long zremrangeByRank(final byte[] key, final long start, final long stop) {
@@ -3277,6 +3285,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   /**
    * Evaluates scripts using the Lua interpreter built into Redis starting from version 2.6.0.
    * <p>
+   * @param script
+   * @param keys
+   * @param args
    * @return Script result
    */
   @Override
@@ -3468,7 +3479,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    * {@link #persist(byte[]) PERSIST} command.
    * <p>
    * Time complexity: O(1)
-   * @see <ahref="http://redis.io/commands/pexpire">PEXPIRE Command</a>
+   * @see <a href="http://redis.io/commands/pexpire">PEXPIRE Command</a>
    * @param key
    * @param milliseconds
    * @return Integer reply, specifically: 1: the timeout was set. 0: the timeout was not set since
@@ -3504,6 +3515,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    * @param value
    * @return Status code reply
    */
+  @Override
   public String psetex(final byte[] key, final long milliseconds, final byte[] value) {
     checkIsInMultiOrPipeline();
     client.psetex(key, milliseconds, value);

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -2109,6 +2109,8 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
    * @param key
    * @param min
    * @param max
+   * @param offset
+   * @param count
    * @return Multi bulk reply specifically a list of elements in the specified score range.
    */
   @Override
@@ -2235,6 +2237,8 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
    * @param key
    * @param min
    * @param max
+   * @param offset
+   * @param count
    * @return Multi bulk reply specifically a list of elements in the specified score range.
    */
   @Override
@@ -2326,6 +2330,10 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
    * <p>
    * <b>Time complexity:</b> O(log(N))+O(M) with N being the number of elements in the sorted set
    * and M the number of elements removed by the operation
+   * @param key
+   * @param start
+   * @param stop
+   * @return 
    */
   @Override
   public Long zremrangeByRank(final String key, final long start, final long stop) {

--- a/src/main/java/redis/clients/jedis/ScanParams.java
+++ b/src/main/java/redis/clients/jedis/ScanParams.java
@@ -29,6 +29,9 @@ public class ScanParams {
 
   /**
    * @see <a href="https://redis.io/commands/scan#the-match-option">MATCH option in Redis documentation</a>
+   * 
+   * @param pattern
+   * @return 
    */
   public ScanParams match(final String pattern) {
     params.put(MATCH, ByteBuffer.wrap(SafeEncoder.encode(pattern)));
@@ -37,6 +40,9 @@ public class ScanParams {
 
   /**
    * @see <a href="https://redis.io/commands/scan#the-count-option">COUNT option in Redis documentation</a>
+   * 
+   * @param count
+   * @return 
    */
   public ScanParams count(final Integer count) {
     params.put(COUNT, ByteBuffer.wrap(Protocol.toByteArray(count)));

--- a/src/main/java/redis/clients/jedis/ZParams.java
+++ b/src/main/java/redis/clients/jedis/ZParams.java
@@ -26,6 +26,7 @@ public class ZParams {
   /**
    * Set weights.
    * @param weights weights.
+   * @return 
    */
   public ZParams weights(final double... weights) {
     params.add(WEIGHTS.raw);

--- a/src/main/java/redis/clients/jedis/commands/BinaryJedisClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/BinaryJedisClusterCommands.java
@@ -311,6 +311,7 @@ public interface BinaryJedisClusterCommands {
    * Executes BITFIELD Redis command
    * @param key
    * @param arguments
+   * @return 
    */
   List<Long> bitfield(byte[] key, byte[]... arguments);
   
@@ -318,6 +319,7 @@ public interface BinaryJedisClusterCommands {
    * Used for HSTRLEN Redis command
    * @param key 
    * @param field
+   * @return 
    */
   Long hstrlen(byte[] key, byte[] field);
 

--- a/src/main/java/redis/clients/jedis/commands/BinaryJedisCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/BinaryJedisCommands.java
@@ -318,6 +318,7 @@ public interface BinaryJedisCommands {
    * Executes BITFIELD Redis command
    * @param key
    * @param arguments
+   * @return 
    */
   List<Long> bitfield(byte[] key, byte[]... arguments);
   

--- a/src/main/java/redis/clients/jedis/commands/JedisClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/JedisClusterCommands.java
@@ -305,6 +305,7 @@ public interface JedisClusterCommands {
    * Executes BITFIELD Redis command
    * @param key
    * @param arguments
+   * @return 
    */
   List<Long> bitfield(String key, String...arguments);
   

--- a/src/main/java/redis/clients/jedis/commands/JedisCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/JedisCommands.java
@@ -327,6 +327,7 @@ public interface JedisCommands {
    * Executes BITFIELD Redis command
    * @param key
    * @param arguments
+   * @return 
    */
   List<Long> bitfield(String key, String...arguments);
   

--- a/src/main/java/redis/clients/jedis/commands/MultiKeyCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/MultiKeyCommands.java
@@ -111,6 +111,9 @@ public interface MultiKeyCommands {
 
   /**
    * @see #scan(String, ScanParams)
+   * 
+   * @param cursor
+   * @return 
    */
   ScanResult<String> scan(String cursor);
 

--- a/src/main/java/redis/clients/jedis/util/JedisClusterCRC16.java
+++ b/src/main/java/redis/clients/jedis/util/JedisClusterCRC16.java
@@ -75,6 +75,8 @@ public final class JedisClusterCRC16 {
    * Create a CRC16 checksum from the bytes. implementation is from mp911de/lettuce, modified with
    * some more optimizations
    * @param bytes
+   * @param s
+   * @param e
    * @return CRC16 as integer value See <a
    *         href="https://github.com/xetorthio/jedis/pull/733#issuecomment-55840331">Issue 733</a>
    */


### PR DESCRIPTION
I ran the FindBugs tool and added missing:

```
@param
@return
@Override
```

in the javadoc comments.