### PR TITLE
added general send command to Jedis

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -25,6 +25,7 @@ import redis.clients.jedis.commands.BasicCommands;
 import redis.clients.jedis.commands.BinaryJedisCommands;
 import redis.clients.jedis.commands.BinaryScriptingCommands;
 import redis.clients.jedis.commands.MultiKeyBinaryCommands;
+import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.exceptions.InvalidURIException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.exceptions.JedisException;
@@ -4040,5 +4041,11 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     checkIsInMultiOrPipeline();
     client.xclaim(key, groupname, consumername, minIdleTime, newIdleTime, retries, force, ids);
     return client.getBinaryMultiBulkReply();  
+  }
+
+  @Override
+  public Object sendCommand(ProtocolCommand cmd, byte[]... args) {
+    client.sendCommand(cmd, args);
+    return client.getOne();
   }
 }

--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -3,6 +3,7 @@ package redis.clients.jedis;
 import redis.clients.jedis.commands.BinaryJedisClusterCommands;
 import redis.clients.jedis.commands.JedisClusterBinaryScriptingCommands;
 import redis.clients.jedis.commands.MultiKeyBinaryJedisClusterCommands;
+import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.SetParams;
 import redis.clients.jedis.params.ZAddParams;
@@ -2200,5 +2201,15 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
         return connection.waitReplicas(replicas, timeout);
       }
     }.runBinary(key);
+  }
+
+  @Override
+  public Object sendCommand(final byte[] sampleKey, final ProtocolCommand cmd, final byte[]... args) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
+      @Override
+      public Object execute(Jedis connection){
+        return connection.sendCommand(cmd, args);
+      }
+    }.runBinary(sampleKey);
   }
 }

--- a/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import redis.clients.jedis.commands.BinaryJedisCommands;
+import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.SetParams;
@@ -1033,5 +1034,14 @@ public class BinaryShardedJedis extends Sharded<Jedis, JedisShardInfo> implement
       int retries, boolean force, byte[][] ids) {
     Jedis j = getShard(key);
     return j.xclaim(key, groupname, consumername, minIdleTime, newIdleTime, retries, force, ids);
-  }  
+  }
+
+  @Override
+  public Object sendCommand(ProtocolCommand cmd, byte[]... args) {
+    // default since no sample key provided in JedisCommands interface
+    byte[] sampleKey = args.length > 0 ? args[0] : cmd.getRaw();
+    Jedis j = getShard(args[0]);
+    return j.sendCommand(cmd, args);
+  }
+
 }

--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -554,6 +554,17 @@ public final class BuilderFactory {
     }
   };
 
+  public static final Builder<Object> OBJECT = new Builder<Object>() {
+    @Override
+    public Object build(Object data) {
+      return data;
+    }
+    @Override
+    public String toString() {
+      return "Object";
+    }
+  };
+
 
 
   private BuilderFactory() {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -19,6 +19,7 @@ import redis.clients.jedis.commands.ClusterCommands;
 import redis.clients.jedis.commands.JedisCommands;
 import redis.clients.jedis.commands.ModuleCommands;
 import redis.clients.jedis.commands.MultiKeyCommands;
+import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.commands.ScriptingCommands;
 import redis.clients.jedis.commands.SentinelCommands;
 import redis.clients.jedis.params.GeoRadiusParam;
@@ -3826,5 +3827,11 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     client.xclaim( key, group, consumername, minIdleTime, newIdleTime, retries, force, ids);
     
     return BuilderFactory.STREAM_ENTRY_LIST.build(client.getObjectMultiBulkReply());
+  }
+
+  @Override
+  public Object sendCommand(ProtocolCommand cmd, String... args) {
+    client.sendCommand(cmd, args);
+    return client.getOne();
   }
 }

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis;
 
+import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.SetParams;
 import redis.clients.jedis.params.ZAddParams;
@@ -2233,4 +2234,16 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       }
     }.run(key);
   }
+
+  @Override
+  public Object sendCommand(final String sampleKey, final ProtocolCommand cmd, final String... args) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
+      @Override
+      public Object execute(Jedis connection){
+        return connection.sendCommand(cmd, args);
+      }
+    }.run(sampleKey);
+  }
+
+
 }

--- a/src/main/java/redis/clients/jedis/MultiKeyPipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiKeyPipelineBase.java
@@ -702,5 +702,11 @@ public abstract class MultiKeyPipelineBase extends PipelineBase implements
     client.migrate(host, port, destinationDB, timeout, params, keys);
     return getResponse(BuilderFactory.STRING);
   }
+
+  @Override
+  public Response<Object> sendCommand(ProtocolCommand cmd, String... args){
+    client.sendCommand(cmd, args);
+    return getResponse(BuilderFactory.OBJECT);
+  }
   
 }

