### PR TITLE
trim dnComponent white spaces

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/SSLJedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/SSLJedisTest.java
@@ -318,6 +318,7 @@ public class SSLJedisTest {
       String subjectDN = peerCertificate.getSubjectDN().getName();
       String[] dnComponents = subjectDN.split(",");
       for (String dnComponent : dnComponents) {
+        dnComponent = dnComponent.trim();
         if (dnComponent.startsWith(COMMON_NAME_RDN_PREFIX)) {
           return dnComponent.substring(COMMON_NAME_RDN_PREFIX.length());
         }


### PR DESCRIPTION
In case the CN is not the first attribute the test fails, e.g.
```
DN=sdsa, CN=localhost
```