### PR TITLE
[Ehancement]Try run again after renew the redis cluster slot cache

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -112,13 +112,15 @@ public abstract class JedisClusterCommand<T> {
       releaseConnection(connection);
       connection = null;
 
-      if (attempts <= 1) {
+      if (attempts == 2) {
         //We need this because if node is not reachable anymore - we need to finally initiate slots
         //renewing, or we can stuck with cluster state without one node in opposite case.
         //But now if maxAttempts = [1 or 2] we will do it too often.
         //TODO make tracking of successful/unsuccessful operations for node - do renewing only
         //if there were no successful responses from this node last few seconds
         this.connectionHandler.renewSlotCache();
+        //try again after renew the slot cache
+        return runWithRetries(slot, attempts - 1, tryRandomNode, redirect);
       }
 
       return runWithRetries(slot, attempts - 1, tryRandomNode, redirect);


### PR DESCRIPTION
Consider such a scenario in redis cluster, one master node down and the replica node promote to master, which means the cluster topological changed. So the request to the previous master node will fail and retry. But in this scenario, retry will never success.
Currently, Jedis will renew the slots cache in the last retry, then just throws  a `JedisClusterMaxAttemptsException`, so this request get failed.
I think it's better to give a chance to retry run command after renew the cluster's slots cache, so I add this logic: in the second last retry, renew slots cache, then run last retry.