### PR TITLE
Implementation in Jedis cluster, use slot to get HostAndPort

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -45,6 +45,10 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
     return cache.getNodes();
   }
 
+  public Map<Integer, JedisPool> getSlots() {
+    return cache.getSlots();
+  }
+
   private void initializeSlotsCache(Set<HostAndPort> startNodes,
       int connectionTimeout, int soTimeout, String password, String clientName,
       boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters, HostnameVerifier hostnameVerifier) {

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -246,6 +246,15 @@ public class JedisClusterInfoCache {
     }
   }
 
+  public Map<Integer, JedisPool> getSlots() {
+    r.lock();
+    try {
+      return new HashMap<Integer, JedisPool>(slots);
+    } finally {
+      r.unlock();
+    }
+  }
+
   public List<JedisPool> getShuffledNodesPool() {
     r.lock();
     try {

--- a/src/main/java/redis/clients/jedis/JedisFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisFactory.java
@@ -18,7 +18,7 @@ import redis.clients.jedis.util.JedisURIHelper;
 /**
  * PoolableObjectFactory custom impl.
  */
-class JedisFactory implements PooledObjectFactory<Jedis> {
+public class JedisFactory implements PooledObjectFactory<Jedis> {
   private final AtomicReference<HostAndPort> hostAndPort = new AtomicReference<HostAndPort>();
   private final int connectionTimeout;
   private final int soTimeout;
@@ -79,6 +79,10 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
 
   public void setHostAndPort(final HostAndPort hostAndPort) {
     this.hostAndPort.set(hostAndPort);
+  }
+
+  public AtomicReference<HostAndPort> getHostAndPort() {
+    return hostAndPort;
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/util/Pool.java
+++ b/src/main/java/redis/clients/jedis/util/Pool.java
@@ -12,7 +12,7 @@ import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.exceptions.JedisExhaustedPoolException;
 
 public abstract class Pool<T> implements Closeable {
-  protected GenericObjectPool<T> internalPool;
+  public GenericObjectPool<T> internalPool;
 
   /**
    * Using this constructor means you have to set and initialize the internalPool yourself.


### PR DESCRIPTION
I am implementing the mset/mget command across slots in the redis cluster(JedisCluster for multiple keys, only execute if they all share the same connection slot).

I've tried to merge and forward by slot, but in the case of a small number of machines, there are too many slots on each machine (for example, 3 machines, 16384 / 3 ≈ 5460), so the efficiency of dividing keys by slot is too poor, so I need to divide them by IP:PORT.

But I can't get IP:PORT information according to key or slot, It is recorded in `redis.clients.jedis.JedisClusterInfoCache#slots`, so, I submit this PR.

```
import redis.clients.jedis.HostAndPort;
import redis.clients.jedis.JedisCluster;
import redis.clients.jedis.JedisFactory;

public class MyCluster extends JedisCluster {
    public MyCluster(HostAndPort node) {
        super(node);
    }

    public HostAndPort getHostAndPortFormSlot() {
        int slot = 1;
        return ((JedisFactory)connectionHandler.getSlots().get(slot).internalPool.getFactory())
            .getHostAndPort().get();
    }
}
```

@sazzad16  @gkorland Please review when you have time, I would appreciate any suggestions.