### PR TITLE
Update Migrate tests for Redis 6 and Support MIGRATE with AUTH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,16 @@ appendonly no
 slaveof localhost 6384
 endef
 
+define REDIS8_CONF
+daemonize yes
+protected-mode no
+port 6386
+pidfile /tmp/redis8.pid
+logfile /tmp/redis8.log
+save ""
+appendonly no
+endef
+
 # SENTINELS
 define REDIS_SENTINEL1
 port 26379
@@ -242,6 +252,7 @@ export REDIS4_CONF
 export REDIS5_CONF
 export REDIS6_CONF
 export REDIS7_CONF
+export REDIS8_CONF
 export REDIS_SENTINEL1
 export REDIS_SENTINEL2
 export REDIS_SENTINEL3
@@ -268,6 +279,7 @@ start: stunnel cleanup
 	echo "$$REDIS5_CONF" | redis-server -
 	echo "$$REDIS6_CONF" | redis-server -
 	echo "$$REDIS7_CONF" | redis-server -
+	echo "$$REDIS8_CONF" | redis-server -
 	echo "$$REDIS_SENTINEL1" > /tmp/sentinel1.conf && redis-server /tmp/sentinel1.conf --sentinel
 	@sleep 0.5
 	echo "$$REDIS_SENTINEL2" > /tmp/sentinel2.conf && redis-server /tmp/sentinel2.conf --sentinel

--- a/src/main/java/redis/clients/jedis/params/MigrateParams.java
+++ b/src/main/java/redis/clients/jedis/params/MigrateParams.java
@@ -4,6 +4,7 @@ public class MigrateParams extends Params {
 
   private static final String COPY = "COPY";
   private static final String REPLACE = "REPLACE";
+  private static final String AUTH = "AUTH";
 
   public MigrateParams() {
   }
@@ -19,6 +20,11 @@ public class MigrateParams extends Params {
 
   public MigrateParams replace() {
     addParam(REPLACE);
+    return this;
+  }
+  
+  public MigrateParams auth(String password) {
+    addParam(AUTH, password);
     return this;
   }
 }

--- a/src/test/java/redis/clients/jedis/tests/HostAndPortUtil.java
+++ b/src/test/java/redis/clients/jedis/tests/HostAndPortUtil.java
@@ -23,6 +23,7 @@ public final class HostAndPortUtil {
     redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT + 4));
     redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT + 5));
     redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT + 6));
+    redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT + 7));
 
     sentinelHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT));
     sentinelHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 1));