--- a/src/main/java/redis/clients/jedis/PipelineBase.java
+++ b/src/main/java/redis/clients/jedis/PipelineBase.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 
 import redis.clients.jedis.commands.BinaryRedisPipeline;
+import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.commands.RedisPipeline;
 import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.SetParams;
@@ -1960,5 +1961,19 @@ public abstract class PipelineBase extends Queable implements BinaryRedisPipelin
       long newIdleTime, int retries, boolean force, byte[]... ids){
     getClient(key).xclaim(key, group, consumername, minIdleTime, newIdleTime, retries, force, ids);
     return getResponse(BuilderFactory.BYTE_ARRAY_LIST);            
+  }
+
+  @Override
+  public Response<Object> sendCommand(ProtocolCommand cmd, String... args){
+    String key = args.length > 0 ? args[0] : cmd.toString();
+    getClient(key).sendCommand(cmd, args);
+    return getResponse(BuilderFactory.OBJECT);
+  }
+
+  @Override
+  public Response<Object> sendCommand(ProtocolCommand cmd, byte[]... args){
+    byte[] key = args.length > 0 ? args[0] : cmd.getRaw();
+    getClient(key).sendCommand(cmd, args);
+    return getResponse(BuilderFactory.OBJECT);
   }
 }

--- a/src/main/java/redis/clients/jedis/ShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedis.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import redis.clients.jedis.commands.JedisCommands;
+import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.SetParams;
 import redis.clients.jedis.params.ZAddParams;
@@ -1052,5 +1053,13 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands, C
       int retries, boolean force, StreamEntryID... ids) {
     Jedis j = getShard(key);
     return j.xclaim(key, group, consumername, minIdleTime, newIdleTime, retries, force, ids);
+  }
+
+  @Override
+  public Object sendCommand(ProtocolCommand cmd, String... args) {
+    // default since no sample key provided in JedisCommands interface
+    String sampleKey = args.length > 0 ? args[0] : cmd.toString();
+    Jedis j = getShard(sampleKey);
+    return j.sendCommand(cmd, args);
   }
 }

--- a/src/main/java/redis/clients/jedis/commands/BinaryJedisClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/BinaryJedisClusterCommands.java
@@ -350,4 +350,6 @@ public interface BinaryJedisClusterCommands {
   List<byte[]> xclaim(byte[] key, byte[] groupname, byte[] consumername, long minIdleTime, long newIdleTime, int retries, boolean force, byte[][] ids);
 
   Long waitReplicas(byte[] key, final int replicas, final long timeout);
+
+  Object sendCommand(final byte[] sampleKey, ProtocolCommand cmd, byte[]... args);
 }

--- a/src/main/java/redis/clients/jedis/commands/BinaryJedisCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/BinaryJedisCommands.java
@@ -356,4 +356,6 @@ public interface BinaryJedisCommands {
   List<byte[]> xpending(byte[] key, byte[] groupname, byte[] start, byte[] end, int count, byte[] consumername);
 
   List<byte[]> xclaim(byte[] key, byte[] groupname, byte[] consumername, long minIdleTime, long newIdleTime, int retries, boolean force, byte[][] ids);
+
+  Object sendCommand(ProtocolCommand cmd, byte[]... args);
 }

--- a/src/main/java/redis/clients/jedis/commands/BinaryRedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/commands/BinaryRedisPipeline.java
@@ -353,4 +353,6 @@ public interface BinaryRedisPipeline {
   Response<String> psetex(byte[] key, long milliseconds, byte[] value);
 
   Response<Double> hincrByFloat(byte[] key, byte[] field, double increment);
+
+  Response<Object> sendCommand(ProtocolCommand cmd, byte[]... args);
 }

--- a/src/main/java/redis/clients/jedis/commands/JedisClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/JedisClusterCommands.java
@@ -482,4 +482,6 @@ public interface JedisClusterCommands {
       long newIdleTime, int retries, boolean force, StreamEntryID... ids);
 
   Long waitReplicas(final String key, final int replicas, final long timeout);
+
+  Object sendCommand(final String sampleKey, ProtocolCommand cmd, String... args);
 }

--- a/src/main/java/redis/clients/jedis/commands/JedisCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/JedisCommands.java
@@ -481,4 +481,6 @@ public interface JedisCommands {
   List<StreamEntry> xclaim( String key, String group, String consumername, long minIdleTime, 
       long newIdleTime, int retries, boolean force, StreamEntryID... ids);
 
+
+  Object sendCommand(ProtocolCommand cmd, String... args);
 }

