### PR TITLE
Fix client-side caching for non-Serializable objects

### DIFF
--- a/src/main/java/redis/clients/jedis/csc/CacheEntry.java
+++ b/src/main/java/redis/clients/jedis/csc/CacheEntry.java
@@ -36,6 +36,12 @@ public class CacheEntry<T> {
   private static byte[] toBytes(Object object) {
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+
+      if (!(object instanceof java.io.Serializable)) {
+        // Fallback: store as string
+        object = object.toString();
+      }
+      
       oos.writeObject(object);
       oos.flush();
       oos.close();

--- a/src/test/java/redis/clients/jedis/csc/CacheEntryTest.java
+++ b/src/test/java/redis/clients/jedis/csc/CacheEntryTest.java
@@ -1,0 +1,50 @@
+package redis.clients.jedis.csc;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.CommandObject;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CacheEntryTest {
+    @Test
+    public void testJsonObjectCaching() {
+        JSONObject json = new JSONObject();
+        json.put("foo", "bar");
+
+        CommandObject<JSONObject> command = mock(CommandObject.class);
+        CacheKey<JSONObject> key = new CacheKey<>(command);
+
+        // Mock CacheConnection instead of creating a real one
+        CacheConnection conn = mock(CacheConnection.class);
+
+        CacheEntry<JSONObject> entry = new CacheEntry<>(key, json, conn);
+        Object value = entry.getValue();
+
+        // JSONObject is not Serializable → should fallback to String
+        assertTrue(value instanceof String);
+        assertEquals("{\"foo\":\"bar\"}", value.toString());
+    }
+
+    @Test
+    public void testSerializableObjectCaching() {
+        // Prepare a normal Serializable object
+        String str = "Hello Jedis!";
+
+        CommandObject<String> command = mock(CommandObject.class);
+        CacheKey<String> key = new CacheKey<>(command);
+
+        CacheConnection conn = mock(CacheConnection.class);
+
+        CacheEntry<String> entry = new CacheEntry<>(key, str, conn);
+        Object value = entry.getValue();
+
+        // Serializable object should remain intact
+        assertTrue(value instanceof String);
+        assertEquals(str, value);
+
+        // Check getters
+        assertEquals(key, entry.getCacheKey());
+        assertEquals(conn, entry.getConnection());
+    }
+}


### PR DESCRIPTION
Fix client-side caching for non-Serializable objects (e.g., JSONObject)

## Problem:
When using client-side caching (CacheEntry) with JSONObject returned from JSON commands (jsonGet), the cache threw a JedisCacheException. This happened because JSONObject does not implement Serializable, so the original CacheEntry tried to serialize it to bytes using ObjectOutputStream, which failed.

Issue #4279

## Solution:

Added logic in CacheEntry to fallback to storing a String when the object is not Serializable.

## Updated unit tests to cover:

- JSONObject (non-Serializable) → stored as String.
- Serializable objects (e.g., String) → stored as-is.
- `getCacheKey()` and `getConnection()` behaviors.

## Benefits:

Fixes caching for JSON commands without breaking existing Serializable objects.
Ensures client-side cache works smoothly for all object types.

## Testing:

### Unit tests added in CacheEntryTest.java:

- `testJsonObjectCaching() ` → verifies fallback for JSONObject.
- `testSerializableObjectCaching()` → verifies normal Serializable objects.