### PR TITLE
delete isLoopbackAddress method

### DIFF
--- a/src/main/java/redis/clients/jedis/HostAndPort.java
+++ b/src/main/java/redis/clients/jedis/HostAndPort.java
@@ -102,10 +102,10 @@ public class HostAndPort implements Serializable {
          * at the beginning of processing and then not used again.  So even if the DNS
          * lookup needs to be done then the cost is miniscule.
          */
-      InetAddress inetAddress = InetAddress.getByName(host);
+      InetAddress.getByName(host);
 
       // isLoopbackAddress() handles both IPV4 and IPV6
-      if (inetAddress.isLoopbackAddress() || host.equals("0.0.0.0") || host.startsWith("169.254"))
+      if (host.equals("0.0.0.0") || host.startsWith("169.254"))
         return getLocalhost();
       else
         return host;

--- a/src/test/java/redis/clients/jedis/tests/HostAndPortTest.java
+++ b/src/test/java/redis/clients/jedis/tests/HostAndPortTest.java
@@ -1,13 +1,11 @@
 package redis.clients.jedis.tests;
 
-import org.junit.Test;
-
-import java.util.Arrays;
-
-import redis.clients.jedis.HostAndPort;
-
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import redis.clients.jedis.HostAndPort;
 
 public class HostAndPortTest {
   @Test
@@ -52,6 +50,10 @@ public class HostAndPortTest {
   @Test
   public void checkConvertHost() {
     String host = "2a11:1b1:0:111:e111:1f11:1111:1f1e";
+    assertEquals(host, HostAndPort.convertHost(host));
+    host = "127.0.0.1";
+    assertEquals(host, HostAndPort.convertHost(host));
+    host = "localhost";
     assertEquals(host, HostAndPort.convertHost(host));
   }
 }


### PR DESCRIPTION
when user use 127.0.0.1 ip to connect to redis. Jredis throw
exception.the code should enable
calling redis by 127.0.0.1 and localhost ip.