### PR TITLE
Fix broken spop with count test

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/commands/SetCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/SetCommandsTest.java
@@ -162,7 +162,7 @@ public class SetCommandsTest extends JedisCommandTestBase {
     assertEquals(1, members.size());
     assertEquals(superSet, members);
 
-    assertNull(jedis.spop("foo", 2));
+    assertTrue(jedis.spop("foo", 2).isEmpty());
 
     // Binary
     jedis.sadd(bfoo, ba);
@@ -184,7 +184,7 @@ public class SetCommandsTest extends JedisCommandTestBase {
     assertEquals(1, bmembers.size());
     assertByteArraySetEquals(bsuperSet, bmembers);
 
-    assertNull(jedis.spop(bfoo, 2));
+    assertTrue(jedis.spop(bfoo, 2).isEmpty());
   }
 
   @Test


### PR DESCRIPTION
- According to redis specifications, a list/set response will always be an empty list/set instead of nil
- Tested on CLI:

```
$ redis-cli
127.0.0.1:6379> flushall
OK
127.0.0.1:6379> spop a
(nil)
127.0.0.1:6379> spop a 2
(empty list or set)
```