### PR TITLE
PipelineBase should not contain multi key operations

### DIFF
--- a/src/main/java/redis/clients/jedis/MultiKeyPipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiKeyPipelineBase.java
@@ -709,10 +709,14 @@ public abstract class MultiKeyPipelineBase extends PipelineBase implements
     return getResponse(BuilderFactory.STRING);
   }
 
-  @Override
-  public Response<Object> sendCommand(ProtocolCommand cmd, String... args){
+  public Response<Object> sendCommand(final ProtocolCommand cmd, final String... args) {
     client.sendCommand(cmd, args);
     return getResponse(BuilderFactory.OBJECT);
   }
-  
+
+  public Response<Object> sendCommand(final ProtocolCommand cmd, final byte[]... args) {
+    client.sendCommand(cmd, args);
+    return getResponse(BuilderFactory.OBJECT);
+  }
+
 }

--- a/src/main/java/redis/clients/jedis/PipelineBase.java
+++ b/src/main/java/redis/clients/jedis/PipelineBase.java
@@ -1975,15 +1975,13 @@ public abstract class PipelineBase extends Queable implements BinaryRedisPipelin
     return getResponse(BuilderFactory.BYTE_ARRAY_LIST);            
   }
 
-  public Response<Object> sendCommand(ProtocolCommand cmd, String... args){
-    String key = args.length > 0 ? args[0] : cmd.toString();
-    getClient(key).sendCommand(cmd, args);
+  public Response<Object> sendCommand(final String sampleKey, final ProtocolCommand cmd, final String... args) {
+    getClient(sampleKey).sendCommand(cmd, args);
     return getResponse(BuilderFactory.OBJECT);
   }
 
-  public Response<Object> sendCommand(ProtocolCommand cmd, byte[]... args){
-    byte[] key = args.length > 0 ? args[0] : cmd.getRaw();
-    getClient(key).sendCommand(cmd, args);
+  public Response<Object> sendCommand(final byte[] sampleKey, final ProtocolCommand cmd, final byte[]... args) {
+    getClient(sampleKey).sendCommand(cmd, args);
     return getResponse(BuilderFactory.OBJECT);
   }
 }


### PR DESCRIPTION
PipelineBase should not *look like* it contains multi key operations.

This is modification of #2007 and #2025 