--- a/src/main/java/redis/clients/jedis/commands/RedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/commands/RedisPipeline.java
@@ -353,4 +353,6 @@ public interface RedisPipeline {
   Response<String> psetex(String key, long milliseconds, String value);
 
   Response<Double> hincrByFloat(String key, String field, double increment);
+
+  Response<Object> sendCommand(ProtocolCommand cmd, String... args);
 }

--- a/src/test/java/redis/clients/jedis/tests/commands/BinaryValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/BinaryValuesCommandsTest.java
@@ -1,8 +1,13 @@
 package redis.clients.jedis.tests.commands;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static redis.clients.jedis.Protocol.Command.GET;
+import static redis.clients.jedis.Protocol.Command.LRANGE;
+import static redis.clients.jedis.Protocol.Command.RPUSH;
+import static redis.clients.jedis.Protocol.Command.SET;
 import static redis.clients.jedis.params.SetParams.setParams;
 import static redis.clients.jedis.tests.utils.AssertUtil.assertByteArrayListEquals;
 
@@ -15,6 +20,7 @@ import org.junit.Test;
 
 import redis.clients.jedis.Protocol.Keyword;
 import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class BinaryValuesCommandsTest extends JedisCommandTestBase {
   byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };
@@ -280,5 +286,27 @@ public class BinaryValuesCommandsTest extends JedisCommandTestBase {
   public void strlen() {
     jedis.set(bfoo, binaryValue);
     assertEquals(binaryValue.length, jedis.strlen(bfoo).intValue());
+  }
+
+  public void sendCommandTest(){
+    Object obj = jedis.sendCommand(SET, "x".getBytes(), "1".getBytes());
+    String returnValue = SafeEncoder.encode((byte[]) obj);
+    assertEquals("OK", returnValue);
+    obj = jedis.sendCommand(GET, "x".getBytes());
+    returnValue = SafeEncoder.encode((byte[]) obj);
+    assertEquals("1", returnValue);
+
+    jedis.sendCommand(RPUSH,"foo".getBytes(), "a".getBytes());
+    jedis.sendCommand(RPUSH,"foo".getBytes(), "b".getBytes());
+    jedis.sendCommand(RPUSH,"foo".getBytes(), "c".getBytes());
+
+    obj = jedis.sendCommand(LRANGE,"foo".getBytes(), "0".getBytes(), "2".getBytes());
+    List<byte[]> list = (List<byte[]>) obj;
+    List<byte[]> expected = new ArrayList<>(3);
+    expected.add("a".getBytes());
+    expected.add("b".getBytes());
+    expected.add("c".getBytes());
+    for (int i = 0; i < 3; i++)
+      assertArrayEquals(expected.get(i), list.get(i));
   }
 }

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterBinaryJedisCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterBinaryJedisCommandsTest.java
@@ -3,6 +3,7 @@ package redis.clients.jedis.tests.commands;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static redis.clients.jedis.Protocol.Command.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,6 +22,7 @@ import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.tests.HostAndPortUtil;
 import redis.clients.jedis.util.JedisClusterCRC16;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class ClusterBinaryJedisCommandsTest {
   private Jedis node1;
@@ -173,6 +175,25 @@ public class ClusterBinaryJedisCommandsTest {
     jedisCluster.set("{f}oo3".getBytes(), "bar".getBytes());
     assertEquals(3, jedisCluster.keys("{f}o*".getBytes()).size());
   }
+
+  @Test
+  public void testBinaryGeneralCommand(){
+    byte[] key = "x".getBytes();
+    byte[] value = "1".getBytes();
+    jedisCluster.sendCommand("z".getBytes(), SET, key, value);
+    jedisCluster.sendCommand("y".getBytes(), INCR, key);
+    Object returnObj = jedisCluster.sendCommand("w".getBytes(), GET, key);
+    assertEquals("2", SafeEncoder.encode((byte[])returnObj));
+  }
+
+  @Test
+  public void testGeneralCommand(){
+    jedisCluster.sendCommand("z", SET, "x", "1");
+    jedisCluster.sendCommand("y", INCR, "x");
+    Object returnObj = jedisCluster.sendCommand("w", GET, "x");
+    assertEquals("2", SafeEncoder.encode((byte[])returnObj));
+  }
+
 
   @Test(expected = IllegalArgumentException.class)
   public void failKeys() {


### PR DESCRIPTION
Added general "send command" functionality to Jedis and Transaction objects. 
Input: Command, and command arguments.
Output: Object, as returned by `client.getOne()`. It is the caller responsibility to handle the returned object properly.
The main motivation for this addition: add modules functionality, including sending module command in MULTI/EXEC:
1. There is no need to call `jedis.getClient()` in order to directly access and expose the binary client, in order to send a module command or 3rd party command.
2. Allowing 3rd party commands to be sent during MULTI/EXEC session