### PR TITLE
Bump commons-pool2 from 2.6.1 to 2.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-pool2</artifactId>
-			<version>2.6.1</version>
+			<version>2.6.2</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>


### PR DESCRIPTION
commons-pool2 2.6.2 contains a fix where the pool eviction thread is set to daemon, so that it does not prevent the JVM from shutting down.

See also: https://issues.apache.org/jira/browse/POOL-363
https://mail-archives.apache.org/mod_mbox/www-announce/201904.mbox/%3CCACZkXPz8VnVvhnFv-6R8KGYtFrx0Layn1n42CrPwNM+zMgebZg@mail.gmail.com%3E