### PR TITLE
fix(transaction): connections not returned to pool after exec() or discard() in JedisPooled

### DIFF
--- a/src/main/java/redis/clients/jedis/Transaction.java
+++ b/src/main/java/redis/clients/jedis/Transaction.java
@@ -214,6 +214,7 @@ public class Transaction extends TransactionBase {
       if (jedis != null) {
         jedis.resetState();
       }
+      close();
     }
   }
 
@@ -241,6 +242,7 @@ public class Transaction extends TransactionBase {
       if (jedis != null) {
         jedis.resetState();
       }
+      close();
     }
   }
 }


### PR DESCRIPTION
When using JedisPooled.multi(), the returned Transaction object borrows a connection from the pool. However, the connection would not be released after exec() or discard() was called. Over time, this led to connection exhaustion and blocked threads.

This change ensures that the connection is returned to the pool automatically by calling close() at the end of exec() and discard().