### PR TITLE
Create Unflushed getObjectMultiBulkReply variant in Connection

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisPubSub.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisPubSub.java
@@ -84,7 +84,7 @@ public abstract class BinaryJedisPubSub {
 
   private void process(Client client) {
     do {
-      List<Object> reply = client.getRawObjectMultiBulkReply();
+      List<Object> reply = client.getUnflushedObjectMultiBulkReply();
       final Object firstObj = reply.get(0);
       if (!(firstObj instanceof byte[])) {
         throw new JedisException("Unknown message type: " + firstObj);

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -270,13 +270,18 @@ public class Connection implements Closeable {
     return (List<byte[]>) readProtocolWithCheckingBroken();
   }
 
+  /**
+   * This method is used by JedisPubSub::process and must not interact
+   * with the Connection outputStream in order to prevent protocol
+   * desynchronization.
+   */
   @SuppressWarnings("unchecked")
   public List<Object> getRawObjectMultiBulkReply() {
-    flush();
     return (List<Object>) readProtocolWithCheckingBroken();
   }
 
   public List<Object> getObjectMultiBulkReply() {
+    flush();
     return getRawObjectMultiBulkReply();
   }
 

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -270,6 +270,11 @@ public class Connection implements Closeable {
     return (List<byte[]>) readProtocolWithCheckingBroken();
   }
 
+  @Deprecated
+  public List<Object> getRawObjectMultiBulkReply() {
+    return getUnflushedObjectMultiBulkReply();
+  }
+
   @SuppressWarnings("unchecked")
   public List<Object> getUnflushedObjectMultiBulkReply() {
     return (List<Object>) readProtocolWithCheckingBroken();

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -270,19 +270,14 @@ public class Connection implements Closeable {
     return (List<byte[]>) readProtocolWithCheckingBroken();
   }
 
-  /**
-   * This method is used by JedisPubSub::process and must not interact
-   * with the Connection outputStream in order to prevent protocol
-   * desynchronization.
-   */
   @SuppressWarnings("unchecked")
-  public List<Object> getRawObjectMultiBulkReply() {
+  public List<Object> getUnflushedObjectMultiBulkReply() {
     return (List<Object>) readProtocolWithCheckingBroken();
   }
 
   public List<Object> getObjectMultiBulkReply() {
     flush();
-    return getRawObjectMultiBulkReply();
+    return getUnflushedObjectMultiBulkReply();
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/redis/clients/jedis/JedisPubSub.java
+++ b/src/main/java/redis/clients/jedis/JedisPubSub.java
@@ -120,7 +120,7 @@ public abstract class JedisPubSub {
   private void process(Client client) {
 
     do {
-      List<Object> reply = client.getRawObjectMultiBulkReply();
+      List<Object> reply = client.getUnflushedObjectMultiBulkReply();
       final Object firstObj = reply.get(0);
       if (!(firstObj instanceof byte[])) {
         throw new JedisException("Unknown message type: " + firstObj);


### PR DESCRIPTION
Ensure that the mechanism used by subscription clients does not flush
the connection. This allows client synchronization to prevent protocol
message interleaving when manipulating the subscription connection.