### PR TITLE
Add unit tests for redis.clients.jedis.util.KeyMergeUtil

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/utils/KeyMergeUtilTest.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/KeyMergeUtilTest.java
@@ -1,0 +1,25 @@
+package redis.clients.jedis.tests.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import redis.clients.jedis.util.KeyMergeUtil;
+
+public class KeyMergeUtilTest {
+
+  @Test
+  public void mergeByteArray() {
+    byte[][] bytes = KeyMergeUtil.merge(new byte[] {3, 2, 1}, new byte[][] {{1, 2, 3}, {2, 4, 8}});
+
+    Assert.assertArrayEquals(new byte[] {3, 2, 1}, ((bytes)[0]));
+    Assert.assertArrayEquals(new byte[] {1, 2, 3}, ((bytes)[1]));
+    Assert.assertArrayEquals(new byte[] {2, 4, 8}, ((bytes)[2]));
+  }
+
+  @Test
+  public void mergeString() {
+    String[] strings = KeyMergeUtil.merge("1234", new String[] {"fooBar"});
+
+    Assert.assertEquals("1234", strings[0]);
+    Assert.assertEquals("fooBar", strings[1]);
+  }
+}


### PR DESCRIPTION
Hi,

I've analysed your code base and noticed that `redis.clients.jedis.util.KeyMergeUtil` in the `jedis` module is not fully tested.

I've written some tests that cover this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.