### PR TITLE
fix #2243 return null when redis returns nil on deleted entries

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -574,6 +574,10 @@ public final class BuilderFactory {
       }
 
       for(ArrayList<Object> res : objectList) {
+        if(res == null) {
+          responses.add(null);
+          continue;
+        }
         String entryIdString = SafeEncoder.encode((byte[])res.get(0));
         StreamEntryID entryID = new StreamEntryID(entryIdString);
         List<byte[]> hash = (List<byte[]>)res.get(1);


### PR DESCRIPTION
1. Return `null` when Redis returns `nil` on deleted Entries in XCLAIM
2. Improve the xpending and xclaim tests