--- a/src/test/java/redis/clients/jedis/tests/commands/JedisCommandTestBase.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/JedisCommandTestBase.java
@@ -13,7 +13,7 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.tests.HostAndPortUtil;
 
 public abstract class JedisCommandTestBase {
-  protected static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
+  protected static final HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
 
   protected Jedis jedis;
 

--- a/src/test/java/redis/clients/jedis/tests/commands/MigrateTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/MigrateTest.java
@@ -79,6 +79,22 @@ public class MigrateTest extends JedisCommandTestBase {
   }
 
   @Test
+  public void migrateMulti() {
+    jedis.mset("foo1", "bar1", "foo2", "bar2", "foo3", "bar3");
+    MigrateParams params = MigrateParams.migrateParams().auth("");
+    assertEquals("OK", jedis.migrate(host, port, destDB, timeout, params, "foo1", "foo2", "foo3"));
+    assertEquals("bar1", dest.get("foo1"));
+    assertEquals("bar2", dest.get("foo2"));
+    assertEquals("bar3", dest.get("foo3"));
+
+    jedis.mset(bfoo1, bbar1, bfoo2, bbar2, bfoo3, bbar3);
+    assertEquals("OK", jedis.migrate(host, port, destDB, timeout, params, bfoo1, bfoo2, bfoo3));
+    assertArrayEquals(bbar1, dest.get(bfoo1));
+    assertArrayEquals(bbar2, dest.get(bfoo2));
+    assertArrayEquals(bbar3, dest.get(bfoo3));
+  }
+
+  @Test
   public void migrateConflict() {
     jedis.mset("foo1", "bar1", "foo2", "bar2", "foo3", "bar3");
     dest.set("foo2", "bar");

--- a/src/test/java/redis/clients/jedis/tests/commands/MigrateTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/MigrateTest.java
@@ -26,13 +26,10 @@ public class MigrateTest extends JedisCommandTestBase {
   private static final byte[] bfoo3 = {0x07, 0x08, 0x03};
   private static final byte[] bbar3 = {0x09, 0x00, 0x03};
 
-  private Jedis destAuth;
-  private Jedis destNoauth;
+  private Jedis dest;
   private static final String host = hnp.getHost();
-  private static final int portAuth = 6380;
-  private static final int portNoauth = 6386;
-  private static final int dbAuth = 2;
-  private static final int dbNoauth = 4;
+  private static final int port = 6386;
+  private static final int db = 2;
   private static final int timeout = Protocol.DEFAULT_TIMEOUT;
 
   @Before
@@ -40,103 +37,135 @@ public class MigrateTest extends JedisCommandTestBase {
   public void setUp() throws Exception {
     super.setUp();
 
-    destAuth = new Jedis(host, portAuth, 500);
-    destAuth.auth("foobared");
-    destAuth.flushAll();
-    destAuth.select(dbAuth);
-
-    destNoauth = new Jedis(host, portNoauth, 500);
-    destNoauth.flushAll();
-    destNoauth.select(dbNoauth);
-
+    dest = new Jedis(host, port, 500);
+    dest.flushAll();
+    dest.select(db);
   }
 
   @After
   @Override
   public void tearDown() {
-    destAuth.close();
-    destNoauth.close();
+    dest.close();
     super.tearDown();
   }
 
   @Test
   public void nokey() {
-    assertEquals("NOKEY", jedis.migrate(host, portNoauth, "foo", dbNoauth, timeout));
-    assertEquals("NOKEY", jedis.migrate(host, portNoauth, bfoo, dbNoauth, timeout));
-    assertEquals("NOKEY", jedis.migrate(host, portNoauth, dbNoauth, timeout, new MigrateParams(), "foo1", "foo2", "foo3"));
-    assertEquals("NOKEY", jedis.migrate(host, portNoauth, dbNoauth, timeout, new MigrateParams(), bfoo1, bfoo2, bfoo3));
-    assertEquals("NOKEY", jedis.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth("foobared"), "foo1", "foo2", "foo3"));
-    assertEquals("NOKEY", jedis.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth("foobared"), bfoo1, bfoo2, bfoo3));
+    assertEquals("NOKEY", jedis.migrate(host, port, "foo", db, timeout));
+    assertEquals("NOKEY", jedis.migrate(host, port, bfoo, db, timeout));
+    assertEquals("NOKEY", jedis.migrate(host, port, db, timeout, new MigrateParams(), "foo1", "foo2", "foo3"));
+    assertEquals("NOKEY", jedis.migrate(host, port, db, timeout, new MigrateParams(), bfoo1, bfoo2, bfoo3));
   }
 
   @Test
   public void migrate() {
     jedis.set("foo", "bar");
-    assertEquals("OK", jedis.migrate(host, portNoauth, "foo", dbNoauth, timeout));
-    assertEquals("bar", destNoauth.get("foo"));
+    assertEquals("OK", jedis.migrate(host, port, "foo", db, timeout));
+    assertEquals("bar", dest.get("foo"));
     assertNull(jedis.get("foo"));
 
     jedis.set(bfoo, bbar);
-    assertEquals("OK", jedis.migrate(host, portNoauth, bfoo, dbNoauth, timeout));
-    assertArrayEquals(bbar, destNoauth.get(bfoo));
+    assertEquals("OK", jedis.migrate(host, port, bfoo, db, timeout));
+    assertArrayEquals(bbar, dest.get(bfoo));
     assertNull(jedis.get(bfoo));
   }
 
   @Test
-  public void migrateMulti() {
-    jedis.mset("foo1", "bar1", "foo2", "bar2", "foo3", "bar3");
-    assertEquals("OK", jedis.migrate(host, portNoauth, dbNoauth, timeout, new MigrateParams(), "foo1", "foo2", "foo3"));
-    assertEquals("bar1", destNoauth.get("foo1"));
-    assertEquals("bar2", destNoauth.get("foo2"));
-    assertEquals("bar3", destNoauth.get("foo3"));
+  public void migrateEmptyParams() {
+    jedis.set("foo", "bar");
+    assertEquals("OK", jedis.migrate(host, port, db, timeout, new MigrateParams(), "foo"));
+    assertEquals("bar", dest.get("foo"));
+    assertNull(jedis.get("foo"));
 
-    jedis.mset(bfoo1, bbar1, bfoo2, bbar2, bfoo3, bbar3);
-    assertEquals("OK", jedis.migrate(host, portNoauth, dbNoauth, timeout, new MigrateParams(), bfoo1, bfoo2, bfoo3));
-    assertArrayEquals(bbar1, destNoauth.get(bfoo1));
-    assertArrayEquals(bbar2, destNoauth.get(bfoo2));
-    assertArrayEquals(bbar3, destNoauth.get(bfoo3));
+    jedis.set(bfoo, bbar);
+    assertEquals("OK", jedis.migrate(host, port, db, timeout, new MigrateParams(), bfoo));
+    assertArrayEquals(bbar, dest.get(bfoo));
+    assertNull(jedis.get(bfoo));
   }
 
   @Test
-  public void migrateConflict() {
-    jedis.mset("foo1", "bar1", "foo2", "bar2", "foo3", "bar3");
-    destNoauth.set("foo2", "bar");
-    try {
-      jedis.migrate(host, portNoauth, dbNoauth, timeout, new MigrateParams(), "foo1", "foo2", "foo3");
-      fail("Should get BUSYKEY error");
-    } catch(JedisDataException jde) {
-      assertTrue(jde.getMessage().contains("BUSYKEY"));
-    }
-    assertEquals("bar1", destNoauth.get("foo1"));
-    assertEquals("bar", destNoauth.get("foo2"));
-    assertEquals("bar3", destNoauth.get("foo3"));
+  public void migrateCopy() {
+    jedis.set("foo", "bar");
+    assertEquals("OK", jedis.migrate(host, port, db, timeout, new MigrateParams().copy(), "foo"));
+    assertEquals("bar", dest.get("foo"));
+    assertEquals("bar", jedis.get("foo"));
 
-    jedis.mset(bfoo1, bbar1, bfoo2, bbar2, bfoo3, bbar3);
-    destNoauth.set(bfoo2, bbar);
-    try {
-      jedis.migrate(host, portNoauth, dbNoauth, timeout, new MigrateParams(), bfoo1, bfoo2, bfoo3);
-      fail("Should get BUSYKEY error");
-    } catch(JedisDataException jde) {
-      assertTrue(jde.getMessage().contains("BUSYKEY"));
-    }
-    assertArrayEquals(bbar1, destNoauth.get(bfoo1));
-    assertArrayEquals(bbar, destNoauth.get(bfoo2));
-    assertArrayEquals(bbar3, destNoauth.get(bfoo3));
+    jedis.set(bfoo, bbar);
+    assertEquals("OK", jedis.migrate(host, port, db, timeout, new MigrateParams().copy(), bfoo));
+    assertArrayEquals(bbar, dest.get(bfoo));
+    assertArrayEquals(bbar, jedis.get(bfoo));
+  }
+
+  @Test
+  public void migrateReplace() {
+    jedis.set("foo", "bar1");
+    dest.set("foo", "bar2");
+    assertEquals("OK", jedis.migrate(host, port, db, timeout, new MigrateParams().copy().replace(), "foo"));
+    assertEquals("bar1", dest.get("foo"));
+    assertNull(jedis.get("foo"));
+
+    jedis.set(bfoo, bbar1);
+    dest.set(bfoo, bbar2);
+    assertEquals("OK", jedis.migrate(host, port, db, timeout, new MigrateParams().copy().replace(), bfoo));
+    assertArrayEquals(bbar1, dest.get(bfoo));
+    assertNull(jedis.get(bfoo));
   }
 
   @Test
   public void migrateCopyReplace() {
     jedis.set("foo", "bar1");
-    destNoauth.set("foo", "bar2");
-    assertEquals("OK", jedis.migrate(host, portNoauth, dbNoauth, timeout, new MigrateParams().copy().replace(), "foo"));
+    dest.set("foo", "bar2");
+    assertEquals("OK", jedis.migrate(host, port, db, timeout, new MigrateParams().copy().replace(), "foo"));
+    assertEquals("bar1", dest.get("foo"));
     assertEquals("bar1", jedis.get("foo"));
-    assertEquals("bar1", destNoauth.get("foo"));
 
     jedis.set(bfoo, bbar1);
-    destNoauth.set(bfoo, bbar2);
-    assertEquals("OK", jedis.migrate(host, portNoauth, dbNoauth, timeout, new MigrateParams().copy().replace(), bfoo));
+    dest.set(bfoo, bbar2);
+    assertEquals("OK", jedis.migrate(host, port, db, timeout, new MigrateParams().copy().replace(), bfoo));
+    assertArrayEquals(bbar1, dest.get(bfoo));
     assertArrayEquals(bbar1, jedis.get(bfoo));
-    assertArrayEquals(bbar1, destNoauth.get(bfoo));
+  }
+
+  @Test
+  public void migrateMulti() {
+    jedis.mset("foo1", "bar1", "foo2", "bar2", "foo3", "bar3");
+    assertEquals("OK", jedis.migrate(host, port, db, timeout, new MigrateParams(), "foo1", "foo2", "foo3"));
+    assertEquals("bar1", dest.get("foo1"));
+    assertEquals("bar2", dest.get("foo2"));
+    assertEquals("bar3", dest.get("foo3"));
+
+    jedis.mset(bfoo1, bbar1, bfoo2, bbar2, bfoo3, bbar3);
+    assertEquals("OK", jedis.migrate(host, port, db, timeout, new MigrateParams(), bfoo1, bfoo2, bfoo3));
+    assertArrayEquals(bbar1, dest.get(bfoo1));
+    assertArrayEquals(bbar2, dest.get(bfoo2));
+    assertArrayEquals(bbar3, dest.get(bfoo3));
+  }
+
+  @Test
+  public void migrateConflict() {
+    jedis.mset("foo1", "bar1", "foo2", "bar2", "foo3", "bar3");
+    dest.set("foo2", "bar");
+    try {
+      jedis.migrate(host, port, db, timeout, new MigrateParams(), "foo1", "foo2", "foo3");
+      fail("Should get BUSYKEY error");
+    } catch(JedisDataException jde) {
+      assertTrue(jde.getMessage().contains("BUSYKEY"));
+    }
+    assertEquals("bar1", dest.get("foo1"));
+    assertEquals("bar", dest.get("foo2"));
+    assertEquals("bar3", dest.get("foo3"));
+
+    jedis.mset(bfoo1, bbar1, bfoo2, bbar2, bfoo3, bbar3);
+    dest.set(bfoo2, bbar);
+    try {
+      jedis.migrate(host, port, db, timeout, new MigrateParams(), bfoo1, bfoo2, bfoo3);
+      fail("Should get BUSYKEY error");
+    } catch(JedisDataException jde) {
+      assertTrue(jde.getMessage().contains("BUSYKEY"));
+    }
+    assertArrayEquals(bbar1, dest.get(bfoo1));
+    assertArrayEquals(bbar, dest.get(bfoo2));
+    assertArrayEquals(bbar3, dest.get(bfoo3));
   }
 
 }

--- a/src/test/java/redis/clients/jedis/tests/commands/MigrateTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/MigrateTest.java
@@ -68,76 +68,75 @@ public class MigrateTest extends JedisCommandTestBase {
     assertEquals("NOKEY", jedis.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth("foobared"), "foo1", "foo2", "foo3"));
     assertEquals("NOKEY", jedis.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth("foobared"), bfoo1, bfoo2, bfoo3));
   }
-/*
+
   @Test
   public void migrate() {
     jedis.set("foo", "bar");
-    assertEquals("OK", jedis.migrate(host, portNoauth, "foo", destDB, timeout));
-    assertEquals("bar", dest.get("foo"));
+    assertEquals("OK", jedis.migrate(host, portNoauth, "foo", dbNoauth, timeout));
+    assertEquals("bar", destNoauth.get("foo"));
     assertNull(jedis.get("foo"));
 
     jedis.set(bfoo, bbar);
-    assertEquals("OK", jedis.migrate(host, portNoauth, bfoo, destDB, timeout));
-    assertArrayEquals(bbar, dest.get(bfoo));
+    assertEquals("OK", jedis.migrate(host, portNoauth, bfoo, dbNoauth, timeout));
+    assertArrayEquals(bbar, destNoauth.get(bfoo));
     assertNull(jedis.get(bfoo));
   }
 
   @Test
   public void migrateMulti() {
     jedis.mset("foo1", "bar1", "foo2", "bar2", "foo3", "bar3");
-    MigrateParams params = MigrateParams.migrateParams().auth("");
-    assertEquals("OK", jedis.migrate(host, port, destDB, timeout, params, "foo1", "foo2", "foo3"));
-    assertEquals("bar1", dest.get("foo1"));
-    assertEquals("bar2", dest.get("foo2"));
-    assertEquals("bar3", dest.get("foo3"));
+    assertEquals("OK", jedis.migrate(host, portNoauth, dbNoauth, timeout, new MigrateParams(), "foo1", "foo2", "foo3"));
+    assertEquals("bar1", destNoauth.get("foo1"));
+    assertEquals("bar2", destNoauth.get("foo2"));
+    assertEquals("bar3", destNoauth.get("foo3"));
 
     jedis.mset(bfoo1, bbar1, bfoo2, bbar2, bfoo3, bbar3);
-    assertEquals("OK", jedis.migrate(host, port, destDB, timeout, params, bfoo1, bfoo2, bfoo3));
-    assertArrayEquals(bbar1, dest.get(bfoo1));
-    assertArrayEquals(bbar2, dest.get(bfoo2));
-    assertArrayEquals(bbar3, dest.get(bfoo3));
+    assertEquals("OK", jedis.migrate(host, portNoauth, dbNoauth, timeout, new MigrateParams(), bfoo1, bfoo2, bfoo3));
+    assertArrayEquals(bbar1, destNoauth.get(bfoo1));
+    assertArrayEquals(bbar2, destNoauth.get(bfoo2));
+    assertArrayEquals(bbar3, destNoauth.get(bfoo3));
   }
 
   @Test
   public void migrateConflict() {
     jedis.mset("foo1", "bar1", "foo2", "bar2", "foo3", "bar3");
-    dest.set("foo2", "bar");
+    destNoauth.set("foo2", "bar");
     try {
-      jedis.migrate(host, port, destDB, timeout, new MigrateParams(), "foo1", "foo2", "foo3");
+      jedis.migrate(host, portNoauth, dbNoauth, timeout, new MigrateParams(), "foo1", "foo2", "foo3");
       fail("Should get BUSYKEY error");
     } catch(JedisDataException jde) {
       assertTrue(jde.getMessage().contains("BUSYKEY"));
     }
-    assertEquals("bar1", dest.get("foo1"));
-    assertEquals("bar", dest.get("foo2"));
-    assertEquals("bar3", dest.get("foo3"));
+    assertEquals("bar1", destNoauth.get("foo1"));
+    assertEquals("bar", destNoauth.get("foo2"));
+    assertEquals("bar3", destNoauth.get("foo3"));
 
     jedis.mset(bfoo1, bbar1, bfoo2, bbar2, bfoo3, bbar3);
-    dest.set(bfoo2, bbar);
+    destNoauth.set(bfoo2, bbar);
     try {
-      jedis.migrate(host, port, destDB, timeout, new MigrateParams(), bfoo1, bfoo2, bfoo3);
+      jedis.migrate(host, portNoauth, dbNoauth, timeout, new MigrateParams(), bfoo1, bfoo2, bfoo3);
       fail("Should get BUSYKEY error");
     } catch(JedisDataException jde) {
       assertTrue(jde.getMessage().contains("BUSYKEY"));
     }
-    assertArrayEquals(bbar1, dest.get(bfoo1));
-    assertArrayEquals(bbar, dest.get(bfoo2));
-    assertArrayEquals(bbar3, dest.get(bfoo3));
+    assertArrayEquals(bbar1, destNoauth.get(bfoo1));
+    assertArrayEquals(bbar, destNoauth.get(bfoo2));
+    assertArrayEquals(bbar3, destNoauth.get(bfoo3));
   }
 
   @Test
   public void migrateCopyReplace() {
     jedis.set("foo", "bar1");
-    dest.set("foo", "bar2");
-    assertEquals("OK", jedis.migrate(host, port, destDB, timeout, new MigrateParams().copy().replace(), "foo"));
+    destNoauth.set("foo", "bar2");
+    assertEquals("OK", jedis.migrate(host, portNoauth, dbNoauth, timeout, new MigrateParams().copy().replace(), "foo"));
     assertEquals("bar1", jedis.get("foo"));
-    assertEquals("bar1", dest.get("foo"));
+    assertEquals("bar1", destNoauth.get("foo"));
 
     jedis.set(bfoo, bbar1);
-    dest.set(bfoo, bbar2);
-    assertEquals("OK", jedis.migrate(host, port, destDB, timeout, new MigrateParams().copy().replace(), bfoo));
+    destNoauth.set(bfoo, bbar2);
+    assertEquals("OK", jedis.migrate(host, portNoauth, dbNoauth, timeout, new MigrateParams().copy().replace(), bfoo));
     assertArrayEquals(bbar1, jedis.get(bfoo));
-    assertArrayEquals(bbar1, dest.get(bfoo));
+    assertArrayEquals(bbar1, destNoauth.get(bfoo));
   }
-*/
+
 }

