### PR TITLE
Add args checkNull for sendCommand

### DIFF
--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -85,8 +85,17 @@ public final class Protocol {
     sendCommand(os, command.getRaw(), args);
   }
 
+  private static void checkArgsIsNull(final byte[]... args) {
+    for (byte[] arg : args) {
+      if (arg == null) {
+        throw new JedisDataException("value sent to redis cannot be null");
+      }
+    }
+  }
+
   private static void sendCommand(final RedisOutputStream os, final byte[] command,
       final byte[]... args) {
+    checkArgsIsNull(args);
     try {
       os.write(ASTERISK_BYTE);
       os.writeIntCrLf(args.length + 1);


### PR DESCRIPTION
Hi, 
This PR check if the args of `sendCommand` is null. In the following cases, protocol errors will be caused.

```
Jedis jedis = new Jedis("127.0.0.1", 6379);

try {
      jedis.set("key".getBytes(), null);
  } catch (Exception e) {
      // will catch NullPointerException
  }

jedis.get("key");  // cause ERR Protocol error: invalid bulk length
```
will get:
```
Exception in thread "main" redis.clients.jedis.exceptions.JedisDataException: ERR Protocol error: invalid bulk length
	at redis.clients.jedis.Protocol.processError(Protocol.java:132)
	at redis.clients.jedis.Protocol.process(Protocol.java:166)
	at redis.clients.jedis.Protocol.read(Protocol.java:220)
	at redis.clients.jedis.Connection.readProtocolWithCheckingBroken(Connection.java:278)
	at redis.clients.jedis.Connection.getBinaryBulkReply(Connection.java:215)
	at redis.clients.jedis.Connection.getBulkReply(Connection.java:205)
	at redis.clients.jedis.Jedis.get(Jedis.java:185)
	at redis.clients.jedis.tests.fanche.JedisTest.main(JedisTest.java:21)
```
Because jedis has cached part of the previous data to `redis.clients.jedis . util.RedisOutputStream#buf`, the `get` command sent it to the server, resulting in an error.

I think it is necessary to detect null. If you have better suggestions, please let me know.