### PR TITLE
#2119 Implements GeoRadiusParam.withHash()

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -424,7 +424,7 @@ public final class BuilderFactory {
                   DOUBLE.build(coord.get(1))));
             } else if (info instanceof Long) {
               // score
-              resp.setScore(LONG.build(info));
+              resp.setRawScore(LONG.build(info));
             } else {
               // distance
               resp.setDistance(DOUBLE.build(info));

--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -418,10 +418,13 @@ public final class BuilderFactory {
             Object info = informations.get(idx);
             if (info instanceof List<?>) {
               // coordinate
-              List<Object> coord = (List<Object>) info;
+              List<Object> coord = (List<Object>)info;
 
               resp.setCoordinate(new GeoCoordinate(DOUBLE.build(coord.get(0)),
                   DOUBLE.build(coord.get(1))));
+            } else if (info instanceof Long) {
+              // score
+              resp.setScore(LONG.build(info));
             } else {
               // distance
               resp.setDistance(DOUBLE.build(info));

--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -418,7 +418,7 @@ public final class BuilderFactory {
             Object info = informations.get(idx);
             if (info instanceof List<?>) {
               // coordinate
-              List<Object> coord = (List<Object>)info;
+              List<Object> coord = (List<Object>) info;
 
               resp.setCoordinate(new GeoCoordinate(DOUBLE.build(coord.get(0)),
                   DOUBLE.build(coord.get(1))));

--- a/src/main/java/redis/clients/jedis/GeoRadiusResponse.java
+++ b/src/main/java/redis/clients/jedis/GeoRadiusResponse.java
@@ -6,7 +6,7 @@ public class GeoRadiusResponse {
   private byte[] member;
   private double distance;
   private GeoCoordinate coordinate;
-  private long score;
+  private long rawScore;
 
   public GeoRadiusResponse(byte[] member) {
     this.member = member;
@@ -36,11 +36,11 @@ public class GeoRadiusResponse {
     return coordinate;
   }
 
-  public long getScore() {
-    return score;
+  public long getRawScore() {
+    return rawScore;
   }
 
-  public void setScore(long score) {
-    this.score = score;
+  public void setRawScore(long rawScore) {
+    this.rawScore = rawScore;
   }
 }

--- a/src/main/java/redis/clients/jedis/GeoRadiusResponse.java
+++ b/src/main/java/redis/clients/jedis/GeoRadiusResponse.java
@@ -6,6 +6,7 @@ public class GeoRadiusResponse {
   private byte[] member;
   private double distance;
   private GeoCoordinate coordinate;
+  private long score;
 
   public GeoRadiusResponse(byte[] member) {
     this.member = member;
@@ -33,5 +34,13 @@ public class GeoRadiusResponse {
 
   public GeoCoordinate getCoordinate() {
     return coordinate;
+  }
+
+  public long getScore() {
+    return score;
+  }
+
+  public void setScore(long score) {
+    this.score = score;
   }
 }

--- a/src/main/java/redis/clients/jedis/params/GeoRadiusParam.java
+++ b/src/main/java/redis/clients/jedis/params/GeoRadiusParam.java
@@ -8,9 +8,7 @@ import java.util.ArrayList;
 public class GeoRadiusParam extends Params {
   private static final String WITHCOORD = "withcoord";
   private static final String WITHDIST = "withdist";
-
-  // Do not add WITHHASH since we can't classify result of WITHHASH and WITHDIST,
-  // and WITHHASH is for debugging purposes
+  private static final String WITHHASH = "withhash";
 
   private static final String ASC = "asc";
   private static final String DESC = "desc";
@@ -30,6 +28,11 @@ public class GeoRadiusParam extends Params {
 
   public GeoRadiusParam withDist() {
     addParam(WITHDIST);
+    return this;
+  }
+
+  public GeoRadiusParam withHash() {
+    addParam(WITHHASH);
     return this;
   }
 
@@ -61,6 +64,9 @@ public class GeoRadiusParam extends Params {
     }
     if (contains(WITHDIST)) {
       byteParams.add(SafeEncoder.encode(WITHDIST));
+    }
+    if (contains(WITHHASH)) {
+      byteParams.add(SafeEncoder.encode(WITHHASH));
     }
 
     if (contains(COUNT)) {

--- a/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
@@ -155,14 +155,14 @@ public class GeoCommandsTest extends JedisCommandTestBase {
     assertTrue(equalsWithinEpsilon(56.4413, response.getDistance()));
     assertTrue(equalsWithinEpsilon(15.087269, response.getCoordinate().getLongitude()));
     assertTrue(equalsWithinEpsilon(37.502669, response.getCoordinate().getLatitude()));
-    assertEquals(3479447370796909L, response.getScore());
+    assertEquals(3479447370796909L, response.getRawScore());
 
     // sort, count 1, with hash
     members = jedis.georadius("Sicily", 15, 37, 200, GeoUnit.KM, GeoRadiusParam.geoRadiusParam()
         .sortAscending().count(1).withHash());
     assertEquals(1, members.size());
     response = members.get(0);
-    assertEquals(3479447370796909L, response.getScore());
+    assertEquals(3479447370796909L, response.getRawScore());
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
@@ -162,7 +162,7 @@ public class GeoCommandsTest extends JedisCommandTestBase {
         .sortAscending().count(1).withHash());
     assertEquals(1, members.size());
     response = members.get(0);
-    assertEquals("3479447370796909", Long.toString(response.getScore()));
+    assertEquals(3479447370796909L, response.getScore());
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
@@ -155,7 +155,7 @@ public class GeoCommandsTest extends JedisCommandTestBase {
     assertTrue(equalsWithinEpsilon(56.4413, response.getDistance()));
     assertTrue(equalsWithinEpsilon(15.087269, response.getCoordinate().getLongitude()));
     assertTrue(equalsWithinEpsilon(37.502669, response.getCoordinate().getLatitude()));
-    assertEquals("3479447370796909", Long.toString(response.getScore()));
+    assertEquals(3479447370796909L, response.getScore());
 
     // sort, count 1, with hash
     members = jedis.georadius("Sicily", 15, 37, 200, GeoUnit.KM, GeoRadiusParam.geoRadiusParam()

--- a/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
@@ -149,12 +149,20 @@ public class GeoCommandsTest extends JedisCommandTestBase {
 
     // sort, count 1, withdist, withcoord
     members = jedis.georadius("Sicily", 15, 37, 200, GeoUnit.KM, GeoRadiusParam.geoRadiusParam()
-        .sortAscending().count(1).withCoord().withDist());
+        .sortAscending().count(1).withCoord().withDist().withHash());
     assertEquals(1, members.size());
     GeoRadiusResponse response = members.get(0);
     assertTrue(equalsWithinEpsilon(56.4413, response.getDistance()));
     assertTrue(equalsWithinEpsilon(15.087269, response.getCoordinate().getLongitude()));
     assertTrue(equalsWithinEpsilon(37.502669, response.getCoordinate().getLatitude()));
+    assertEquals("3479447370796909", Long.toString(response.getScore()));
+
+    // sort, count 1, with hash
+    members = jedis.georadius("Sicily", 15, 37, 200, GeoUnit.KM, GeoRadiusParam.geoRadiusParam()
+        .sortAscending().count(1).withHash());
+    assertEquals(1, members.size());
+    response = members.get(0);
+    assertEquals("3479447370796909", Long.toString(response.getScore()));
   }
 
   @Test


### PR DESCRIPTION
Implements `GeoRadiusParam.withHash()`, Redis [source](https://github.com/antirez/redis/blob/unstable/src/geo.c#L624) `addReplyLongLong(c, gp->score);`, so the score type is long.