### PR TITLE
Handle exceptions on close in JedisSentinelPool

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -237,8 +237,13 @@ public class JedisSentinelPool extends JedisPoolAbstract {
   @Override
   protected void returnResource(final Jedis resource) {
     if (resource != null) {
-      resource.resetState();
-      returnResourceObject(resource);
+      try {
+        resource.resetState();
+        returnResourceObject(resource);
+      } catch (Exception e) {
+        returnBrokenResource(resource);
+        throw new JedisException("Resource is returned to the pool as broken", e);
+      }
     }
   }
 


### PR DESCRIPTION
When returning a Jedis object to the pool, handle any exceptions and still return the connection to prevent deadlock.
This is similar to issue and fix for #791, but for the JedisSentinelPool.