--- a/src/test/java/redis/clients/jedis/tests/commands/MigrateTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/MigrateTest.java
@@ -81,13 +81,14 @@ public class MigrateTest extends JedisCommandTestBase {
   @Test
   public void migrateMulti() {
     jedis.mset("foo1", "bar1", "foo2", "bar2", "foo3", "bar3");
-    assertEquals("OK", jedis.migrate(host, port, destDB, timeout, new MigrateParams(), "foo1", "foo2", "foo3"));
+    MigrateParams params = MigrateParams.migrateParams().auth("");
+    assertEquals("OK", jedis.migrate(host, port, destDB, timeout, params, "foo1", "foo2", "foo3"));
     assertEquals("bar1", dest.get("foo1"));
     assertEquals("bar2", dest.get("foo2"));
     assertEquals("bar3", dest.get("foo3"));
 
     jedis.mset(bfoo1, bbar1, bfoo2, bbar2, bfoo3, bbar3);
-    assertEquals("OK", jedis.migrate(host, port, destDB, timeout, new MigrateParams(), bfoo1, bfoo2, bfoo3));
+    assertEquals("OK", jedis.migrate(host, port, destDB, timeout, params, bfoo1, bfoo2, bfoo3));
     assertArrayEquals(bbar1, dest.get(bfoo1));
     assertArrayEquals(bbar2, dest.get(bfoo2));
     assertArrayEquals(bbar3, dest.get(bfoo3));

--- a/src/test/java/redis/clients/jedis/tests/commands/MigrateTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/MigrateTest.java
@@ -100,13 +100,13 @@ public class MigrateTest extends JedisCommandTestBase {
   public void migrateReplace() {
     jedis.set("foo", "bar1");
     dest.set("foo", "bar2");
-    assertEquals("OK", jedis.migrate(host, port, db, timeout, new MigrateParams().copy().replace(), "foo"));
+    assertEquals("OK", jedis.migrate(host, port, db, timeout, new MigrateParams().replace(), "foo"));
     assertEquals("bar1", dest.get("foo"));
     assertNull(jedis.get("foo"));
 
     jedis.set(bfoo, bbar1);
     dest.set(bfoo, bbar2);
-    assertEquals("OK", jedis.migrate(host, port, db, timeout, new MigrateParams().copy().replace(), bfoo));
+    assertEquals("OK", jedis.migrate(host, port, db, timeout, new MigrateParams().replace(), bfoo));
     assertArrayEquals(bbar1, dest.get(bfoo));
     assertNull(jedis.get(bfoo));
   }

--- a/src/test/java/redis/clients/jedis/tests/commands/MigrateTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/MigrateTest.java
@@ -151,15 +151,15 @@ public class MigrateTest extends JedisCommandTestBase {
   @Test
   public void migrateCopyReplaceAuth() {
     jedis.set("foo", "bar1");
-    dest.set("foo", "bar2");
+    destAuth.set("foo", "bar2");
     assertEquals("OK", jedis.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().copy().replace().auth("foobared"), "foo"));
-    assertEquals("bar1", dest.get("foo"));
+    assertEquals("bar1", destAuth.get("foo"));
     assertEquals("bar1", jedis.get("foo"));
 
     jedis.set(bfoo, bbar1);
-    dest.set(bfoo, bbar2);
+    destAuth.set(bfoo, bbar2);
     assertEquals("OK", jedis.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().copy().replace().auth("foobared"), bfoo));
-    assertArrayEquals(bbar1, dest.get(bfoo));
+    assertArrayEquals(bbar1, destAuth.get(bfoo));
     assertArrayEquals(bbar1, jedis.get(bfoo));
   }
 

--- a/src/test/java/redis/clients/jedis/tests/commands/MigrateTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/MigrateTest.java
@@ -79,22 +79,6 @@ public class MigrateTest extends JedisCommandTestBase {
   }
 
   @Test
-  public void migrateMulti() {
-    jedis.mset("foo1", "bar1", "foo2", "bar2", "foo3", "bar3");
-    MigrateParams params = MigrateParams.migrateParams().auth("");
-    assertEquals("OK", jedis.migrate(host, port, destDB, timeout, params, "foo1", "foo2", "foo3"));
-    assertEquals("bar1", dest.get("foo1"));
-    assertEquals("bar2", dest.get("foo2"));
-    assertEquals("bar3", dest.get("foo3"));
-
-    jedis.mset(bfoo1, bbar1, bfoo2, bbar2, bfoo3, bbar3);
-    assertEquals("OK", jedis.migrate(host, port, destDB, timeout, params, bfoo1, bfoo2, bfoo3));
-    assertArrayEquals(bbar1, dest.get(bfoo1));
-    assertArrayEquals(bbar2, dest.get(bfoo2));
-    assertArrayEquals(bbar3, dest.get(bfoo3));
-  }
-
-  @Test
   public void migrateConflict() {
     jedis.mset("foo1", "bar1", "foo2", "bar2", "foo3", "bar3");
     dest.set("foo2", "bar");


### PR DESCRIPTION
- Support MIGRATE command with AUTH parameter
- Update MIGRATE tests for Redis 6
- More tests for MIGRATE command

Resolves #1788 
Closes #1997 