### PR TITLE
Implement multi keys sendCommand for cluster

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -2251,4 +2251,13 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
       }
     }.runBinary(sampleKey);
   }
+
+  public Object sendCommand(final ProtocolCommand cmd, final byte[]... keys) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
+      @Override
+      public Object execute(Jedis connection) {
+        return connection.sendCommand(cmd, keys);
+      }
+    }.runBinary(keys.length, keys);
+  }
 }

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -2284,5 +2284,13 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
     }.run(sampleKey);
   }
 
+  public Object sendCommand(final ProtocolCommand cmd, final String... keys) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
+      @Override
+      public Object execute(Jedis connection) {
+        return connection.sendCommand(cmd, keys);
+      }
+    }.run(keys.length, keys);
+  }
 
 }


### PR DESCRIPTION
Implement multi keys sendCommand for Cluster, although single key command can pass multiple keys directly through `args`, like below:
```
public Object sendCommand(final String sampleKey, final ProtocolCommand cmd, final String... args) {
    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
      @Override
      public Object execute(Jedis connection){
        return connection.sendCommand(cmd, args);
      }
    }.run(sampleKey);
  }
```
user code：
```
jedisCluster.sendCommand(sampleKey1, cmd, sampleKey2, sampleKey3, sampleKey4...);
```
this will lack the detection of whether these keys are in the same slot, so I added this command.