### PR TITLE
 [automatic failover] Automatic failover client improvements (part 2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,8 @@
 						<include>**/mcf/MultiCluster*</include>
 						<include>**/mcf/StatusTracker*</include>
 						<include>**/Health*.java</include>
+						<include>**/*IT.java</include>
+						<include>**/scenario/RestEndpointUtil.java</include>
 						<include>src/main/java/redis/clients/jedis/MultiClusterClientConfig.java</include>
 						<include>src/main/java/redis/clients/jedis/HostAndPort.java</include>
 					</includes>

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -267,7 +267,7 @@ public class Connection implements Closeable {
     if (!isConnected()) {
       try {
         socket = socketFactory.createSocket();
-        soTimeout = socket.getSoTimeout(); //?
+        soTimeout = socket.getSoTimeout(); // ?
 
         outputStream = new RedisOutputStream(socket.getOutputStream());
         inputStream = new RedisInputStream(socket.getInputStream());
@@ -326,6 +326,10 @@ public class Connection implements Closeable {
   }
 
   public void forceDisconnect() throws IOException {
+    // setBroken() must be called first here,
+    // otherwise a concurrent close attempt would call 'returnResource' (instead of
+    // 'returnBrokenResource'),
+    // assuming it's an open/healthy connection whereas this individual socket is already closed.
     setBroken();
     IOUtils.closeQuietly(socket);
   }
@@ -476,7 +480,6 @@ public class Connection implements Closeable {
 
   /**
    * Check if the client name libname, libver, characters are legal
-   *
    * @param info the name
    * @return Returns true if legal, false throws exception
    * @throws JedisException if characters illegal

--- a/src/main/java/redis/clients/jedis/MultiClusterClientConfig.java
+++ b/src/main/java/redis/clients/jedis/MultiClusterClientConfig.java
@@ -161,6 +161,12 @@ public final class MultiClusterClientConfig {
   /** Default grace period in milliseconds to keep clusters disabled after they become unhealthy. */
   private static final long GRACE_PERIOD_DEFAULT = 10000;
 
+  /** Default maximum number of failover attempts. */
+  private static final int MAX_NUM_FAILOVER_ATTEMPTS_DEFAULT = 10;
+
+  /** Default delay in milliseconds between failover attempts. */
+  private static final int DELAY_IN_BETWEEN_FAILOVER_ATTEMPTS_DEFAULT = 12000;
+
   /** Array of cluster configurations defining the available Redis endpoints and their settings. */
   private final ClusterConfig[] clusterConfigs;
 
@@ -486,6 +492,34 @@ public final class MultiClusterClientConfig {
   private boolean fastFailover;
 
   /**
+   * Maximum number of failover attempts.
+   * <p>
+   * This setting controls how many times the system will attempt to failover to a different cluster
+   * before giving up. For example, if set to 3, the system will make 1 initial attempt plus 2
+   * failover attempts for a total of 3 attempts.
+   * </p>
+   * <p>
+   * <strong>Default:</strong> {@value #MAX_NUM_FAILOVER_ATTEMPTS_DEFAULT}
+   * </p>
+   * @see #getMaxNumFailoverAttempts()
+   */
+  private int maxNumFailoverAttempts;
+
+  /**
+   * Delay in milliseconds between failover attempts.
+   * <p>
+   * This setting controls how long the system will wait before attempting to failover to a
+   * different cluster. For example, if set to 1000, the system will wait 1 second before attempting
+   * to failover to a different cluster.
+   * </p>
+   * <p>
+   * <strong>Default:</strong> {@value #DELAY_IN_BETWEEN_FAILOVER_ATTEMPTS_DEFAULT} milliseconds
+   * </p>
+   * @see #getDelayInBetweenFailoverAttempts()
+   */
+  private int delayInBetweenFailoverAttempts;
+
+  /**
    * Constructs a new MultiClusterClientConfig with the specified cluster configurations.
    * <p>
    * This constructor validates that at least one cluster configuration is provided and that all
@@ -677,6 +711,25 @@ public final class MultiClusterClientConfig {
    */
   public long getGracePeriod() {
     return gracePeriod;
+  }
+
+  /**
+   * Returns the maximum number of failover attempts.
+   * @return maximum number of failover attempts
+   * @see #maxNumFailoverAttempts
+   */
+  public int getMaxNumFailoverAttempts() {
+    return maxNumFailoverAttempts;
+
+  }
+
+  /**
+   * Returns the delay in milliseconds between failover attempts.
+   * @return delay in milliseconds between failover attempts
+   * @see #delayInBetweenFailoverAttempts
+   */
+  public int getDelayInBetweenFailoverAttempts() {
+    return delayInBetweenFailoverAttempts;
   }
 
   /**
@@ -1089,6 +1142,12 @@ public final class MultiClusterClientConfig {
 
     /** Whether to forcefully terminate connections during failover. */
     private boolean fastFailover = false;
+
+    /** Maximum number of failover attempts. */
+    private int maxNumFailoverAttempts = MAX_NUM_FAILOVER_ATTEMPTS_DEFAULT;
+
+    /** Delay in milliseconds between failover attempts. */
+    private int delayInBetweenFailoverAttempts = DELAY_IN_BETWEEN_FAILOVER_ATTEMPTS_DEFAULT;
 
     /**
      * Constructs a new Builder with the specified cluster configurations.
@@ -1540,6 +1599,42 @@ public final class MultiClusterClientConfig {
     }
 
     /**
+     * Sets the maximum number of failover attempts.
+     * <p>
+     * This setting controls how many times the system will attempt to failover to a different
+     * cluster before giving up. For example, if set to 3, the system will make 1 initial attempt
+     * plus 2 failover attempts for a total of 3 attempts.
+     * </p>
+     * <p>
+     * <strong>Default:</strong> {@value #MAX_NUM_FAILOVER_ATTEMPTS_DEFAULT}
+     * </p>
+     * @param maxNumFailoverAttempts maximum number of failover attempts
+     * @return this builder instance for method chaining
+     */
+    public Builder maxNumFailoverAttempts(int maxNumFailoverAttempts) {
+      this.maxNumFailoverAttempts = maxNumFailoverAttempts;
+      return this;
+    }
+
+    /**
+     * Sets the delay in milliseconds between failover attempts.
+     * <p>
+     * This setting controls how long the system will wait before attempting to failover to a
+     * different cluster. For example, if set to 1000, the system will wait 1 second before
+     * attempting to failover to a different cluster.
+     * </p>
+     * <p>
+     * <strong>Default:</strong> {@value #DELAY_IN_BETWEEN_FAILOVER_ATTEMPTS_DEFAULT} milliseconds
+     * </p>
+     * @param delayInBetweenFailoverAttempts delay in milliseconds between failover attempts
+     * @return this builder instance for method chaining
+     */
+    public Builder delayInBetweenFailoverAttempts(int delayInBetweenFailoverAttempts) {
+      this.delayInBetweenFailoverAttempts = delayInBetweenFailoverAttempts;
+      return this;
+    }
+
+    /**
      * Builds and returns a new MultiClusterClientConfig instance with all configured settings.
      * <p>
      * This method creates the final configuration object by copying all builder settings to the
@@ -1576,6 +1671,8 @@ public final class MultiClusterClientConfig {
       config.failbackCheckInterval = this.failbackCheckInterval;
       config.gracePeriod = this.gracePeriod;
       config.fastFailover = this.fastFailover;
+      config.maxNumFailoverAttempts = this.maxNumFailoverAttempts;
+      config.delayInBetweenFailoverAttempts = this.delayInBetweenFailoverAttempts;
 
       return config;
     }

--- a/src/main/java/redis/clients/jedis/MultiClusterClientConfig.java
+++ b/src/main/java/redis/clients/jedis/MultiClusterClientConfig.java
@@ -1460,7 +1460,7 @@ public final class MultiClusterClientConfig {
      * <ul>
      * <li>Health checks must be enabled on cluster configurations</li>
      * <li>Grace period must elapse after cluster becomes unhealthy</li>
-     * <li>Higher-priority cluster must pass consecutive health checks</li>
+     * <li>Higher-priority cluster must pass health checks</li>
      * </ul>
      * @param supported true to enable automatic failback, false for manual failback only
      * @return this builder instance for method chaining

--- a/src/main/java/redis/clients/jedis/MultiClusterClientConfig.java
+++ b/src/main/java/redis/clients/jedis/MultiClusterClientConfig.java
@@ -22,8 +22,8 @@ import redis.clients.jedis.mcf.HealthCheckStrategy;
  * This configuration enables seamless failover between multiple Redis clusters, databases, or
  * endpoints by providing comprehensive settings for retry logic, circuit breaker behavior, health
  * checks, and failback mechanisms. It is designed to work with
- * {@link redis.clients.jedis.providers.MultiClusterPooledConnectionProvider} to provide high
- * availability and disaster recovery capabilities.
+ * {@link redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider} to provide high availability
+ * and disaster recovery capabilities.
  * </p>
  * <p>
  * <strong>Key Features:</strong>
@@ -70,7 +70,7 @@ import redis.clients.jedis.mcf.HealthCheckStrategy;
  * The configuration leverages <a href="https://resilience4j.readme.io/docs">Resilience4j</a> for
  * circuit breaker and retry implementations, providing battle-tested fault tolerance patterns.
  * </p>
- * @see redis.clients.jedis.providers.MultiClusterPooledConnectionProvider
+ * @see redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider
  * @see redis.clients.jedis.mcf.HealthCheckStrategy
  * @see redis.clients.jedis.mcf.EchoStrategy
  * @see redis.clients.jedis.mcf.LagAwareStrategy

--- a/src/main/java/redis/clients/jedis/SslOptions.java
+++ b/src/main/java/redis/clients/jedis/SslOptions.java
@@ -343,7 +343,7 @@ public class SslOptions {
 
         if (keystoreResource != null) {
 
-            KeyStore keyStore = KeyStore.getInstance(keyStoreType);
+            KeyStore keyStore = KeyStore.getInstance(keyStoreType==null ? KeyStore.getDefaultType() : keyStoreType);
             try (InputStream keystoreStream = keystoreResource.get()) {
                 keyStore.load(keystoreStream, keystorePassword);
             }
@@ -355,7 +355,8 @@ public class SslOptions {
 
         if (trustManagers == null && truststoreResource != null) {
 
-            KeyStore trustStore = KeyStore.getInstance(trustStoreType);
+
+            KeyStore trustStore = KeyStore.getInstance(trustStoreType == null ? KeyStore.getDefaultType() : trustStoreType);
             try (InputStream truststoreStream = truststoreResource.get()) {
                 trustStore.load(truststoreStream, truststorePassword);
             }
@@ -377,6 +378,15 @@ public class SslOptions {
      */
     public SSLParameters getSslParameters() {
         return sslParameters;
+    }
+
+
+    /**
+     * Configured ssl verify mode.
+     * @return {@link SslVerifyMode}
+     */
+    public SslVerifyMode getSslVerifyMode() {
+        return sslVerifyMode;
     }
 
     private static char[] getPassword(char[] chars) {

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -34,6 +34,7 @@ import redis.clients.jedis.resps.RawVector;
 import redis.clients.jedis.json.JsonObjectMapper;
 import redis.clients.jedis.mcf.CircuitBreakerCommandExecutor;
 import redis.clients.jedis.mcf.MultiClusterPipeline;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider;
 import redis.clients.jedis.mcf.MultiClusterTransaction;
 import redis.clients.jedis.params.*;
 import redis.clients.jedis.providers.*;

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerCommandExecutor.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerCommandExecutor.java
@@ -7,6 +7,7 @@ import io.github.resilience4j.decorators.Decorators.DecorateSupplier;
 import redis.clients.jedis.CommandObject;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.annots.Experimental;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.executors.CommandExecutor;
 import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider.Cluster;
 
@@ -46,7 +47,14 @@ public class CircuitBreakerCommandExecutor extends CircuitBreakerFailoverBase
    * Functional interface wrapped in retry and circuit breaker logic to handle happy path scenarios
    */
   private <T> T handleExecuteCommand(CommandObject<T> commandObject, Cluster cluster) {
-    try (Connection connection = cluster.getConnection()) {
+    Connection connection;
+    try {
+      connection = cluster.getConnection();
+    } catch (JedisConnectionException e) {
+      provider.assertOperability();
+      throw e;
+    }
+    try {
       return connection.executeCommand(commandObject);
     } catch (Exception e) {
       if (cluster.retryOnFailover() && !isActiveCluster(cluster)
@@ -56,6 +64,8 @@ public class CircuitBreakerCommandExecutor extends CircuitBreakerFailoverBase
       }
 
       throw e;
+    } finally {
+      connection.close();
     }
   }
 

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerCommandExecutor.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerCommandExecutor.java
@@ -38,7 +38,7 @@ public class CircuitBreakerCommandExecutor extends CircuitBreakerFailoverBase
     supplier.withCircuitBreaker(cluster.getCircuitBreaker());
     supplier.withRetry(cluster.getRetry());
     supplier.withFallback(provider.getFallbackExceptionList(),
-      e -> this.handleClusterFailover(commandObject, cluster.getCircuitBreaker()));
+      e -> this.handleClusterFailover(commandObject, cluster));
 
     return supplier.decorate().get();
   }
@@ -73,10 +73,9 @@ public class CircuitBreakerCommandExecutor extends CircuitBreakerFailoverBase
    * Functional interface wrapped in retry and circuit breaker logic to handle open circuit breaker
    * failure scenarios
    */
-  private <T> T handleClusterFailover(CommandObject<T> commandObject,
-      CircuitBreaker circuitBreaker) {
+  private <T> T handleClusterFailover(CommandObject<T> commandObject, Cluster cluster) {
 
-    clusterFailover(circuitBreaker);
+    clusterFailover(cluster);
 
     // Recursive call to the initiating method so the operation can be retried on the next cluster
     // connection

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerCommandExecutor.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerCommandExecutor.java
@@ -8,8 +8,7 @@ import redis.clients.jedis.CommandObject;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.annots.Experimental;
 import redis.clients.jedis.executors.CommandExecutor;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider.Cluster;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider.Cluster;
 
 /**
  * @author Allen Terleto (aterleto)

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverBase.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverBase.java
@@ -38,9 +38,10 @@ public class CircuitBreakerFailoverBase implements AutoCloseable {
    * Functional interface wrapped in retry and circuit breaker logic to handle open circuit breaker
    * failure scenarios
    */
-  protected void clusterFailover(CircuitBreaker circuitBreaker) {
+  protected void clusterFailover(Cluster cluster) {
     lock.lock();
 
+    CircuitBreaker circuitBreaker = cluster.getCircuitBreaker();
     try {
       // Check state to handle race conditions since iterateActiveCluster() is
       // non-idempotent
@@ -52,19 +53,17 @@ public class CircuitBreakerFailoverBase implements AutoCloseable {
 
         Cluster activeCluster = provider.getCluster();
         // This should be possible only if active cluster is switched from by other reasons than
-        // circuit
-        // breaker, just before circuit breaker triggers
-        if (activeCluster.getCircuitBreaker() != circuitBreaker) {
+        // circuit breaker, just before circuit breaker triggers
+        if (activeCluster != cluster) {
           return;
         }
 
-        activeCluster.setGracePeriod();
+        cluster.setGracePeriod();
         circuitBreaker.transitionToForcedOpenState();
 
         // Iterating the active cluster will allow subsequent calls to the executeCommand() to use
         // the next
         // cluster's connection pool - according to the configuration's prioritization/order/weight
-        // int activeMultiClusterIndex = provider.incrementActiveMultiClusterIndex1();
         provider.iterateActiveCluster(SwitchReason.CIRCUIT_BREAKER);
       }
       // this check relies on the fact that many failover attempts can hit with the same CB,
@@ -73,13 +72,12 @@ public class CircuitBreakerFailoverBase implements AutoCloseable {
       // different than
       // active CB. If its the same one and there are no more clusters to failover to, then throw an
       // exception
-      else if (circuitBreaker == provider.getCluster().getCircuitBreaker()
-          && !provider.canIterateOnceMore()) {
-            throw new JedisConnectionException(
-                "Cluster/database endpoint could not failover since the MultiClusterClientConfig was not "
-                    + "provided with an additional cluster/database endpoint according to its prioritized sequence. "
-                    + "If applicable, consider failing back OR restarting with an available cluster/database endpoint");
-          }
+      else if (cluster == provider.getCluster() && !provider.canIterateOnceMore()) {
+        throw new JedisConnectionException(
+            "Cluster/database endpoint could not failover since the MultiClusterClientConfig was not "
+                + "provided with an additional cluster/database endpoint according to its prioritized sequence. "
+                + "If applicable, consider failing back OR restarting with an available cluster/database endpoint");
+      }
       // Ignore exceptions since we are already in a failure state
     } finally {
       lock.unlock();

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverBase.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverBase.java
@@ -5,8 +5,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import redis.clients.jedis.annots.Experimental;
 import redis.clients.jedis.exceptions.JedisConnectionException;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider.Cluster;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider.Cluster;
 import redis.clients.jedis.util.IOUtils;
 
 /**

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverBase.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverBase.java
@@ -63,7 +63,7 @@ public class CircuitBreakerFailoverBase implements AutoCloseable {
         // Iterating the active cluster will allow subsequent calls to the executeCommand() to use
         // the next
         // cluster's connection pool - according to the configuration's prioritization/order/weight
-        provider.iterateActiveCluster(SwitchReason.CIRCUIT_BREAKER);
+        provider.switchToHealthyCluster(SwitchReason.CIRCUIT_BREAKER, cluster);
       }
       // this check relies on the fact that many failover attempts can hit with the same CB,
       // only the first one will trigger a failover, and make the CB FORCED_OPEN.
@@ -71,11 +71,8 @@ public class CircuitBreakerFailoverBase implements AutoCloseable {
       // different than
       // active CB. If its the same one and there are no more clusters to failover to, then throw an
       // exception
-      else if (cluster == provider.getCluster() && !provider.canIterateOnceMore()) {
-        throw new JedisConnectionException(
-            "Cluster/database endpoint could not failover since the MultiClusterClientConfig was not "
-                + "provided with an additional cluster/database endpoint according to its prioritized sequence. "
-                + "If applicable, consider failing back OR restarting with an available cluster/database endpoint");
+      else if (cluster == provider.getCluster()) {
+        provider.switchToHealthyCluster(SwitchReason.CIRCUIT_BREAKER, cluster);
       }
       // Ignore exceptions since we are already in a failure state
     } finally {

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverConnectionProvider.java
@@ -31,7 +31,7 @@ public class CircuitBreakerFailoverConnectionProvider extends CircuitBreakerFail
     supplier.withRetry(cluster.getRetry());
     supplier.withCircuitBreaker(cluster.getCircuitBreaker());
     supplier.withFallback(provider.getFallbackExceptionList(),
-      e -> this.handleClusterFailover(cluster.getCircuitBreaker()));
+      e -> this.handleClusterFailover(cluster));
 
     return supplier.decorate().get();
   }
@@ -49,9 +49,9 @@ public class CircuitBreakerFailoverConnectionProvider extends CircuitBreakerFail
    * Functional interface wrapped in retry and circuit breaker logic to handle open circuit breaker
    * failure scenarios
    */
-  private Connection handleClusterFailover(CircuitBreaker circuitBreaker) {
+  private Connection handleClusterFailover(Cluster cluster) {
 
-    clusterFailover(circuitBreaker);
+    clusterFailover(cluster);
 
     // Recursive call to the initiating method so the operation can be retried on the next cluster
     // connection

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverConnectionProvider.java
@@ -6,8 +6,7 @@ import io.github.resilience4j.decorators.Decorators.DecorateSupplier;
 
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.annots.Experimental;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider.Cluster;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider.Cluster;
 
 /**
  * ConnectionProvider with built-in retry, circuit-breaker, and failover to another cluster/database

--- a/src/main/java/redis/clients/jedis/mcf/ClusterSwitchEventArgs.java
+++ b/src/main/java/redis/clients/jedis/mcf/ClusterSwitchEventArgs.java
@@ -1,7 +1,7 @@
 package redis.clients.jedis.mcf;
 
 import redis.clients.jedis.Endpoint;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider.Cluster;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider.Cluster;
 
 public class ClusterSwitchEventArgs {
 

--- a/src/main/java/redis/clients/jedis/mcf/EchoStrategy.java
+++ b/src/main/java/redis/clients/jedis/mcf/EchoStrategy.java
@@ -1,10 +1,14 @@
 package redis.clients.jedis.mcf;
 
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import redis.clients.jedis.Connection;
 import redis.clients.jedis.Endpoint;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
+import redis.clients.jedis.JedisPooled;
 import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.MultiClusterClientConfig.StrategySupplier;
 
@@ -20,7 +24,9 @@ public class EchoStrategy implements HealthCheckStrategy {
 
   public EchoStrategy(HostAndPort hostAndPort, JedisClientConfig jedisClientConfig,
       HealthCheckStrategy.Config config) {
-    this.jedis = new UnifiedJedis(hostAndPort, jedisClientConfig);
+    GenericObjectPoolConfig<Connection> poolConfig = new GenericObjectPoolConfig<>();
+    poolConfig.setMaxTotal(2);
+    this.jedis = new JedisPooled(hostAndPort, jedisClientConfig, poolConfig);
     this.config = config;
   }
 

--- a/src/main/java/redis/clients/jedis/mcf/EchoStrategy.java
+++ b/src/main/java/redis/clients/jedis/mcf/EchoStrategy.java
@@ -1,8 +1,6 @@
 package redis.clients.jedis.mcf;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.Endpoint;
@@ -13,13 +11,12 @@ import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.MultiClusterClientConfig.StrategySupplier;
 
 public class EchoStrategy implements HealthCheckStrategy {
-  private static final Logger log = LoggerFactory.getLogger(EchoStrategy.class);
 
   private final UnifiedJedis jedis;
   private final HealthCheckStrategy.Config config;
 
   public EchoStrategy(HostAndPort hostAndPort, JedisClientConfig jedisClientConfig) {
-    this(hostAndPort, jedisClientConfig, new HealthCheckStrategy.Config(1000, 1000, 3));
+    this(hostAndPort, jedisClientConfig, HealthCheckStrategy.Config.builder().build());
   }
 
   public EchoStrategy(HostAndPort hostAndPort, JedisClientConfig jedisClientConfig,
@@ -41,19 +38,24 @@ public class EchoStrategy implements HealthCheckStrategy {
   }
 
   @Override
-  public int minConsecutiveSuccessCount() {
-    return config.getMinConsecutiveSuccessCount();
+  public int getNumProbes() {
+    return config.getNumProbes();
+  }
+
+  @Override
+  public ProbingPolicy getPolicy() {
+    return config.getPolicy();
+  }
+
+  @Override
+  public int getDelayInBetweenProbes() {
+    return config.getDelayInBetweenProbes();
   }
 
   @Override
   public HealthStatus doHealthCheck(Endpoint endpoint) {
-    try {
-      return "HealthCheck".equals(jedis.echo("HealthCheck")) ? HealthStatus.HEALTHY
-          : HealthStatus.UNHEALTHY;
-    } catch (Exception e) {
-      log.error("Error while performing health check", e);
-      return HealthStatus.UNHEALTHY;
-    }
+    return "HealthCheck".equals(jedis.echo("HealthCheck")) ? HealthStatus.HEALTHY
+        : HealthStatus.UNHEALTHY;
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/mcf/HealthCheck.java
+++ b/src/main/java/redis/clients/jedis/mcf/HealthCheck.java
@@ -18,8 +18,7 @@ public interface HealthCheck {
    * stable state.
    * <p>
    * Transition to stable state means either HEALTHY or UNHEALTHY. UNKNOWN is not considered stable.
-   * This is calculated based on the health check strategy's interval, timeout, and minimum
-   * consecutive success count.
+   * This is calculated based on the health check strategy's timeout, retry delay and retry count.
    * </p>
    * @return the maximum wait duration in milliseconds
    */

--- a/src/main/java/redis/clients/jedis/mcf/HealthCheckImpl.java
+++ b/src/main/java/redis/clients/jedis/mcf/HealthCheckImpl.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -17,8 +18,64 @@ import org.slf4j.LoggerFactory;
 
 import redis.clients.jedis.Endpoint;
 import redis.clients.jedis.annots.VisibleForTesting;
+import redis.clients.jedis.mcf.ProbingPolicy.ProbeContext;
+import redis.clients.jedis.util.JedisAsserts;
 
 public class HealthCheckImpl implements HealthCheck {
+
+  static class HealthProbeContext implements ProbeContext {
+    private final ProbingPolicy policy;
+    private int remainingProbes;
+    private int successes;
+    private int fails;
+    private boolean isCompleted;
+    private HealthStatus result;
+
+    HealthProbeContext(ProbingPolicy policy, int maxProbes) {
+      this.policy = policy;
+      this.remainingProbes = maxProbes;
+    }
+
+    void record(boolean success) {
+      if (success) {
+        this.successes++;
+      } else {
+        this.fails++;
+      }
+      remainingProbes--;
+      ProbingPolicy.Decision decision = policy.evaluate(this);
+      if (decision == ProbingPolicy.Decision.SUCCESS) {
+        setCompleted(HealthStatus.HEALTHY);
+      } else if (decision == ProbingPolicy.Decision.FAIL) {
+        setCompleted(HealthStatus.UNHEALTHY);
+      }
+    }
+
+    public int getRemainingProbes() {
+      return remainingProbes;
+    }
+
+    public int getSuccesses() {
+      return successes;
+    }
+
+    public int getFails() {
+      return fails;
+    }
+
+    void setCompleted(HealthStatus status) {
+      this.result = status;
+      this.isCompleted = true;
+    }
+
+    boolean isCompleted() {
+      return isCompleted;
+    }
+
+    HealthStatus getResult() {
+      return result;
+    }
+  }
 
   private static class HealthCheckResult {
     private final long timestamp;
@@ -40,27 +97,30 @@ public class HealthCheckImpl implements HealthCheck {
 
   private static final Logger log = LoggerFactory.getLogger(HealthCheckImpl.class);
 
+  private static AtomicInteger workerCounter = new AtomicInteger(1);
+  private static ExecutorService workers = Executors.newCachedThreadPool(r -> {
+    Thread t = new Thread(r, "jedis-healthcheck-worker-" + workerCounter.getAndIncrement());
+    t.setDaemon(true);
+    return t;
+  });
+
   private Endpoint endpoint;
   private HealthCheckStrategy strategy;
   private AtomicReference<HealthCheckResult> resultRef = new AtomicReference<HealthCheckResult>();
   private Consumer<HealthStatusChangeEvent> statusChangeCallback;
 
   private final ScheduledExecutorService scheduler;
-  private final ExecutorService executor;
 
   HealthCheckImpl(Endpoint endpoint, HealthCheckStrategy strategy,
       Consumer<HealthStatusChangeEvent> statusChangeCallback) {
 
+    JedisAsserts.isTrue(strategy.getNumProbes() > 0,
+      "Number of HealthCheckStrategy probes must be greater than 0");
     this.endpoint = endpoint;
     this.strategy = strategy;
     this.statusChangeCallback = statusChangeCallback;
     resultRef.set(new HealthCheckResult(0L, HealthStatus.UNKNOWN));
 
-    executor = Executors.newCachedThreadPool(r -> {
-      Thread t = new Thread(r, "jedis-healthcheck-worker-" + this.endpoint);
-      t.setDaemon(true);
-      return t;
-    });
     scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
       Thread t = new Thread(r, "jedis-healthcheck-" + this.endpoint);
       t.setDaemon(true);
@@ -85,53 +145,100 @@ public class HealthCheckImpl implements HealthCheck {
     strategy.close();
     this.statusChangeCallback = null;
     scheduler.shutdown();
-    executor.shutdown();
+
     try {
       // Wait for graceful shutdown then force if required
       if (!scheduler.awaitTermination(1, TimeUnit.SECONDS)) {
         scheduler.shutdownNow();
       }
-      if (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
-        executor.shutdownNow();
-      }
     } catch (InterruptedException e) {
       // Force shutdown immediately
       scheduler.shutdownNow();
-      executor.shutdownNow();
       Thread.currentThread().interrupt();
     }
   }
 
-  private void healthCheck() {
-    long me = System.currentTimeMillis();
-    Future<?> future = executor.submit(() -> {
-      HealthStatus newStatus = strategy.doHealthCheck(endpoint);
-      safeUpdate(me, newStatus);
-      log.trace("Health check completed for {} with status {}", endpoint, newStatus);
-    });
-
-    try {
-      future.get(strategy.getTimeout(), TimeUnit.MILLISECONDS);
-    } catch (TimeoutException | ExecutionException e) {
-      // Cancel immediately on timeout or exec exception
-      future.cancel(true);
-      safeUpdate(me, HealthStatus.UNHEALTHY);
-      log.warn("Health check timed out or failed for {}", endpoint, e);
-    } catch (InterruptedException e) {
-      // Health check thread was interrupted
-      future.cancel(true);
-      safeUpdate(me, HealthStatus.UNHEALTHY);
-      Thread.currentThread().interrupt(); // Restore interrupted status
-      log.warn("Health check interrupted for {}", endpoint, e);
-    }
+  private HealthStatus doHealthCheck() {
+    HealthStatus newStatus = strategy.doHealthCheck(endpoint);
+    log.trace("Health check completed for {} with status {}", endpoint, newStatus);
+    return newStatus;
   }
 
-  // -> 0 -> Unhealthy
-  // -> 1 ->
-  // -> 2 -> Healthy
-  // -> 1 -> Unhealthy
+  private void healthCheck() {
+    long me = System.currentTimeMillis();
+    HealthStatus update = null;
+    HealthProbeContext probeContext = new HealthProbeContext(strategy.getPolicy(),
+        strategy.getNumProbes());
 
-  // just to avoid to replace status with an outdated result from another healthCheck
+    while (!probeContext.isCompleted()) {
+      Future<HealthStatus> future = workers.submit(this::doHealthCheck);
+      try {
+        update = future.get(strategy.getTimeout(), TimeUnit.MILLISECONDS);
+        probeContext.record(update == HealthStatus.HEALTHY);
+      } catch (TimeoutException | ExecutionException e) {
+        future.cancel(true);
+        if (log.isWarnEnabled()) {
+          log.warn(String.format("Health check timed out or failed for %s.", endpoint), e);
+        }
+        probeContext.record(false);
+      } catch (InterruptedException e) {// Health check thread was interrupted
+        future.cancel(true);
+        Thread.currentThread().interrupt(); // Restore interrupted status
+        log.warn(String.format("Health check interrupted for %s.", endpoint), e);
+        // thread interrupted, stop health check process
+        return;
+      }
+      if (!probeContext.isCompleted()) {
+        try {
+          Thread.sleep(strategy.getDelayInBetweenProbes());
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt(); // Restore interrupted status
+          log.warn(String.format("Health check interrupted while sleeping for %s.", endpoint), e);
+          // thread interrupted, stop health check process
+          return;
+        }
+      }
+    }
+
+    safeUpdate(me, probeContext.getResult());
+  }
+
+  /**
+   * just to avoid to replace status with an outdated result from another healthCheck
+   *
+   * <pre>
+   * Health Check Race Condition Prevention
+   *
+   * Problem: Async health checks can complete out of order, causing stale results
+   * to overwrite newer ones.
+   *
+   * Timeline Example:
+   * ─────────────────────────────────────────────────────────────────
+   * T0: Start Check #1 ────────────────────┐
+   * T1: Start Check #2 ──────────┐         │
+   * T2:                          │         │
+   * T3: Check #2 completes ──────┘         │  → status = "Healthy"
+   * T4: Check #1 completes ────────────────┘  → status = "Unhealthy" (STALE!)
+   *
+   *
+   * Result: Final status shows "Unhealthy" even though the most recent
+   * check (#2) returned "Healthy"
+   *
+   * How Parallel Health Checks Can Occur:
+   * 1. Timeout scenario: A scheduled health check times out and future.cancel(true)
+   *    is called, but the actual health check operation continues running in the
+   *    background thread and may complete any time later
+   * 2. Scheduler overlap: If a health check takes longer than the configured
+   *    interval, the next scheduled check can start before the previous one finishes
+   * 3. Interruption handling: When a health check thread is interrupted, it may
+   *    still complete its operation before recognizing the interruption
+   *
+   * Solution: Track execution order/timestamp to ignore outdated results
+   * </pre>
+   *
+   * @param owner the timestamp of the health check that is updating the status
+   * @param status the new status to set
+   */
   @VisibleForTesting
   void safeUpdate(long owner, HealthStatus status) {
     HealthCheckResult newResult = new HealthCheckResult(owner, status);
@@ -162,7 +269,7 @@ public class HealthCheckImpl implements HealthCheck {
 
   @Override
   public long getMaxWaitFor() {
-    return (strategy.getTimeout() + strategy.getInterval()) * strategy.minConsecutiveSuccessCount();
+    return (strategy.getTimeout() + strategy.getDelayInBetweenProbes()) * strategy.getNumProbes();
   }
 
 }

--- a/src/main/java/redis/clients/jedis/mcf/HealthCheckStrategy.java
+++ b/src/main/java/redis/clients/jedis/mcf/HealthCheckStrategy.java
@@ -1,7 +1,6 @@
 package redis.clients.jedis.mcf;
 
 import java.io.Closeable;
-
 import redis.clients.jedis.Endpoint;
 
 public interface HealthCheckStrategy extends Closeable {
@@ -32,23 +31,45 @@ public interface HealthCheckStrategy extends Closeable {
   }
 
   /**
-   * Get the minimum number of consecutive successful health checks required to mark the endpoint as
-   * healthy.
-   * @return the minimum number of consecutive successful health checks
+   * Get the number of probes for health checks to repeat.
+   * @return the number of probes
    */
-  default int minConsecutiveSuccessCount() {
-    return 1;
-  }
+  int getNumProbes();
+
+  /**
+   * Get the policy for health checks.
+   * @return the policy
+   */
+  ProbingPolicy getPolicy();
+
+  /**
+   * Get the delay (in milliseconds) between retries for failed health checks.
+   * @return the delay in milliseconds
+   */
+  int getDelayInBetweenProbes();
 
   public static class Config {
     protected final int interval;
     protected final int timeout;
-    protected final int minConsecutiveSuccessCount;
+    protected final int numProbes;
+    protected final int delayInBetweenProbes;
+    protected final ProbingPolicy policy;
 
-    public Config(int interval, int timeout, int minConsecutiveSuccessCount) {
+    public Config(int interval, int timeout, int numProbes, int delayInBetweenProbes,
+        ProbingPolicy policy) {
       this.interval = interval;
       this.timeout = timeout;
-      this.minConsecutiveSuccessCount = minConsecutiveSuccessCount;
+      this.numProbes = numProbes;
+      this.delayInBetweenProbes = delayInBetweenProbes;
+      this.policy = policy;
+    }
+
+    Config(Builder<?, ?> builder) {
+      this.interval = builder.interval;
+      this.timeout = builder.timeout;
+      this.numProbes = builder.numProbes;
+      this.delayInBetweenProbes = builder.delayInBetweenProbes;
+      this.policy = builder.policy;
     }
 
     public int getInterval() {
@@ -59,8 +80,16 @@ public interface HealthCheckStrategy extends Closeable {
       return timeout;
     }
 
-    public int getMinConsecutiveSuccessCount() {
-      return minConsecutiveSuccessCount;
+    public int getNumProbes() {
+      return numProbes;
+    }
+
+    public int getDelayInBetweenProbes() {
+      return delayInBetweenProbes;
+    }
+
+    public ProbingPolicy getPolicy() {
+      return policy;
     }
 
     /**
@@ -87,7 +116,9 @@ public interface HealthCheckStrategy extends Closeable {
     public static class Builder<T extends Builder<T, C>, C extends Config> {
       protected int interval = 1000;
       protected int timeout = 1000;
-      protected int minConsecutiveSuccessCount = 3;
+      protected int numProbes = 3;
+      protected ProbingPolicy policy = ProbingPolicy.BuiltIn.ALL_SUCCESS;
+      protected int delayInBetweenProbes = 100;
 
       /**
        * Set the interval between health checks in milliseconds.
@@ -112,13 +143,35 @@ public interface HealthCheckStrategy extends Closeable {
       }
 
       /**
-       * Set the minimum number of consecutive successful health checks required.
-       * @param minConsecutiveSuccessCount the minimum count (default: 3)
+       * Set the number of probes for health check.
+       * @param numProbes the number of repeats (default: 3)
        * @return this builder
        */
       @SuppressWarnings("unchecked")
-      public T minConsecutiveSuccessCount(int minConsecutiveSuccessCount) {
-        this.minConsecutiveSuccessCount = minConsecutiveSuccessCount;
+      public T numProbes(int numProbes) {
+        this.numProbes = numProbes;
+        return (T) this;
+      }
+
+      /**
+       * Set the policy for health checks.
+       * @param policy the policy (default: ProbingPolicy.BuiltIn.ALL_SUCCESS)
+       * @return this builder
+       */
+      @SuppressWarnings("unchecked")
+      public T policy(ProbingPolicy policy) {
+        this.policy = policy;
+        return (T) this;
+      }
+
+      /**
+       * Set the delay between retries for failed health checks in milliseconds.
+       * @param delayInBetweenProbes the delay in milliseconds (default: 100)
+       * @return this builder
+       */
+      @SuppressWarnings("unchecked")
+      public T delayInBetweenProbes(int delayInBetweenProbes) {
+        this.delayInBetweenProbes = delayInBetweenProbes;
         return (T) this;
       }
 
@@ -126,8 +179,9 @@ public interface HealthCheckStrategy extends Closeable {
        * Build the Config instance.
        * @return a new Config instance
        */
-      public Config build() {
-        return new Config(interval, timeout, minConsecutiveSuccessCount);
+      @SuppressWarnings("unchecked")
+      public C build() {
+        return (C) new Config(this);
       }
     }
   }

--- a/src/main/java/redis/clients/jedis/mcf/JedisFailoverException.java
+++ b/src/main/java/redis/clients/jedis/mcf/JedisFailoverException.java
@@ -1,0 +1,66 @@
+package redis.clients.jedis.mcf;
+
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+/**
+ * Exception thrown when a failover attempt fails due to lack of available/healthy clusters.
+ * <p>
+ * This exception itself is not thrown, see the child exceptions for more details.
+ * </p>
+ * @see JedisFailoverException.JedisPermanentlyNotAvailableException
+ * @see JedisFailoverException.JedisTemporarilyNotAvailableException
+ */
+public class JedisFailoverException extends JedisConnectionException {
+  private static final String MESSAGE = "Cluster/database endpoint could not failover since the MultiClusterClientConfig was not "
+      + "provided with an additional cluster/database endpoint according to its prioritized sequence. "
+      + "If applicable, consider falling back OR restarting with an available cluster/database endpoint";
+
+  public JedisFailoverException(String s) {
+    super(s);
+  }
+
+  public JedisFailoverException() {
+    super(MESSAGE);
+  }
+
+  /**
+   * Exception thrown when a failover attempt fails due to lack of available/healthy clusters, and
+   * the max number of failover attempts has been exceeded. And there is still no healthy cluster.
+   * <p>
+   * See the configuration properties
+   * {@link redis.clients.jedis.MultiClusterClientConfig#maxNumFailoverAttempts} and
+   * {@link redis.clients.jedis.MultiClusterClientConfig#delayInBetweenFailoverAttempts} for more
+   * details.
+   */
+  public static class JedisPermanentlyNotAvailableException extends JedisFailoverException {
+    public JedisPermanentlyNotAvailableException(String s) {
+      super(s);
+    }
+
+    public JedisPermanentlyNotAvailableException() {
+      super();
+    }
+  }
+
+  /**
+   * Exception thrown when a failover attempt fails due to lack of available/healthy clusters, but
+   * the max number of failover attempts has not been exceeded yet. Though there is no healthy
+   * cluster including the selected/current one, given configuration suggests that it should be a
+   * temporary condition and it is possible that there will be a healthy cluster available.
+   * <p>
+   * See the configuration properties
+   * {@link redis.clients.jedis.MultiClusterClientConfig#maxNumFailoverAttempts} and
+   * {@link redis.clients.jedis.MultiClusterClientConfig#delayInBetweenFailoverAttempts} for more
+   * details.
+   */
+  public static class JedisTemporarilyNotAvailableException extends JedisFailoverException {
+
+    public JedisTemporarilyNotAvailableException(String s) {
+      super(s);
+    }
+
+    public JedisTemporarilyNotAvailableException() {
+      super();
+    }
+  }
+}

--- a/src/main/java/redis/clients/jedis/mcf/MultiClusterPipeline.java
+++ b/src/main/java/redis/clients/jedis/mcf/MultiClusterPipeline.java
@@ -7,7 +7,6 @@ import java.util.Queue;
 
 import redis.clients.jedis.*;
 import redis.clients.jedis.annots.Experimental;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
 import redis.clients.jedis.util.KeyValue;
 
 /**

--- a/src/main/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProvider.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -35,6 +36,7 @@ import redis.clients.jedis.annots.VisibleForTesting;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.exceptions.JedisValidationException;
+import redis.clients.jedis.mcf.JedisFailoverException.*;
 import redis.clients.jedis.providers.ConnectionProvider;
 import redis.clients.jedis.MultiClusterClientConfig.StrategySupplier;
 
@@ -100,6 +102,9 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
   private RetryConfig retryConfig;
   private CircuitBreakerConfig circuitBreakerConfig;
   private MultiClusterClientConfig multiClusterClientConfig;
+
+  private AtomicLong failoverFreezeUntil = new AtomicLong(0);
+  private AtomicInteger failoverAttemptCount = new AtomicInteger(0);
 
   public MultiClusterPooledConnectionProvider(MultiClusterClientConfig multiClusterClientConfig) {
 
@@ -174,14 +179,15 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
 
     // Mark initialization as complete - handleHealthStatusChange can now process events
     initializationComplete = true;
-    if (!activeCluster.isHealthy()) {
+    Cluster temp = activeCluster;
+    if (!temp.isHealthy()) {
       // Race condition: Direct assignment to 'activeCluster' is not thread safe because
       // 'onHealthStatusChange' may execute concurrently once 'initializationComplete'
       // is set to true.
       // Simple rule is to never assign value of 'activeCluster' outside of
       // 'activeClusterChangeLock' once the 'initializationComplete' is done.
       waitForInitialHealthyCluster(statusTracker);
-      iterateActiveCluster(SwitchReason.HEALTH_CHECK);
+      switchToHealthyCluster(SwitchReason.HEALTH_CHECK, temp);
     }
     this.fallbackExceptionList = multiClusterClientConfig.getFallbackExceptionList();
 
@@ -238,6 +244,7 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
     }
     log.debug("Removing endpoint {}", endpoint);
 
+    Map.Entry<Endpoint, Cluster> notificationData = null;
     activeClusterChangeLock.lock();
     try {
       Cluster clusterToRemove = multiClusterMap.get(endpoint);
@@ -245,12 +252,13 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
 
       if (isActiveCluster) {
         log.info("Active cluster is being removed. Finding a new active cluster...");
-        Map.Entry<Endpoint, Cluster> candidate = findWeightedHealthyClusterToIterate();
+        Map.Entry<Endpoint, Cluster> candidate = findWeightedHealthyClusterToIterate(
+          clusterToRemove);
         if (candidate != null) {
           Cluster selectedCluster = candidate.getValue();
           if (setActiveCluster(selectedCluster, true)) {
             log.info("New active cluster set to {}", candidate.getKey());
-            onClusterSwitch(SwitchReason.FORCED, candidate.getKey(), selectedCluster);
+            notificationData = candidate;
           }
         } else {
           throw new JedisException(
@@ -272,6 +280,9 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
       }
     } finally {
       activeClusterChangeLock.unlock();
+    }
+    if (notificationData != null) {
+      onClusterSwitch(SwitchReason.FORCED, notificationData.getKey(), notificationData.getValue());
     }
   }
 
@@ -342,7 +353,7 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
     if (initializationComplete) {
       if (!newStatus.isHealthy() && clusterWithHealthChange == activeCluster) {
         clusterWithHealthChange.setGracePeriod();
-        iterateActiveCluster(SwitchReason.HEALTH_CHECK);
+        switchToHealthyCluster(SwitchReason.HEALTH_CHECK, clusterWithHealthChange);
       }
     }
   }
@@ -442,19 +453,65 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
     }
   }
 
-  Endpoint iterateActiveCluster(SwitchReason reason) {
-    Map.Entry<Endpoint, Cluster> clusterToIterate = findWeightedHealthyClusterToIterate();
+  Endpoint switchToHealthyCluster(SwitchReason reason, Cluster iterateFrom) {
+    Map.Entry<Endpoint, Cluster> clusterToIterate = findWeightedHealthyClusterToIterate(
+      iterateFrom);
     if (clusterToIterate == null) {
-      throw new JedisConnectionException(
-          "Cluster/database endpoint could not failover since the MultiClusterClientConfig was not "
-              + "provided with an additional cluster/database endpoint according to its prioritized sequence. "
-              + "If applicable, consider failing back OR restarting with an available cluster/database endpoint");
+      // throws exception anyway since not able to iterate
+      handleNoHealthyCluster();
     }
+
     Cluster cluster = clusterToIterate.getValue();
     boolean changed = setActiveCluster(cluster, false);
     if (!changed) return null;
+    failoverAttemptCount.set(0);
     onClusterSwitch(reason, clusterToIterate.getKey(), cluster);
     return clusterToIterate.getKey();
+  }
+
+  private void handleNoHealthyCluster() {
+    int max = multiClusterClientConfig.getMaxNumFailoverAttempts();
+    log.error("No healthy cluster available to switch to");
+    if (failoverAttemptCount.get() > max) {
+      throw new JedisPermanentlyNotAvailableException();
+    }
+
+    int currentAttemptCount = markAsFreeze() ? failoverAttemptCount.incrementAndGet()
+        : failoverAttemptCount.get();
+
+    if (currentAttemptCount > max) {
+      throw new JedisPermanentlyNotAvailableException();
+    }
+    throw new JedisTemporarilyNotAvailableException();
+  }
+
+  private boolean markAsFreeze() {
+    long until = failoverFreezeUntil.get();
+    long now = System.currentTimeMillis();
+    if (until <= now) {
+      long nextUntil = now + multiClusterClientConfig.getDelayInBetweenFailoverAttempts();
+      if (failoverFreezeUntil.compareAndSet(until, nextUntil)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Asserts that the active cluster is operable. If not, throws an exception.
+   * <p>
+   * This method is called by the circuit breaker command executor before executing a command.
+   * @throws JedisPermanentlyNotAvailableException if the there is no operable cluster and the max
+   *           number of failover attempts has been exceeded.
+   * @throws JedisTemporarilyNotAvailableException if the there is no operable cluster and the max
+   *           number of failover attempts has not been exceeded.
+   */
+  @VisibleForTesting
+  public void assertOperability() {
+    Cluster current = activeCluster;
+    if (!current.isHealthy() && !this.canIterateFrom(current)) {
+      handleNoHealthyCluster();
+    }
   }
 
   private static Comparator<Map.Entry<Endpoint, Cluster>> maxByWeight = Map.Entry
@@ -463,9 +520,9 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
   private static Predicate<Map.Entry<Endpoint, Cluster>> filterByHealth = c -> c.getValue()
       .isHealthy();
 
-  private Map.Entry<Endpoint, Cluster> findWeightedHealthyClusterToIterate() {
+  private Map.Entry<Endpoint, Cluster> findWeightedHealthyClusterToIterate(Cluster iterateFrom) {
     return multiClusterMap.entrySet().stream().filter(filterByHealth)
-        .filter(entry -> entry.getValue() != activeCluster).max(maxByWeight).orElse(null);
+        .filter(entry -> entry.getValue() != iterateFrom).max(maxByWeight).orElse(null);
   }
 
   /**
@@ -545,8 +602,7 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
     try {
 
       // Allows an attempt to reset the current cluster from a FORCED_OPEN to CLOSED state in the
-      // event that no
-      // failover is possible
+      // event that no failover is possible
       if (activeCluster == cluster && !cluster.isCBForcedOpen()) return false;
 
       if (validateConnection) validateTargetConnection(cluster);
@@ -637,8 +693,8 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
    * pre-configured list provided at startup via the MultiClusterClientConfig, is unavailable and
    * therefore no further failover is possible. Users can manually failback to an available cluster
    */
-  public boolean canIterateOnceMore() {
-    Map.Entry<Endpoint, Cluster> e = findWeightedHealthyClusterToIterate();
+  public boolean canIterateFrom(Cluster iterateFrom) {
+    Map.Entry<Endpoint, Cluster> e = findWeightedHealthyClusterToIterate(iterateFrom);
     return e != null;
   }
 

--- a/src/main/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProvider.java
@@ -1,4 +1,4 @@
-package redis.clients.jedis.providers;
+package redis.clients.jedis.mcf;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker.State;
@@ -35,18 +35,10 @@ import redis.clients.jedis.annots.VisibleForTesting;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.exceptions.JedisValidationException;
-import redis.clients.jedis.mcf.HealthStatus;
-import redis.clients.jedis.mcf.HealthStatusChangeEvent;
-import redis.clients.jedis.mcf.HealthStatusManager;
-import redis.clients.jedis.mcf.StatusTracker;
-import redis.clients.jedis.mcf.SwitchReason;
-import redis.clients.jedis.mcf.TrackingConnectionPool;
+import redis.clients.jedis.providers.ConnectionProvider;
 import redis.clients.jedis.MultiClusterClientConfig.StrategySupplier;
 
 import redis.clients.jedis.util.Pool;
-import redis.clients.jedis.mcf.ClusterSwitchEventArgs;
-import redis.clients.jedis.mcf.HealthCheck;
-import redis.clients.jedis.mcf.HealthCheckStrategy;
 
 /**
  * @author Allen Terleto (aterleto)
@@ -450,7 +442,7 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
     }
   }
 
-  public Endpoint iterateActiveCluster(SwitchReason reason) {
+  Endpoint iterateActiveCluster(SwitchReason reason) {
     Map.Entry<Endpoint, Cluster> clusterToIterate = findWeightedHealthyClusterToIterate();
     if (clusterToIterate == null) {
       throw new JedisConnectionException(

--- a/src/main/java/redis/clients/jedis/mcf/MultiClusterTransaction.java
+++ b/src/main/java/redis/clients/jedis/mcf/MultiClusterTransaction.java
@@ -14,7 +14,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import redis.clients.jedis.*;
 import redis.clients.jedis.annots.Experimental;
 import redis.clients.jedis.exceptions.JedisDataException;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
 import redis.clients.jedis.util.KeyValue;
 
 /**

--- a/src/main/java/redis/clients/jedis/mcf/ProbingPolicy.java
+++ b/src/main/java/redis/clients/jedis/mcf/ProbingPolicy.java
@@ -1,0 +1,100 @@
+package redis.clients.jedis.mcf;
+
+public interface ProbingPolicy {
+
+  public enum Decision {
+    CONTINUE, SUCCESS, FAIL
+  }
+
+  Decision evaluate(ProbeContext data);
+
+  public static interface ProbeContext {
+
+    public int getRemainingProbes();
+
+    public int getSuccesses();
+
+    public int getFails();
+
+  }
+
+  public static class BuiltIn {
+    public static final ProbingPolicy ALL_SUCCESS = new AllSuccessPolicy();
+    public static final ProbingPolicy ANY_SUCCESS = new AnySuccessPolicy();
+    public static final ProbingPolicy MAJORITY_SUCCESS = new MajoritySuccessPolicy();
+
+    /*
+     * All probes need to be healthy. If a database doesn’t pass the health check for numProbes
+     * times, then the check wasn’t successful. This means you can stop probing after you got the
+     * first failed health check (e.g., timeout or unhealthy status)
+     */
+    private static class AllSuccessPolicy implements ProbingPolicy {
+      @Override
+      public Decision evaluate(ProbeContext ctx) {
+        // Any failure means overall failure
+        if (ctx.getFails() > 0) {
+          return Decision.FAIL;
+        }
+
+        // All probes completed successfully
+        if (ctx.getRemainingProbes() == 0) {
+          return Decision.SUCCESS;
+        }
+
+        return Decision.CONTINUE;
+      }
+    }
+
+    /*
+     * A database is healthy if at least one probe returned a healthy status. You can stop probing
+     * as soon as you got the first healthy status.
+     */
+    private static class AnySuccessPolicy implements ProbingPolicy {
+      @Override
+      public Decision evaluate(ProbeContext ctx) {
+        // Any success means overall success
+        if (ctx.getSuccesses() > 0) {
+          return Decision.SUCCESS;
+        }
+
+        // All probes completed with failures
+        if (ctx.getRemainingProbes() == 0) {
+          return Decision.FAIL;
+        }
+
+        return Decision.CONTINUE;
+      }
+    }
+
+    /*
+     * A database is healthy if the majority of probes returned ‘healthy’. This means you can stop
+     * probing as soon as the majority can’t be guaranteed any more (e.g., you have 4 probes and 2
+     * of them failed), or as soon as the majority is reached (e.g., 3 out of 4 were healthy)
+     */
+    private static class MajoritySuccessPolicy implements ProbingPolicy {
+      @Override
+      public Decision evaluate(ProbeContext ctx) {
+        int total = ctx.getRemainingProbes() + ctx.getSuccesses() + ctx.getFails();
+        int required = (total / 2) + 1;
+
+        // Early success
+        if (ctx.getSuccesses() >= required) {
+          return Decision.SUCCESS;
+        }
+
+        // Early failure - impossible to reach majority
+        int maxPossibleSuccesses = ctx.getSuccesses() + ctx.getRemainingProbes();
+        if (maxPossibleSuccesses < required) {
+          return Decision.FAIL;
+        }
+
+        // Final evaluation
+        if (ctx.getRemainingProbes() == 0) {
+          return ctx.getSuccesses() >= required ? Decision.SUCCESS : Decision.FAIL;
+        }
+
+        return Decision.CONTINUE;
+      }
+    }
+  }
+}

--- a/src/main/java/redis/clients/jedis/mcf/RedisRestAPI.java
+++ b/src/main/java/redis/clients/jedis/mcf/RedisRestAPI.java
@@ -5,10 +5,13 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.function.Supplier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,10 +23,14 @@ import com.google.gson.JsonParser;
 
 import redis.clients.jedis.Endpoint;
 import redis.clients.jedis.RedisCredentials;
+import redis.clients.jedis.SslOptions;
+import redis.clients.jedis.SslVerifyMode;
+import redis.clients.jedis.annots.Internal;
 
 /**
  * Helper class to check the availability of a Redis database
  */
+@Internal
 class RedisRestAPI {
 
   private static final Logger log = LoggerFactory.getLogger(RedisRestAPI.class);
@@ -31,20 +38,29 @@ class RedisRestAPI {
   private static final String AVAILABILITY_URL = "https://%s:%s/v1/bdbs/%s/availability";
   private static final String LAGAWARE_AVAILABILITY_URL = "https://%s:%s/v1/bdbs/%s/availability?extend_check=lag";
 
-  private Endpoint endpoint;
-  private Supplier<RedisCredentials> credentialsSupplier;
-  private int timeoutMs;
+  private static final int DEFAULT_TIMEOUT_MS = 1000;
+
+  private final Endpoint endpoint;
+  private final Supplier<RedisCredentials> credentialsSupplier;
+  private final int timeoutMs;
+  private final SslOptions sslOptions;
   private String bdbsUri;
 
   public RedisRestAPI(Endpoint endpoint, Supplier<RedisCredentials> credentialsSupplier) {
-    this(endpoint, credentialsSupplier, 1000);
+    this(endpoint, credentialsSupplier, DEFAULT_TIMEOUT_MS);
   }
 
   public RedisRestAPI(Endpoint endpoint, Supplier<RedisCredentials> credentialsSupplier,
       int timeoutMs) {
+    this(endpoint, credentialsSupplier, timeoutMs, null);
+  }
+
+  public RedisRestAPI(Endpoint endpoint, Supplier<RedisCredentials> credentialsSupplier,
+      int timeoutMs, SslOptions sslOptions) {
     this.endpoint = endpoint;
     this.credentialsSupplier = credentialsSupplier;
     this.timeoutMs = timeoutMs;
+    this.sslOptions = sslOptions;
   }
 
   public List<RedisRestAPI.BdbInfo> getBdbs() throws IOException {
@@ -110,6 +126,23 @@ class RedisRestAPI {
       throws IOException {
     URL url = new URL(urlString);
     HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+
+    // Configure SSL if this is an HTTPS connection and SSL options are provided
+    if (connection instanceof HttpsURLConnection && sslOptions != null) {
+      HttpsURLConnection httpsConnection = (HttpsURLConnection) connection;
+      try {
+        SSLContext sslContext = sslOptions.createSslContext();
+        httpsConnection.setSSLSocketFactory(sslContext.getSocketFactory());
+
+        if (sslOptions.getSslVerifyMode() == SslVerifyMode.CA
+            || sslOptions.getSslVerifyMode() == SslVerifyMode.INSECURE) {
+          httpsConnection.setHostnameVerifier((h, s) -> true); // skip hostname check
+        }
+      } catch (GeneralSecurityException e) {
+        throw new IOException("SSL configuration failed", e);
+      }
+    }
+
     connection.setRequestMethod(method);
     connection.setConnectTimeout(timeoutMs);
     connection.setReadTimeout(timeoutMs);

--- a/src/main/java/redis/clients/jedis/mcf/TrackingConnectionPool.java
+++ b/src/main/java/redis/clients/jedis/mcf/TrackingConnectionPool.java
@@ -176,7 +176,7 @@ public class TrackingConnectionPool extends ConnectionPool {
   public void forceDisconnect() {
     this.close();
     ((FailFastConnectionFactory) this.getFactory()).failFast = true;
-    while (numWaiters.get() > 0 || getNumWaiters() > 0 || getNumActive() > 0 || getNumIdle() > 0) {
+    while (numWaiters.get() > 0 || getNumActive() > 0 || getNumIdle() > 0) {
       this.clear();
       ((FailFastConnectionFactory) this.getFactory()).forceDisconnect();
       for (Connection connection : poolTrackedObjects) {

--- a/src/main/java/redis/clients/jedis/mcf/TrackingConnectionPool.java
+++ b/src/main/java/redis/clients/jedis/mcf/TrackingConnectionPool.java
@@ -22,7 +22,7 @@ import redis.clients.jedis.exceptions.JedisConnectionException;
 public class TrackingConnectionPool extends ConnectionPool {
 
   private static class FailFastConnectionFactory extends ConnectionFactory {
-    private boolean failFast = false;
+    private volatile boolean failFast = false;
     private final Set<Connection> factoryTrackedObjects = ConcurrentHashMap.newKeySet();
 
     public FailFastConnectionFactory(ConnectionFactory.Builder factoryBuilder,
@@ -53,8 +53,12 @@ public class TrackingConnectionPool extends ConnectionPool {
         } finally {
           factoryTrackedObjects.remove(object.getObject());
         }
+        // this can make a marginal improvement on fast failover duration!
+        if (failFast) {
+          object.getObject().close();
+          throw new JedisConnectionException("Failed to create connection!");
+        }
         return object;
-
       } catch (JedisConnectionException e) {
         throw e;
       } catch (Exception e) {
@@ -176,11 +180,20 @@ public class TrackingConnectionPool extends ConnectionPool {
   public void forceDisconnect() {
     this.close();
     ((FailFastConnectionFactory) this.getFactory()).failFast = true;
-    while (numWaiters.get() > 0 || getNumActive() > 0 || getNumIdle() > 0) {
+    int numOfConnected = poolTrackedObjects.size();
+    // we need to wait for all waiters to leave before we are done with disconnecting the
+    // connections, since a user app thread might be either;
+    // - in the middle of a factory call(create|init) and not yet show up in poolTrackedObjects
+    // - blocked on an exhausted pool, waiting for resources to return back pool
+    while (numWaiters.get() > 0 || numOfConnected > 0) {
       this.clear();
       ((FailFastConnectionFactory) this.getFactory()).forceDisconnect();
+      numOfConnected = 0;
       for (Connection connection : poolTrackedObjects) {
         try {
+          if (connection.isConnected()) {
+            numOfConnected++;
+          }
           connection.forceDisconnect();
         } catch (Exception e) {
           log.warn("Error while force disconnecting connection: " + connection.toIdentityString(),
@@ -188,6 +201,7 @@ public class TrackingConnectionPool extends ConnectionPool {
         }
       }
       try {
+        // this is just to yield the thread for a fair share of CPU
         Thread.sleep(1);
       } catch (InterruptedException e) {
       }

--- a/src/main/java/redis/clients/jedis/providers/MultiClusterPooledConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/MultiClusterPooledConnectionProvider.java
@@ -186,8 +186,8 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
       // Race condition: Direct assignment to 'activeCluster' is not thread safe because
       // 'onHealthStatusChange' may execute concurrently once 'initializationComplete'
       // is set to true.
-      // Simple rule is to never assign value of 'activeCluster' outside of 
-      // 'activeClusterChangeLock' once the 'initializationComplete' is done. 
+      // Simple rule is to never assign value of 'activeCluster' outside of
+      // 'activeClusterChangeLock' once the 'initializationComplete' is done.
       waitForInitialHealthyCluster(statusTracker);
       iterateActiveCluster(SwitchReason.HEALTH_CHECK);
     }

--- a/src/test/java/redis/clients/jedis/failover/FailoverIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/failover/FailoverIntegrationTest.java
@@ -37,6 +37,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType.COUNT_BASED;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -137,6 +138,9 @@ public class FailoverIntegrationTest {
   public void testAutomaticFailoverWhenServerBecomesUnavailable() throws Exception {
     assertThat(getNodeId(failoverClient.info("server")), equalTo(JEDIS1_ID));
 
+    await().atMost(1, TimeUnit.SECONDS).pollInterval(50, TimeUnit.MILLISECONDS)
+        .until(() -> provider.getCluster(endpoint2.getHostAndPort()).isHealthy());
+
     // Disable redisProxy1
     redisProxy1.disable();
 
@@ -169,6 +173,9 @@ public class FailoverIntegrationTest {
   public void testManualFailoverNewCommandsAreSentToActiveCluster() throws InterruptedException {
     assertThat(getNodeId(failoverClient.info("server")), equalTo(JEDIS1_ID));
 
+    await().atMost(1, TimeUnit.SECONDS).pollInterval(50, TimeUnit.MILLISECONDS)
+        .until(() -> provider.getCluster(endpoint2.getHostAndPort()).isHealthy());
+
     provider.setActiveCluster(endpoint2.getHostAndPort());
 
     assertThat(getNodeId(failoverClient.info("server")), equalTo(JEDIS2_ID));
@@ -186,6 +193,9 @@ public class FailoverIntegrationTest {
   @Timeout(5)
   public void testManualFailoverInflightCommandsCompleteGracefully()
       throws ExecutionException, InterruptedException {
+
+    await().atMost(1, TimeUnit.SECONDS).pollInterval(50, TimeUnit.MILLISECONDS)
+        .until(() -> provider.getCluster(endpoint2.getHostAndPort()).isHealthy());
 
     assertThat(getNodeId(failoverClient.info("server")), equalTo(JEDIS1_ID));
 
@@ -214,6 +224,9 @@ public class FailoverIntegrationTest {
   @Test
   public void testManualFailoverInflightCommandsWithErrorsPropagateError() throws Exception {
     assertThat(getNodeId(failoverClient.info("server")), equalTo(JEDIS1_ID));
+
+    await().atMost(1, TimeUnit.SECONDS).pollInterval(50, TimeUnit.MILLISECONDS)
+        .until(() -> provider.getCluster(endpoint2.getHostAndPort()).isHealthy());
 
     Future<List<String>> blpop = executor.submit(() -> failoverClient.blpop(10000, "test-list-1"));
 

--- a/src/test/java/redis/clients/jedis/failover/FailoverIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/failover/FailoverIntegrationTest.java
@@ -19,8 +19,7 @@ import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.MultiClusterClientConfig;
 import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.exceptions.JedisConnectionException;
-
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider;
 import redis.clients.jedis.scenario.RecommendedSettings;
 
 import java.io.IOException;

--- a/src/test/java/redis/clients/jedis/mcf/ActiveActiveLocalFailoverTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/ActiveActiveLocalFailoverTest.java
@@ -19,7 +19,6 @@ import eu.rekawek.toxiproxy.ToxiproxyClient;
 import eu.rekawek.toxiproxy.model.Toxic;
 import redis.clients.jedis.*;
 import redis.clients.jedis.MultiClusterClientConfig.ClusterConfig;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
 import redis.clients.jedis.scenario.ActiveActiveFailoverTest;
 import redis.clients.jedis.scenario.MultiThreadedFakeApp;
 import redis.clients.jedis.scenario.RecommendedSettings;

--- a/src/test/java/redis/clients/jedis/mcf/EchoStrategyIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/EchoStrategyIntegrationTest.java
@@ -13,6 +13,7 @@ import redis.clients.jedis.EndpointConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.HostAndPorts;
 import redis.clients.jedis.JedisClientConfig;
+import redis.clients.jedis.exceptions.JedisException;
 
 import java.io.IOException;
 
@@ -68,8 +69,7 @@ public class EchoStrategyIntegrationTest {
       redisProxy.disable();
 
       // Health check should now fail - this will expose the bug
-      HealthStatus statusAfterDisable = strategy.doHealthCheck(proxyHostAndPort);
-      assertEquals(HealthStatus.UNHEALTHY, statusAfterDisable);
+      assertThrows(JedisException.class, () -> strategy.doHealthCheck(proxyHostAndPort));
 
       // Re-enable proxy
       redisProxy.enable();
@@ -86,7 +86,7 @@ public class EchoStrategyIntegrationTest {
         .connectionTimeoutMillis(100).build();
 
     try (EchoStrategy strategy = new EchoStrategy(proxyHostAndPort, config,
-        new HealthCheckStrategy.Config(1000, 500, 1))) {
+        HealthCheckStrategy.Config.builder().interval(1000).timeout(500).numProbes(1).build())) {
 
       // Initial health check should work
       assertEquals(HealthStatus.HEALTHY, strategy.doHealthCheck(proxyHostAndPort));
@@ -95,9 +95,7 @@ public class EchoStrategyIntegrationTest {
       redisProxy.toxics().latency("slow-connection", ToxicDirection.DOWNSTREAM, 1000);
 
       // Health check should timeout and return unhealthy
-      HealthStatus slowStatus = strategy.doHealthCheck(proxyHostAndPort);
-      assertEquals(HealthStatus.UNHEALTHY, slowStatus,
-        "Health check should fail with high latency");
+      assertThrows(JedisException.class, () -> strategy.doHealthCheck(proxyHostAndPort));
 
       // Remove toxic
       redisProxy.toxics().get("slow-connection").remove();
@@ -122,8 +120,7 @@ public class EchoStrategyIntegrationTest {
       redisProxy.toxics().limitData("connection-drop", ToxicDirection.UPSTREAM, 10);
 
       // This should fail due to connection issues
-      HealthStatus droppedStatus = strategy.doHealthCheck(proxyHostAndPort);
-      assertEquals(HealthStatus.UNHEALTHY, droppedStatus);
+      assertThrows(JedisException.class, () -> strategy.doHealthCheck(proxyHostAndPort));
 
       // Remove toxic
       redisProxy.toxics().get("connection-drop").remove();

--- a/src/test/java/redis/clients/jedis/mcf/FailbackMechanismIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/FailbackMechanismIntegrationTest.java
@@ -19,8 +19,6 @@ import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.MultiClusterClientConfig;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProviderHelper;
 
 @ExtendWith(MockitoExtension.class)
 class FailbackMechanismIntegrationTest {

--- a/src/test/java/redis/clients/jedis/mcf/HealthCheckIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/HealthCheckIntegrationTest.java
@@ -1,22 +1,26 @@
 package redis.clients.jedis.mcf;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType;
-import redis.clients.jedis.Endpoint;
 import redis.clients.jedis.EndpointConfig;
 import redis.clients.jedis.HostAndPorts;
 import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.MultiClusterClientConfig;
 import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.MultiClusterClientConfig.ClusterConfig;
+import redis.clients.jedis.MultiClusterClientConfig.StrategySupplier;
+import redis.clients.jedis.mcf.ProbingPolicy.BuiltIn;
 import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
 import redis.clients.jedis.scenario.RecommendedSettings;
 
@@ -58,30 +62,16 @@ public class HealthCheckIntegrationTest {
     // Create a StrategySupplier that uses the JedisClientConfig when available
     MultiClusterClientConfig.StrategySupplier strategySupplier = (hostAndPort,
         jedisClientConfig) -> {
-      return new HealthCheckStrategy() {
-
-        @Override
-        public int getInterval() {
-          return 500;
-        }
-
-        @Override
-        public int getTimeout() {
-          return 500;
-        }
-
-        @Override
-        public HealthStatus doHealthCheck(Endpoint endpoint) {
-          // Create connection per health check to avoid resource leak
-          try (UnifiedJedis pinger = new UnifiedJedis(hostAndPort, jedisClientConfig)) {
-            String result = pinger.ping();
-            return "PONG".equals(result) ? HealthStatus.HEALTHY : HealthStatus.UNHEALTHY;
-          } catch (Exception e) {
-            return HealthStatus.UNHEALTHY;
-          }
-        }
-
-      };
+      return new TestHealthCheckStrategy(HealthCheckStrategy.Config.builder().interval(500)
+          .timeout(500).numProbes(1).policy(BuiltIn.ANY_SUCCESS).build(), (endpoint) -> {
+            // Create connection per health check to avoid resource leak
+            try (UnifiedJedis pinger = new UnifiedJedis(hostAndPort, jedisClientConfig)) {
+              String result = pinger.ping();
+              return "PONG".equals(result) ? HealthStatus.HEALTHY : HealthStatus.UNHEALTHY;
+            } catch (Exception e) {
+              return HealthStatus.UNHEALTHY;
+            }
+          });
     };
 
     MultiClusterPooledConnectionProvider customProvider = getMCCF(strategySupplier);
@@ -112,4 +102,162 @@ public class HealthCheckIntegrationTest {
 
     return new MultiClusterPooledConnectionProvider(mccf);
   }
+
+  // ========== Probe Logic Integration Tests ==========
+  @Test
+  public void testProbingLogic_RealHealthCheckWithProbes() throws InterruptedException {
+    // Create a strategy that fails first few times then succeeds
+    AtomicInteger attemptCount = new AtomicInteger(0);
+
+    StrategySupplier strategySupplier = (hostAndPort, jedisClientConfig) -> {
+      // Fast interval, short timeout, 3 probes, short delay
+      return new TestHealthCheckStrategy(100, 50, 3, BuiltIn.ANY_SUCCESS, 20, (endpoint) -> {
+        int attempt = attemptCount.incrementAndGet();
+        if (attempt <= 2) {
+          // First 2 attempts fail
+          throw new RuntimeException("Simulated failure on attempt " + attempt);
+        }
+        // Third attempt succeeds - do actual health check
+        try (UnifiedJedis jedis = new UnifiedJedis(hostAndPort, jedisClientConfig)) {
+          String result = jedis.echo("HealthCheck");
+          return "HealthCheck".equals(result) ? HealthStatus.HEALTHY : HealthStatus.UNHEALTHY;
+        } catch (Exception e) {
+          return HealthStatus.UNHEALTHY;
+        }
+      });
+    };
+
+    CountDownLatch healthyLatch = new CountDownLatch(1);
+    HealthStatusManager manager = new HealthStatusManager();
+
+    // Register listener to detect when health becomes HEALTHY
+    manager.registerListener(endpoint1.getHostAndPort(), event -> {
+      if (event.getNewStatus() == HealthStatus.HEALTHY) {
+        healthyLatch.countDown();
+      }
+    });
+
+    // Add health check with strategy
+    HealthCheck healthCheck = manager.add(endpoint1.getHostAndPort(),
+      strategySupplier.get(endpoint1.getHostAndPort(), clientConfig));
+
+    try {
+      // Wait for health check to eventually succeed after probes
+      assertTrue(healthyLatch.await(5, TimeUnit.SECONDS),
+        "Health check should succeed after probes");
+
+      assertEquals(HealthStatus.HEALTHY, healthCheck.getStatus());
+
+      // Verify that multiple attempts were made (should be 3: 2 failures + 1 success)
+      assertTrue(attemptCount.get() >= 3,
+        "Should have made at least 3 probes, but made: " + attemptCount.get());
+
+    } finally {
+      manager.remove(endpoint1.getHostAndPort());
+    }
+  }
+
+  @Test
+  public void testProbingLogic_ExhaustProbesAndStayUnhealthy() throws InterruptedException {
+    // Create a strategy that always fails
+    AtomicInteger attemptCount = new AtomicInteger(0);
+
+    StrategySupplier alwaysFailSupplier = (hostAndPort, jedisClientConfig) -> {
+      // Fast interval, short timeout, 3 probes, short delay
+      return new TestHealthCheckStrategy(100, 50, 3, BuiltIn.ANY_SUCCESS, 10, (endpoint) -> {
+        attemptCount.incrementAndGet();
+        throw new RuntimeException("Always fails");
+      });
+    };
+
+    CountDownLatch unhealthyLatch = new CountDownLatch(1);
+    HealthStatusManager manager = new HealthStatusManager();
+
+    // Register listener to detect when health becomes UNHEALTHY
+    manager.registerListener(endpoint1.getHostAndPort(), event -> {
+      if (event.getNewStatus() == HealthStatus.UNHEALTHY) {
+        unhealthyLatch.countDown();
+      }
+    });
+
+    // Add health check with always-fail strategy
+    HealthCheck healthCheck = manager.add(endpoint1.getHostAndPort(),
+      alwaysFailSupplier.get(endpoint1.getHostAndPort(), clientConfig));
+
+    try {
+      // Wait for health check to fail after exhausting probes
+      assertTrue(unhealthyLatch.await(3, TimeUnit.SECONDS),
+        "Health check should become UNHEALTHY after exhausting probes");
+
+      assertEquals(HealthStatus.UNHEALTHY, healthCheck.getStatus());
+
+      // Verify that all attempts were made (should 3 probes)
+      assertTrue(attemptCount.get() >= 3,
+        "Should have made at least 3 attempts , but made: " + attemptCount.get());
+
+    } finally {
+      manager.remove(endpoint1.getHostAndPort());
+    }
+  }
+
+  @Test
+  public void testProbingLogic_AllSuccess_EarlyFail_Integration() throws InterruptedException {
+    AtomicInteger attemptCount = new AtomicInteger(0);
+
+    StrategySupplier supplier = (hostAndPort, jedisClientConfig) -> new TestHealthCheckStrategy(100,
+        100, 3, BuiltIn.ALL_SUCCESS, 10, e -> {
+          int c = attemptCount.incrementAndGet();
+          return c == 1 ? HealthStatus.UNHEALTHY : HealthStatus.HEALTHY;
+        });
+
+    CountDownLatch unhealthyLatch = new CountDownLatch(1);
+    HealthStatusManager manager = new HealthStatusManager();
+
+    manager.registerListener(endpoint1.getHostAndPort(), event -> {
+      if (event.getNewStatus() == HealthStatus.UNHEALTHY) unhealthyLatch.countDown();
+    });
+
+    HealthCheck hc = manager.add(endpoint1.getHostAndPort(),
+      supplier.get(endpoint1.getHostAndPort(), clientConfig));
+
+    try {
+      assertTrue(unhealthyLatch.await(2, TimeUnit.SECONDS),
+        "Should become UNHEALTHY after first failure with ALL_SUCCESS");
+      assertEquals(HealthStatus.UNHEALTHY, hc.getStatus());
+      assertEquals(1, attemptCount.get());
+    } finally {
+      manager.remove(endpoint1.getHostAndPort());
+    }
+  }
+
+  @Test
+  public void testProbingLogic_Majority_EarlySuccess_Integration() throws InterruptedException {
+    AtomicInteger attemptCount = new AtomicInteger(0);
+
+    StrategySupplier supplier = (hostAndPort, jedisClientConfig) -> new TestHealthCheckStrategy(100,
+        100, 5, BuiltIn.MAJORITY_SUCCESS, 10, e -> {
+          int c = attemptCount.incrementAndGet();
+          return c <= 3 ? HealthStatus.HEALTHY : HealthStatus.UNHEALTHY;
+        });
+
+    CountDownLatch healthyLatch = new CountDownLatch(1);
+    HealthStatusManager manager = new HealthStatusManager();
+
+    manager.registerListener(endpoint1.getHostAndPort(), event -> {
+      if (event.getNewStatus() == HealthStatus.HEALTHY) healthyLatch.countDown();
+    });
+
+    HealthCheck hc = manager.add(endpoint1.getHostAndPort(),
+      supplier.get(endpoint1.getHostAndPort(), clientConfig));
+
+    try {
+      assertTrue(healthyLatch.await(2, TimeUnit.SECONDS),
+        "Should become HEALTHY after reaching majority successes");
+      assertEquals(HealthStatus.HEALTHY, hc.getStatus());
+      assertEquals(3, attemptCount.get());
+    } finally {
+      manager.remove(endpoint1.getHostAndPort());
+    }
+  }
+
 }

--- a/src/test/java/redis/clients/jedis/mcf/HealthCheckIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/HealthCheckIntegrationTest.java
@@ -21,7 +21,6 @@ import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.MultiClusterClientConfig.ClusterConfig;
 import redis.clients.jedis.MultiClusterClientConfig.StrategySupplier;
 import redis.clients.jedis.mcf.ProbingPolicy.BuiltIn;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
 import redis.clients.jedis.scenario.RecommendedSettings;
 
 public class HealthCheckIntegrationTest {

--- a/src/test/java/redis/clients/jedis/mcf/HealthCheckTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/HealthCheckTest.java
@@ -11,12 +11,16 @@ import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.MultiClusterClientConfig;
 import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.mcf.ProbingPolicy.BuiltIn;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,22 +35,8 @@ public class HealthCheckTest {
   @Mock
   private HealthCheckStrategy mockStrategy;
 
-  private final HealthCheckStrategy alwaysHealthyStrategy = new HealthCheckStrategy() {
-    @Override
-    public int getInterval() {
-      return 100;
-    }
-
-    @Override
-    public int getTimeout() {
-      return 50;
-    }
-
-    @Override
-    public HealthStatus doHealthCheck(Endpoint endpoint) {
-      return HealthStatus.HEALTHY;
-    }
-  };
+  private final HealthCheckStrategy alwaysHealthyStrategy = new TestHealthCheckStrategy(100, 50, 1,
+      BuiltIn.ANY_SUCCESS, 10, e -> HealthStatus.HEALTHY);
 
   @Mock
   private Consumer<HealthStatusChangeEvent> mockCallback;
@@ -59,6 +49,11 @@ public class HealthCheckTest {
     MockitoAnnotations.openMocks(this);
     testEndpoint = new HostAndPort("localhost", 6379);
     testConfig = DefaultJedisClientConfig.builder().build();
+
+    // Default stubs for mockStrategy used across tests
+    when(mockStrategy.getNumProbes()).thenReturn(1);
+    when(mockStrategy.getDelayInBetweenProbes()).thenReturn(100);
+    when(mockStrategy.getPolicy()).thenReturn(BuiltIn.ANY_SUCCESS);
   }
 
   // ========== HealthCheckCollection Tests ==========
@@ -306,6 +301,7 @@ public class HealthCheckTest {
   @Test
   void testHealthStatusManagerClose() {
     HealthCheckStrategy closeableStrategy = mock(HealthCheckStrategy.class);
+    when(closeableStrategy.getNumProbes()).thenReturn(1);
     when(closeableStrategy.getInterval()).thenReturn(1000);
     when(closeableStrategy.getTimeout()).thenReturn(500);
     when(closeableStrategy.doHealthCheck(any(Endpoint.class))).thenReturn(HealthStatus.HEALTHY);
@@ -326,11 +322,15 @@ public class HealthCheckTest {
 
   @Test
   void testEchoStrategyCustomIntervalTimeout() {
-    EchoStrategy strategy = new EchoStrategy(testEndpoint, testConfig,
-        new HealthCheckStrategy.Config(2000, 1500, 1000));
-
-    assertEquals(2000, strategy.getInterval());
-    assertEquals(1500, strategy.getTimeout());
+    try (EchoStrategy strategy = new EchoStrategy(testEndpoint, testConfig,
+        HealthCheckStrategy.Config.builder().interval(2000).timeout(1500).delayInBetweenProbes(50)
+            .numProbes(11).policy(BuiltIn.ANY_SUCCESS).build())) {
+      assertEquals(2000, strategy.getInterval());
+      assertEquals(1500, strategy.getTimeout());
+      assertEquals(11, strategy.getNumProbes());
+      assertEquals(BuiltIn.ANY_SUCCESS, strategy.getPolicy());
+      assertEquals(50, strategy.getDelayInBetweenProbes());
+    }
   }
 
   @Test
@@ -452,33 +452,28 @@ public class HealthCheckTest {
   @Test
   @Timeout(5)
   void testHealthCheckRecoversAfterException() throws InterruptedException {
-    // Create a mock strategy that alternates between healthy and throwing an exception
-    HealthCheckStrategy alternatingStrategy = new HealthCheckStrategy() {
-      volatile boolean isHealthy = true;
+    // Create a strategy that alternates between exception/UNHEALTHY and HEALTHY
+    AtomicBoolean isHealthy = new AtomicBoolean(true);
+    AtomicInteger exceptionOccurred = new AtomicInteger(0);
+    int exceptionLimit = 2;
+    HealthCheckStrategy alternatingStrategy = new TestHealthCheckStrategy(
+        HealthCheckStrategy.Config.builder().interval(1).timeout(5).numProbes(1).build(), e -> {
+          if (isHealthy.get()) {
+            isHealthy.set(false);
+            if (exceptionOccurred.getAndIncrement() < exceptionLimit) {
+              throw new RuntimeException("Simulated exception");
+            } else {
+              return HealthStatus.UNHEALTHY;
+            }
+          } else {
+            isHealthy.set(true);
+            return HealthStatus.HEALTHY;
+          }
+        });
 
-      @Override
-      public int getInterval() {
-        return 1;
-      }
-
-      @Override
-      public int getTimeout() {
-        return 5;
-      }
-
-      @Override
-      public HealthStatus doHealthCheck(Endpoint endpoint) {
-        if (isHealthy) {
-          isHealthy = false;
-          throw new RuntimeException("Simulated exception");
-        } else {
-          isHealthy = true;
-          return HealthStatus.HEALTHY;
-        }
-      }
-    };
-
-    CountDownLatch statusChangeLatch = new CountDownLatch(2); // Wait for 2 status changes
+    // Wait for 2 status changes,
+    // it will start with unhealthy(due to simulated exception) and then switch to healthy
+    CountDownLatch statusChangeLatch = new CountDownLatch(2);
     HealthStatusListener listener = event -> statusChangeLatch.countDown();
 
     HealthStatusManager manager = new HealthStatusManager();
@@ -495,25 +490,13 @@ public class HealthCheckTest {
   void testHealthCheckIntegration() throws InterruptedException {
     // Create a mock strategy that alternates between healthy and unhealthy
     AtomicReference<HealthStatus> statusToReturn = new AtomicReference<>(HealthStatus.HEALTHY);
-    HealthCheckStrategy alternatingStrategy = new HealthCheckStrategy() {
-      @Override
-      public int getInterval() {
-        return 100;
-      }
-
-      @Override
-      public int getTimeout() {
-        return 50;
-      }
-
-      @Override
-      public HealthStatus doHealthCheck(Endpoint endpoint) {
-        HealthStatus current = statusToReturn.get();
-        statusToReturn
-            .set(current == HealthStatus.HEALTHY ? HealthStatus.UNHEALTHY : HealthStatus.HEALTHY);
-        return current;
-      }
-    };
+    HealthCheckStrategy alternatingStrategy = new TestHealthCheckStrategy(100, 50, 1,
+        BuiltIn.ALL_SUCCESS, 10, e -> {
+          HealthStatus current = statusToReturn.get();
+          statusToReturn
+              .set(current == HealthStatus.HEALTHY ? HealthStatus.UNHEALTHY : HealthStatus.HEALTHY);
+          return current;
+        });
 
     CountDownLatch statusChangeLatch = new CountDownLatch(2); // Wait for 2 status changes
     HealthStatusListener listener = event -> statusChangeLatch.countDown();
@@ -533,7 +516,7 @@ public class HealthCheckTest {
     MultiClusterClientConfig.StrategySupplier supplier = (hostAndPort, jedisClientConfig) -> {
       if (jedisClientConfig != null) {
         return new EchoStrategy(hostAndPort, jedisClientConfig,
-            new HealthCheckStrategy.Config(500, 250, 1));
+            HealthCheckStrategy.Config.builder().interval(500).timeout(250).numProbes(1).build());
       } else {
         return new EchoStrategy(hostAndPort, DefaultJedisClientConfig.builder().build());
       }
@@ -551,4 +534,273 @@ public class HealthCheckTest {
     assertEquals(1000, strategyWithoutConfig.getInterval()); // Default values
     assertEquals(1000, strategyWithoutConfig.getTimeout());
   }
+
+  // ========== Retry Logic Unit Tests ==========
+
+  @Test
+  void testRetryLogic_SuccessOnFirstAttempt() throws InterruptedException {
+    AtomicInteger callCount = new AtomicInteger(0);
+    TestHealthCheckStrategy strategy = new TestHealthCheckStrategy(100, 50, 2, BuiltIn.ANY_SUCCESS,
+        10, e -> {
+          callCount.incrementAndGet();
+          return HealthStatus.HEALTHY; // Always succeeds
+        });
+
+    CountDownLatch latch = new CountDownLatch(1);
+    Consumer<HealthStatusChangeEvent> callback = event -> latch.countDown();
+
+    HealthCheck healthCheck = new HealthCheckImpl(testEndpoint, strategy, callback);
+    healthCheck.start();
+
+    assertTrue(latch.await(2, TimeUnit.SECONDS));
+    assertEquals(HealthStatus.HEALTHY, healthCheck.getStatus());
+
+    // Should only call doHealthCheck once (no retries needed)
+    assertEquals(1, callCount.get());
+
+    healthCheck.stop();
+  }
+
+  @Test
+  void testRetryLogic_FailThenSucceedOnRetry() throws InterruptedException {
+    AtomicInteger callCount = new AtomicInteger(0);
+    TestHealthCheckStrategy strategy = new TestHealthCheckStrategy(100, 50, 2, BuiltIn.ANY_SUCCESS,
+        10, e -> {
+          int attempt = callCount.incrementAndGet();
+          if (attempt == 1) {
+            throw new RuntimeException("First attempt fails");
+          }
+          return HealthStatus.HEALTHY; // Second attempt succeeds
+        });
+
+    CountDownLatch latch = new CountDownLatch(1);
+    Consumer<HealthStatusChangeEvent> callback = event -> {
+      if (event.getNewStatus() == HealthStatus.HEALTHY) {
+        latch.countDown();
+      }
+    };
+
+    HealthCheck healthCheck = new HealthCheckImpl(testEndpoint, strategy, callback);
+    healthCheck.start();
+
+    assertTrue(latch.await(3, TimeUnit.SECONDS));
+    assertEquals(HealthStatus.HEALTHY, healthCheck.getStatus());
+
+    // Should call doHealthCheck twice (first fails, second succeeds)
+    assertEquals(2, callCount.get());
+
+    healthCheck.stop();
+  }
+
+  @Test
+  void testRetryLogic_ExhaustAllProbesAndFail() throws InterruptedException {
+    AtomicInteger callCount = new AtomicInteger(0);
+    TestHealthCheckStrategy strategy = new TestHealthCheckStrategy(100, 50, 3, BuiltIn.ANY_SUCCESS,
+        10, e -> {
+          callCount.incrementAndGet();
+          throw new RuntimeException("Always fails");
+        });
+
+    CountDownLatch latch = new CountDownLatch(1);
+    Consumer<HealthStatusChangeEvent> callback = event -> {
+      if (event.getNewStatus() == HealthStatus.UNHEALTHY) {
+        latch.countDown();
+      }
+    };
+
+    HealthCheck healthCheck = new HealthCheckImpl(testEndpoint, strategy, callback);
+    healthCheck.start();
+
+    assertTrue(latch.await(3, TimeUnit.SECONDS));
+    assertEquals(HealthStatus.UNHEALTHY, healthCheck.getStatus());
+
+    // Should call doHealthCheck 3 times (all probes fail)
+    assertEquals(3, callCount.get());
+
+    healthCheck.stop();
+  }
+
+  @Test
+  void testRetryLogic_ZeroProbes() throws InterruptedException {
+    AtomicInteger callCount = new AtomicInteger(0);
+    TestHealthCheckStrategy strategy = new TestHealthCheckStrategy(100, 50, 0, BuiltIn.ANY_SUCCESS,
+        10, e -> {
+          callCount.incrementAndGet();
+          throw new RuntimeException("Fails");
+        });
+
+    CountDownLatch latch = new CountDownLatch(1);
+    Consumer<HealthStatusChangeEvent> callback = event -> {
+      if (event.getNewStatus() == HealthStatus.UNHEALTHY) {
+        latch.countDown();
+      }
+    };
+
+    assertThrows(IllegalArgumentException.class,
+      () -> new HealthCheckImpl(testEndpoint, strategy, callback));
+  }
+
+  @Test
+  void testRetryLogic_NegativeProbes() throws InterruptedException {
+    AtomicInteger callCount = new AtomicInteger(0);
+    TestHealthCheckStrategy strategy = new TestHealthCheckStrategy(100, 50, -1, BuiltIn.ANY_SUCCESS,
+        10, e -> {
+          callCount.incrementAndGet();
+          throw new RuntimeException("Fails");
+        });
+
+    CountDownLatch latch = new CountDownLatch(1);
+    Consumer<HealthStatusChangeEvent> callback = event -> {
+      if (event.getNewStatus() == HealthStatus.UNHEALTHY) {
+        latch.countDown();
+      }
+    };
+
+    assertThrows(IllegalArgumentException.class,
+      () -> new HealthCheckImpl(testEndpoint, strategy, callback));
+  }
+
+  /**
+   * <p>
+   * - Verifies that the health check probes stop after the first probe when the scheduler thread is
+   * interrupted.
+   * <p>
+   * - The scheduler thread is the one that calls healthCheck(), which in turn calls
+   * doHealthCheck().
+   * <p>
+   * - This test interrupts the scheduler thread while it is waiting on the future from the first
+   * probe.
+   * <p>
+   * - The health check operation itself is not interrupted. This test does not validate
+   * interruption of the health check operation itself, as that is not the responsibility of the
+   * HealthCheckImpl.
+   */
+  @Test
+  void testRetryLogic_InterruptionStopsProbes() throws Exception {
+    AtomicInteger callCount = new AtomicInteger(0);
+    CountDownLatch schedulerTaskStarted = new CountDownLatch(1);
+    CountDownLatch statusChanged = new CountDownLatch(1);
+
+    Thread[] schedulerThread = new Thread[1];
+
+    final int OPERATION_TIMEOUT = 1000;
+    final int LESS_THAN_OPERATION_TIMEOUT = 800;
+    final int NUM_PROBES = 3;
+    // Long interval so no second run, generous timeout so we can interrupt while waiting
+    Function<Endpoint, HealthStatus> healthCheckOperation = e -> {
+      callCount.incrementAndGet();
+      try {
+        Thread.sleep(LESS_THAN_OPERATION_TIMEOUT); // keep worker busy so scheduler waits on
+                                                   // future.get
+      } catch (InterruptedException ie) {
+      }
+      return HealthStatus.UNHEALTHY;
+    };
+
+    // Override getPolicy() to capture the scheduler thread
+    HealthCheckStrategy strategy = new TestHealthCheckStrategy(5000, OPERATION_TIMEOUT, NUM_PROBES,
+        BuiltIn.ANY_SUCCESS, 10, healthCheckOperation) {
+      public ProbingPolicy getPolicy() {
+        schedulerThread[0] = Thread.currentThread();
+        schedulerTaskStarted.countDown();
+        return super.getPolicy();
+      }
+    };
+
+    Consumer<HealthStatusChangeEvent> callback = evt -> statusChanged.countDown();
+
+    HealthCheckImpl hc = new HealthCheckImpl(testEndpoint, strategy, callback);
+    hc.start();
+
+    // Ensure first probe is in flight (scheduler is blocked on future.get)
+    assertTrue(schedulerTaskStarted.await(1, TimeUnit.SECONDS), "Task should have started");
+
+    // Interrupt the scheduler thread that runs HealthCheckImpl.healthCheck()
+    schedulerThread[0].interrupt();
+
+    // No status change should be published because healthCheck() returns early without safeUpdate
+    assertFalse(statusChanged.await(hc.getMaxWaitFor(), TimeUnit.MILLISECONDS),
+      "No status change expected");
+    assertEquals(HealthStatus.UNKNOWN, hc.getStatus());
+
+    // Only the first probe should have been attempted
+    int calls = callCount.get();
+    assertTrue(calls <= 1, "Only one probe should have been attempted: " + calls);
+
+    hc.stop();
+  }
+
+  // ========== ProbingPolicy Unit Tests ==========
+  @Test
+  void testPolicy_AllSuccess_StopsOnFirstFailure() throws Exception {
+    AtomicInteger callCount = new AtomicInteger(0);
+    CountDownLatch unhealthyLatch = new CountDownLatch(1);
+
+    TestHealthCheckStrategy strategy = new TestHealthCheckStrategy(
+        HealthCheckStrategy.Config.builder().interval(5).timeout(200).numProbes(3)
+            .policy(BuiltIn.ALL_SUCCESS).delayInBetweenProbes(5).build(),
+        e -> {
+          int c = callCount.incrementAndGet();
+          return c == 1 ? HealthStatus.UNHEALTHY : HealthStatus.HEALTHY;
+        });
+
+    HealthCheckImpl hc = new HealthCheckImpl(testEndpoint, strategy, evt -> {
+      if (evt.getNewStatus() == HealthStatus.UNHEALTHY) unhealthyLatch.countDown();
+    });
+
+    hc.start();
+    assertTrue(unhealthyLatch.await(1, TimeUnit.SECONDS));
+    assertEquals(HealthStatus.UNHEALTHY, hc.getStatus());
+    assertEquals(1, callCount.get(), "ALL_SUCCESS should stop after first failure");
+    hc.stop();
+  }
+
+  @Test
+  void testPolicy_Majority_EarlySuccessStopsAtThree() throws Exception {
+    AtomicInteger callCount = new AtomicInteger(0);
+    CountDownLatch healthyLatch = new CountDownLatch(1);
+
+    TestHealthCheckStrategy strategy = new TestHealthCheckStrategy(
+        HealthCheckStrategy.Config.builder().interval(5000).timeout(200).numProbes(5)
+            .policy(BuiltIn.MAJORITY_SUCCESS).delayInBetweenProbes(5).build(),
+        e -> {
+          int c = callCount.incrementAndGet();
+          return c <= 3 ? HealthStatus.HEALTHY : HealthStatus.UNHEALTHY;
+        });
+
+    HealthCheckImpl hc = new HealthCheckImpl(testEndpoint, strategy, evt -> {
+      if (evt.getNewStatus() == HealthStatus.HEALTHY) healthyLatch.countDown();
+    });
+
+    hc.start();
+    assertTrue(healthyLatch.await(1, TimeUnit.SECONDS));
+    assertEquals(HealthStatus.HEALTHY, hc.getStatus());
+    assertEquals(3, callCount.get(), "MAJORITY early success should stop after 3 successes");
+    hc.stop();
+  }
+
+  @Test
+  void testPolicy_Majority_EarlyFailStopsAtTwo() throws Exception {
+    AtomicInteger callCount = new AtomicInteger(0);
+    CountDownLatch unhealthyLatch = new CountDownLatch(1);
+
+    TestHealthCheckStrategy strategy = new TestHealthCheckStrategy(
+        HealthCheckStrategy.Config.builder().interval(5).timeout(200).numProbes(4)
+            .policy(BuiltIn.MAJORITY_SUCCESS).delayInBetweenProbes(5).build(),
+        e -> {
+          int c = callCount.incrementAndGet();
+          return c <= 2 ? HealthStatus.UNHEALTHY : HealthStatus.HEALTHY;
+        });
+
+    HealthCheckImpl hc = new HealthCheckImpl(testEndpoint, strategy, evt -> {
+      if (evt.getNewStatus() == HealthStatus.UNHEALTHY) unhealthyLatch.countDown();
+    });
+
+    hc.start();
+    assertTrue(unhealthyLatch.await(1, TimeUnit.SECONDS));
+    assertEquals(HealthStatus.UNHEALTHY, hc.getStatus());
+    assertEquals(2, callCount.get(), "MAJORITY early fail should stop when majority impossible");
+    hc.stop();
+  }
+
 }

--- a/src/test/java/redis/clients/jedis/mcf/LagAwareStrategyUnitTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/LagAwareStrategyUnitTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.*;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +17,7 @@ import org.mockito.MockedConstruction;
 import redis.clients.jedis.DefaultRedisCredentials;
 import redis.clients.jedis.Endpoint;
 import redis.clients.jedis.RedisCredentials;
+import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.mcf.LagAwareStrategy.Config;
 
 public class LagAwareStrategyUnitTest {
@@ -54,34 +54,32 @@ public class LagAwareStrategyUnitTest {
         reference[0] = mock;
       })) {
       Config lagCheckConfig = Config.builder(endpoint, creds).interval(500).timeout(250)
-          .minConsecutiveSuccessCount(2).build();
+          .numProbes(2).build();
       try (LagAwareStrategy strategy = new LagAwareStrategy(lagCheckConfig)) {
         assertEquals(HealthStatus.HEALTHY, strategy.doHealthCheck(endpoint));
         RedisRestAPI api = reference[0];
-        reset(api);
-        when(api.checkBdbAvailability("1", true, 100L)).thenReturn(true);
 
         assertEquals(HealthStatus.HEALTHY, strategy.doHealthCheck(endpoint));
-        verify(api, never()).getBdbs(); // Should not call getBdbs again when cached
-        verify(api, times(1)).checkBdbAvailability("1", true, 100L);
+        verify(api, times(1)).getBdbs(); // Should not call getBdbs again when cached
+        verify(api, times(2)).checkBdbAvailability("1", true, 100L);
       }
     }
   }
 
   @Test
-  void unhealthy_when_no_bdb_returned() throws Exception {
-    AtomicReference<RedisRestAPI> ref = new AtomicReference<RedisRestAPI>();
+  void exception_when_no_bdb_returned() throws Exception {
+    RedisRestAPI[] reference = new RedisRestAPI[1];
     try (MockedConstruction<RedisRestAPI> mockedConstructor = mockConstruction(RedisRestAPI.class,
       (mock, context) -> {
         when(mock.getBdbs()).thenReturn(Collections.emptyList()); // No BDBs found
-        ref.set(mock);
+        reference[0] = mock;
       })) {
 
       Config lagCheckConfig = Config.builder(endpoint, creds).interval(500).timeout(250)
-          .minConsecutiveSuccessCount(1).build();
+          .numProbes(1).build();
       try (LagAwareStrategy strategy = new LagAwareStrategy(lagCheckConfig)) {
-        assertEquals(HealthStatus.UNHEALTHY, strategy.doHealthCheck(endpoint));
-        RedisRestAPI api = ref.get();
+        assertThrows(JedisException.class, () -> strategy.doHealthCheck(endpoint));
+        RedisRestAPI api = reference[0];
         verify(api, times(1)).getBdbs();
         verify(api, never()).checkBdbAvailability(anyString(), anyBoolean());
       }
@@ -89,28 +87,35 @@ public class LagAwareStrategyUnitTest {
   }
 
   @Test
-  void unhealthy_and_cache_reset_on_exception_then_recovers_next_time() throws Exception {
+  void exception_and_cache_reset_on_exception_then_recovers_next_time() throws Exception {
     RedisRestAPI.BdbInfo bdbInfo = new RedisRestAPI.BdbInfo("42", Arrays.asList(
       new RedisRestAPI.EndpointInfo(Arrays.asList("127.0.0.1"), "localhost", 6379, "1:1")));
 
-    AtomicReference<RedisRestAPI> ref = new AtomicReference<RedisRestAPI>();
+    RedisRestAPI[] reference = new RedisRestAPI[1];
     try (MockedConstruction<RedisRestAPI> mockedConstructor = mockConstruction(RedisRestAPI.class,
       (mock, context) -> {
-        when(mock.getBdbs()).thenThrow(new RuntimeException("boom"));
-        ref.set(mock);
+        // First call throws exception, second call returns bdbInfo
+        when(mock.getBdbs()).thenThrow(new RuntimeException("boom"))
+            .thenReturn(Arrays.asList(bdbInfo));
+        when(mock.checkBdbAvailability("42", true, 100L)).thenReturn(true);
+        reference[0] = mock;
       })) {
 
       Config lagCheckConfig = Config.builder(endpoint, creds).interval(500).timeout(250)
-          .minConsecutiveSuccessCount(1).build();
+          .numProbes(1).build();
       try (LagAwareStrategy strategy = new LagAwareStrategy(lagCheckConfig)) {
-        RedisRestAPI api = ref.get();
-        assertEquals(HealthStatus.UNHEALTHY, strategy.doHealthCheck(endpoint));
+        RedisRestAPI api = reference[0];
 
-        reset(api);
-        when(api.getBdbs()).thenReturn(Arrays.asList(bdbInfo));
-        when(api.checkBdbAvailability("42", true, 100L)).thenReturn(true);
+        // First call should throw JedisException due to getBdbs() throwing RuntimeException
+        assertThrows(JedisException.class, () -> strategy.doHealthCheck(endpoint));
 
+        // Second call should succeed - getBdbs() now returns bdbInfo and availability check passes
         assertEquals(HealthStatus.HEALTHY, strategy.doHealthCheck(endpoint));
+
+        // Verify getBdbs was called twice (once failed, once succeeded)
+        verify(api, times(2)).getBdbs();
+        // Verify availability check was called only once (on the successful attempt)
+        verify(api, times(1)).checkBdbAvailability("42", true, 100L);
       }
     }
   }
@@ -128,8 +133,8 @@ public class LagAwareStrategyUnitTest {
         reference[0] = mock;
       })) {
       Config lagCheckConfig = Config.builder(endpoint, creds).interval(500).timeout(250)
-          .minConsecutiveSuccessCount(2).extendedCheckEnabled(true)
-          .availabilityLagTolerance(Duration.ofMillis(100)).build();
+          .numProbes(2).extendedCheckEnabled(true).availabilityLagTolerance(Duration.ofMillis(100))
+          .build();
       try (LagAwareStrategy strategy = new LagAwareStrategy(lagCheckConfig)) {
         assertEquals(HealthStatus.HEALTHY, strategy.doHealthCheck(endpoint));
         RedisRestAPI api = reference[0];
@@ -140,7 +145,7 @@ public class LagAwareStrategyUnitTest {
   }
 
   @Test
-  void unhealthy_when_no_matching_host_found() throws Exception {
+  void exception_when_no_matching_host_found() throws Exception {
     RedisRestAPI.BdbInfo nonMatchingBdb = new RedisRestAPI.BdbInfo("other-bdb-456",
         Arrays.asList(new RedisRestAPI.EndpointInfo(Arrays.asList("192.168.1.100"),
             "other-host.example.com", 6379, "2:1")));
@@ -153,9 +158,9 @@ public class LagAwareStrategyUnitTest {
         reference[0] = mock;
       })) {
       Config lagCheckConfig = Config.builder(endpoint, creds).interval(500).timeout(250)
-          .minConsecutiveSuccessCount(2).build();
+          .numProbes(2).build();
       try (LagAwareStrategy strategy = new LagAwareStrategy(lagCheckConfig)) {
-        assertEquals(HealthStatus.UNHEALTHY, strategy.doHealthCheck(endpoint));
+        assertThrows(JedisException.class, () -> strategy.doHealthCheck(endpoint));
         RedisRestAPI api = reference[0];
         verify(api, times(1)).getBdbs();
         verify(api, never()).checkBdbAvailability(anyString(), anyBoolean()); // Should not check
@@ -170,7 +175,7 @@ public class LagAwareStrategyUnitTest {
 
     assertEquals(1000, config.interval);
     assertEquals(1000, config.timeout);
-    assertEquals(3, config.minConsecutiveSuccessCount);
+    assertEquals(3, config.numProbes);
     assertEquals(Duration.ofMillis(100), config.getAvailabilityLagTolerance());
     assertEquals(endpoint, config.getRestEndpoint());
     assertEquals(creds, config.getCredentialsSupplier());
@@ -178,12 +183,12 @@ public class LagAwareStrategyUnitTest {
 
   @Test
   void config_builder_creates_config_with_custom_values() {
-    Config config = Config.builder(endpoint, creds).interval(500).timeout(250)
-        .minConsecutiveSuccessCount(2).availabilityLagTolerance(Duration.ofMillis(50)).build();
+    Config config = Config.builder(endpoint, creds).interval(500).timeout(250).numProbes(2)
+        .availabilityLagTolerance(Duration.ofMillis(50)).build();
 
     assertEquals(500, config.interval);
     assertEquals(250, config.timeout);
-    assertEquals(2, config.minConsecutiveSuccessCount);
+    assertEquals(2, config.numProbes);
     assertEquals(Duration.ofMillis(50), config.getAvailabilityLagTolerance());
     assertEquals(endpoint, config.getRestEndpoint());
     assertEquals(creds, config.getCredentialsSupplier());
@@ -192,13 +197,13 @@ public class LagAwareStrategyUnitTest {
   @Test
   void config_builder_allows_fluent_chaining() {
     // Test that all builder methods return the builder instance for chaining
-    Config config = Config.builder(endpoint, creds).interval(800).timeout(400)
-        .minConsecutiveSuccessCount(5).availabilityLagTolerance(Duration.ofMillis(200)).build();
+    Config config = Config.builder(endpoint, creds).interval(800).timeout(400).numProbes(5)
+        .availabilityLagTolerance(Duration.ofMillis(200)).build();
 
     assertNotNull(config);
     assertEquals(800, config.interval);
     assertEquals(400, config.timeout);
-    assertEquals(5, config.minConsecutiveSuccessCount);
+    assertEquals(5, config.numProbes);
     assertEquals(Duration.ofMillis(200), config.getAvailabilityLagTolerance());
   }
 
@@ -272,11 +277,11 @@ public class LagAwareStrategyUnitTest {
   @Test
   void base_config_builder_factory_method_works() {
     HealthCheckStrategy.Config config = HealthCheckStrategy.Config.builder().interval(2000)
-        .timeout(1500).minConsecutiveSuccessCount(5).build();
+        .timeout(1500).numProbes(5).build();
 
     assertEquals(2000, config.getInterval());
     assertEquals(1500, config.getTimeout());
-    assertEquals(5, config.getMinConsecutiveSuccessCount());
+    assertEquals(5, config.getNumProbes());
   }
 
   @Test
@@ -285,6 +290,6 @@ public class LagAwareStrategyUnitTest {
 
     assertEquals(1000, config.getInterval());
     assertEquals(1000, config.getTimeout());
-    assertEquals(3, config.getMinConsecutiveSuccessCount());
+    assertEquals(3, config.getNumProbes());
   }
 }

--- a/src/test/java/redis/clients/jedis/mcf/MultiClusterDynamicEndpointUnitTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiClusterDynamicEndpointUnitTest.java
@@ -14,7 +14,6 @@ import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.MultiClusterClientConfig;
 import redis.clients.jedis.MultiClusterClientConfig.ClusterConfig;
 import redis.clients.jedis.exceptions.JedisValidationException;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doNothing;

--- a/src/test/java/redis/clients/jedis/mcf/MultiClusterFailoverAttemptsConfigTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiClusterFailoverAttemptsConfigTest.java
@@ -1,0 +1,199 @@
+package redis.clients.jedis.mcf;
+
+import org.awaitility.Durations;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisClientConfig;
+import redis.clients.jedis.MultiClusterClientConfig;
+import redis.clients.jedis.MultiClusterClientConfig.ClusterConfig;
+import redis.clients.jedis.mcf.JedisFailoverException.JedisPermanentlyNotAvailableException;
+import redis.clients.jedis.mcf.JedisFailoverException.JedisTemporarilyNotAvailableException;
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Tests for how getMaxNumFailoverAttempts and getDelayInBetweenFailoverAttempts impact
+ * MultiClusterPooledConnectionProvider behaviour when no healthy clusters are available.
+ */
+public class MultiClusterFailoverAttemptsConfigTest {
+
+  private HostAndPort endpoint0 = new HostAndPort("purposefully-incorrect", 0000);
+  private HostAndPort endpoint1 = new HostAndPort("purposefully-incorrect", 0001);
+
+  private MultiClusterPooledConnectionProvider provider;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    JedisClientConfig clientCfg = DefaultJedisClientConfig.builder().build();
+
+    ClusterConfig[] clusterConfigs = new ClusterConfig[] {
+        ClusterConfig.builder(endpoint0, clientCfg).weight(1.0f).healthCheckEnabled(false).build(),
+        ClusterConfig.builder(endpoint1, clientCfg).weight(0.5f).healthCheckEnabled(false)
+            .build() };
+
+    MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(clusterConfigs);
+
+    // Use small values by default for tests unless overridden per-test via reflection
+    setBuilderFailoverConfig(builder, /* maxAttempts */ 10, /* delayMs */ 12000);
+
+    provider = new MultiClusterPooledConnectionProvider(builder.build());
+
+    // Disable both clusters to force handleNoHealthyCluster path
+    provider.getCluster(endpoint0).setDisabled(true);
+    provider.getCluster(endpoint1).setDisabled(true);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (provider != null) provider.close();
+  }
+
+  @Test
+  void delayBetweenFailoverAttempts_gatesCounterIncrementsWithinWindow() throws Exception {
+    // Configure: small max (2) with a large non-zero delay window to ensure rapid calls stay within
+    // window
+    setProviderFailoverConfig(/* maxAttempts */ 2, /* delayMs */ 5000);
+
+    assertEquals(2, getProviderMaxAttempts());
+    assertEquals(5000, getProviderDelayMs());
+    assertEquals(0, getProviderAttemptCount());
+
+    // First call: should throw temporary and start the freeze window, incrementing attempt count to
+    // 1
+    assertThrows(JedisTemporarilyNotAvailableException.class,
+      () -> MultiClusterPooledConnectionProviderHelper.switchToHealthyCluster(provider,
+        SwitchReason.HEALTH_CHECK, provider.getCluster()));
+    int afterFirst = getProviderAttemptCount();
+    assertEquals(1, afterFirst);
+
+    // Many rapid subsequent calls within the delay window should continue to throw temporary
+    // and should NOT increment the attempt count beyond 1
+    for (int i = 0; i < 50; i++) {
+      assertThrows(JedisTemporarilyNotAvailableException.class,
+        () -> MultiClusterPooledConnectionProviderHelper.switchToHealthyCluster(provider,
+          SwitchReason.HEALTH_CHECK, provider.getCluster()));
+      assertEquals(1, getProviderAttemptCount());
+    }
+  }
+
+  @Test
+  void delayBetweenFailoverAttempts_permanentExceptionAfterAttemptsExhausted() throws Exception {
+    // Configure: small max (2) with a large non-zero delay window to ensure rapid calls stay within
+    // window
+    setProviderFailoverConfig(/* maxAttempts */ 2, /* delayMs */ 10);
+
+    assertEquals(2, getProviderMaxAttempts());
+    assertEquals(10, getProviderDelayMs());
+    assertEquals(0, getProviderAttemptCount());
+
+    // First call: should throw temporary and start the freeze window, incrementing attempt count to
+    // 1
+    assertThrows(JedisTemporarilyNotAvailableException.class,
+      () -> MultiClusterPooledConnectionProviderHelper.switchToHealthyCluster(provider,
+        SwitchReason.HEALTH_CHECK, provider.getCluster()));
+    int afterFirst = getProviderAttemptCount();
+    assertEquals(1, afterFirst);
+
+    // Many rapid subsequent calls within the delay window should continue to throw temporary
+    // and should NOT increment the attempt count beyond 1
+    for (int i = 0; i < 50; i++) {
+      assertThrows(JedisTemporarilyNotAvailableException.class,
+        () -> provider.switchToHealthyCluster(SwitchReason.HEALTH_CHECK, provider.getCluster()));
+      assertEquals(1, getProviderAttemptCount());
+    }
+
+    await().atMost(Durations.TWO_HUNDRED_MILLISECONDS).pollInterval(Duration.ofMillis(10))
+        .until(() -> {
+          Exception e = assertThrows(JedisFailoverException.class, () -> provider
+              .switchToHealthyCluster(SwitchReason.HEALTH_CHECK, provider.getCluster()));
+          return e instanceof JedisPermanentlyNotAvailableException;
+        });
+  }
+
+  @Test
+  void maxNumFailoverAttempts_zeroDelay_leadsToPermanentAfterExceeding() throws Exception {
+    // Configure: maxAttempts = 2, delay = 0 so each call increments the counter immediately
+    setProviderFailoverConfig(/* maxAttempts */ 2, /* delayMs */ 0);
+
+    assertEquals(2, getProviderMaxAttempts());
+    assertEquals(0, getProviderDelayMs());
+    assertEquals(0, getProviderAttemptCount());
+
+    // Expect exactly 'maxAttempts' temporary exceptions, then a permanent one
+    assertThrows(JedisTemporarilyNotAvailableException.class,
+      () -> provider.switchToHealthyCluster(SwitchReason.HEALTH_CHECK, provider.getCluster())); // attempt
+    // 1
+    assertThrows(JedisTemporarilyNotAvailableException.class,
+      () -> provider.switchToHealthyCluster(SwitchReason.HEALTH_CHECK, provider.getCluster())); // attempt
+    // 2
+
+    // Next should exceed max and become permanent
+    assertThrows(JedisPermanentlyNotAvailableException.class,
+      () -> provider.switchToHealthyCluster(SwitchReason.HEALTH_CHECK, provider.getCluster())); // attempt
+    // 3
+    // ->
+    // permanent
+  }
+
+  // ======== Test helper methods (reflection) ========
+
+  private static void setBuilderFailoverConfig(MultiClusterClientConfig.Builder builder,
+      int maxAttempts, int delayMs) throws Exception {
+    Field fMax = builder.getClass().getDeclaredField("maxNumFailoverAttempts");
+    fMax.setAccessible(true);
+    fMax.setInt(builder, maxAttempts);
+
+    Field fDelay = builder.getClass().getDeclaredField("delayInBetweenFailoverAttempts");
+    fDelay.setAccessible(true);
+    fDelay.setInt(builder, delayMs);
+  }
+
+  private void setProviderFailoverConfig(int maxAttempts, int delayMs) throws Exception {
+    // Access the underlying MultiClusterClientConfig inside provider and adjust fields for this
+    // test
+    Field cfgField = provider.getClass().getDeclaredField("multiClusterClientConfig");
+    cfgField.setAccessible(true);
+    Object cfg = cfgField.get(provider);
+
+    Field fMax = cfg.getClass().getDeclaredField("maxNumFailoverAttempts");
+    fMax.setAccessible(true);
+    fMax.setInt(cfg, maxAttempts);
+
+    Field fDelay = cfg.getClass().getDeclaredField("delayInBetweenFailoverAttempts");
+    fDelay.setAccessible(true);
+    fDelay.setInt(cfg, delayMs);
+  }
+
+  private int getProviderMaxAttempts() throws Exception {
+    Field cfgField = provider.getClass().getDeclaredField("multiClusterClientConfig");
+    cfgField.setAccessible(true);
+    Object cfg = cfgField.get(provider);
+    Field fMax = cfg.getClass().getDeclaredField("maxNumFailoverAttempts");
+    fMax.setAccessible(true);
+    return fMax.getInt(cfg);
+  }
+
+  private int getProviderDelayMs() throws Exception {
+    Field cfgField = provider.getClass().getDeclaredField("multiClusterClientConfig");
+    cfgField.setAccessible(true);
+    Object cfg = cfgField.get(provider);
+    Field fDelay = cfg.getClass().getDeclaredField("delayInBetweenFailoverAttempts");
+    fDelay.setAccessible(true);
+    return fDelay.getInt(cfg);
+  }
+
+  private int getProviderAttemptCount() throws Exception {
+    Field f = provider.getClass().getDeclaredField("failoverAttemptCount");
+    f.setAccessible(true);
+    AtomicInteger val = (AtomicInteger) f.get(provider);
+    return val.get();
+  }
+}

--- a/src/test/java/redis/clients/jedis/mcf/MultiClusterInitializationTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiClusterInitializationTest.java
@@ -16,7 +16,6 @@ import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.MultiClusterClientConfig;
 import redis.clients.jedis.exceptions.JedisValidationException;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
 
 /**
  * Tests for MultiClusterPooledConnectionProvider initialization edge cases

--- a/src/test/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProviderHelper.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProviderHelper.java
@@ -1,8 +1,6 @@
-package redis.clients.jedis.providers;
+package redis.clients.jedis.mcf;
 
 import redis.clients.jedis.Endpoint;
-import redis.clients.jedis.mcf.HealthStatus;
-import redis.clients.jedis.mcf.HealthStatusChangeEvent;
 
 public class MultiClusterPooledConnectionProviderHelper {
 
@@ -13,5 +11,10 @@ public class MultiClusterPooledConnectionProviderHelper {
 
   public static void periodicFailbackCheck(MultiClusterPooledConnectionProvider provider) {
     provider.periodicFailbackCheck();
+  }
+
+  public static Endpoint iterateActiveCluster(MultiClusterPooledConnectionProvider provider,
+      SwitchReason reason) {
+    return provider.iterateActiveCluster(reason);
   }
 }

--- a/src/test/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProviderHelper.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProviderHelper.java
@@ -13,8 +13,8 @@ public class MultiClusterPooledConnectionProviderHelper {
     provider.periodicFailbackCheck();
   }
 
-  public static Endpoint iterateActiveCluster(MultiClusterPooledConnectionProvider provider,
-      SwitchReason reason) {
-    return provider.iterateActiveCluster(reason);
+  public static Endpoint switchToHealthyCluster(MultiClusterPooledConnectionProvider provider,
+      SwitchReason reason, MultiClusterPooledConnectionProvider.Cluster iterateFrom) {
+    return provider.switchToHealthyCluster(reason, iterateFrom);
   }
 }

--- a/src/test/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProviderTest.java
@@ -1,4 +1,4 @@
-package redis.clients.jedis.providers;
+package redis.clients.jedis.mcf;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 
@@ -14,9 +14,10 @@ import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisValidationException;
 import redis.clients.jedis.mcf.HealthCheckStrategy;
 import redis.clients.jedis.mcf.HealthStatus;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider;
 import redis.clients.jedis.mcf.SwitchReason;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider.Cluster;
 import redis.clients.jedis.mcf.ProbingPolicy.BuiltIn;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider.Cluster;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProviderTest.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis.mcf;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType;
 
 import org.awaitility.Awaitility;
 import org.awaitility.Durations;
@@ -12,18 +13,18 @@ import redis.clients.jedis.*;
 import redis.clients.jedis.MultiClusterClientConfig.ClusterConfig;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisValidationException;
-import redis.clients.jedis.mcf.HealthCheckStrategy;
-import redis.clients.jedis.mcf.HealthStatus;
-import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider;
-import redis.clients.jedis.mcf.SwitchReason;
 import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider.Cluster;
 import redis.clients.jedis.mcf.ProbingPolicy.BuiltIn;
+import redis.clients.jedis.mcf.JedisFailoverException.JedisPermanentlyNotAvailableException;
+import redis.clients.jedis.mcf.JedisFailoverException.JedisTemporarilyNotAvailableException;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -76,37 +77,21 @@ public class MultiClusterPooledConnectionProviderTest {
     waitForClustersToGetHealthy(provider.getCluster(endpointStandalone0.getHostAndPort()),
       provider.getCluster(endpointStandalone1.getHostAndPort()));
 
-    Endpoint e2 = provider.iterateActiveCluster(SwitchReason.HEALTH_CHECK);
+    Endpoint e2 = provider.switchToHealthyCluster(SwitchReason.HEALTH_CHECK, provider.getCluster());
     assertEquals(endpointStandalone1.getHostAndPort(), e2);
-  }
-
-  @Test
-  public void testIterateActiveClusterOutOfRange() {
-    waitForClustersToGetHealthy(provider.getCluster(endpointStandalone0.getHostAndPort()),
-      provider.getCluster(endpointStandalone1.getHostAndPort()));
-
-    provider.setActiveCluster(endpointStandalone0.getHostAndPort());
-    provider.getCluster().setDisabled(true);
-
-    Endpoint e2 = provider.iterateActiveCluster(SwitchReason.HEALTH_CHECK);
-    provider.getCluster().setDisabled(true);
-
-    assertEquals(endpointStandalone1.getHostAndPort(), e2);
-    // Should throw an exception
-    assertThrows(JedisConnectionException.class,
-      () -> provider.iterateActiveCluster(SwitchReason.HEALTH_CHECK));
   }
 
   @Test
   public void testCanIterateOnceMore() {
-    waitForClustersToGetHealthy(provider.getCluster(endpointStandalone0.getHostAndPort()),
+    Endpoint endpoint0 = endpointStandalone0.getHostAndPort();
+    waitForClustersToGetHealthy(provider.getCluster(endpoint0),
       provider.getCluster(endpointStandalone1.getHostAndPort()));
 
-    provider.setActiveCluster(endpointStandalone0.getHostAndPort());
+    provider.setActiveCluster(endpoint0);
     provider.getCluster().setDisabled(true);
-    provider.iterateActiveCluster(SwitchReason.HEALTH_CHECK);
+    provider.switchToHealthyCluster(SwitchReason.HEALTH_CHECK, provider.getCluster(endpoint0));
 
-    assertFalse(provider.canIterateOnceMore());
+    assertFalse(provider.canIterateFrom(provider.getCluster()));
   }
 
   private void waitForClustersToGetHealthy(Cluster... clusters) {
@@ -250,6 +235,87 @@ public class MultiClusterPooledConnectionProviderTest {
     } finally {
       // Ensure cleanup even if test fails
       testProvider.close();
+    }
+  }
+
+  @Test
+  public void userCommand_firstTemporary_thenPermanent_inOrder() {
+    ClusterConfig[] clusterConfigs = new ClusterConfig[2];
+    clusterConfigs[0] = ClusterConfig.builder(endpointStandalone0.getHostAndPort(),
+      endpointStandalone0.getClientConfigBuilder().build()).weight(0.5f).build();
+    clusterConfigs[1] = ClusterConfig.builder(endpointStandalone1.getHostAndPort(),
+      endpointStandalone1.getClientConfigBuilder().build()).weight(0.3f).build();
+
+    MultiClusterPooledConnectionProvider testProvider = new MultiClusterPooledConnectionProvider(
+        new MultiClusterClientConfig.Builder(clusterConfigs).delayInBetweenFailoverAttempts(100)
+            .maxNumFailoverAttempts(2).retryMaxAttempts(1).build());
+
+    try (UnifiedJedis jedis = new UnifiedJedis(testProvider)) {
+      jedis.get("foo");
+
+      // Disable both clusters so any attempt to switch results in 'no healthy cluster' path
+      testProvider.getCluster(endpointStandalone0.getHostAndPort()).setDisabled(true);
+      testProvider.getCluster(endpointStandalone1.getHostAndPort()).setDisabled(true);
+
+      // Simulate user running a command that fails and triggers failover iteration
+      assertThrows(JedisTemporarilyNotAvailableException.class, () -> jedis.get("foo"));
+
+      // Next immediate attempt should exceed max attempts and become permanent (expected to fail
+      // until feature exists)
+      await().atMost(Durations.ONE_SECOND).pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+          .until(() -> (assertThrows(JedisFailoverException.class,
+            () -> jedis.get("foo")) instanceof JedisPermanentlyNotAvailableException));
+    }
+  }
+
+  @Test
+  public void userCommand_connectionExceptions_thenMultipleTemporary_thenPermanent_inOrder() {
+    ClusterConfig[] clusterConfigs = new ClusterConfig[2];
+    clusterConfigs[0] = ClusterConfig
+        .builder(endpointStandalone0.getHostAndPort(),
+          endpointStandalone0.getClientConfigBuilder().build())
+        .weight(0.5f).healthCheckEnabled(false).build();
+    clusterConfigs[1] = ClusterConfig
+        .builder(endpointStandalone1.getHostAndPort(),
+          endpointStandalone1.getClientConfigBuilder().build())
+        .weight(0.3f).healthCheckEnabled(false).build();
+
+    // ATTENTION: these configuration settings are not random and
+    // adjusted to get exact numbers of failures with exact exception types
+    // and open to impact from other defaulted values withing the components in use.
+    MultiClusterPooledConnectionProvider testProvider = new MultiClusterPooledConnectionProvider(
+        new MultiClusterClientConfig.Builder(clusterConfigs).delayInBetweenFailoverAttempts(100)
+            .maxNumFailoverAttempts(2).retryMaxAttempts(1).circuitBreakerSlidingWindowMinCalls(3)
+            .circuitBreakerSlidingWindowSize(5)
+            .circuitBreakerSlidingWindowType(SlidingWindowType.TIME_BASED)
+            .circuitBreakerFailureRateThreshold(60).build()) {
+    };
+
+    try (UnifiedJedis jedis = new UnifiedJedis(testProvider)) {
+      jedis.get("foo");
+
+      // disable most weighted cluster so that it will fail on initial requests
+      testProvider.getCluster(endpointStandalone0.getHostAndPort()).setDisabled(true);
+
+      Exception e = assertThrows(JedisConnectionException.class, () -> jedis.get("foo"));
+      assertEquals(JedisConnectionException.class, e.getClass());
+
+      e = assertThrows(JedisConnectionException.class, () -> jedis.get("foo"));
+      assertEquals(JedisConnectionException.class, e.getClass());
+
+      // then disable the second ones
+      testProvider.getCluster(endpointStandalone1.getHostAndPort()).setDisabled(true);
+      assertThrows(JedisTemporarilyNotAvailableException.class, () -> jedis.get("foo"));
+      assertThrows(JedisTemporarilyNotAvailableException.class, () -> jedis.get("foo"));
+
+      // Third get request should exceed max attempts and throw
+      // JedisPermanentlyNotAvailableException
+      await().atMost(Durations.FIVE_HUNDRED_MILLISECONDS).pollInterval(Duration.ofMillis(50))
+          .until(() -> (assertThrows(JedisFailoverException.class,
+            () -> jedis.get("foo")) instanceof JedisPermanentlyNotAvailableException));
+
+      // Fourth get request should continue to throw JedisPermanentlyNotAvailableException
+      assertThrows(JedisPermanentlyNotAvailableException.class, () -> jedis.get("foo"));
     }
   }
 }

--- a/src/test/java/redis/clients/jedis/mcf/PeriodicFailbackTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/PeriodicFailbackTest.java
@@ -62,7 +62,7 @@ class PeriodicFailbackTest {
         provider.getCluster(endpoint2).setDisabled(true);
 
         // Force failover to cluster1 since cluster2 is disabled
-        provider.iterateActiveCluster(SwitchReason.FORCED);
+        provider.switchToHealthyCluster(SwitchReason.FORCED, provider.getCluster(endpoint2));
 
         // Manually trigger periodic check
         MultiClusterPooledConnectionProviderHelper.periodicFailbackCheck(provider);

--- a/src/test/java/redis/clients/jedis/mcf/PeriodicFailbackTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/PeriodicFailbackTest.java
@@ -2,7 +2,7 @@ package redis.clients.jedis.mcf;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static redis.clients.jedis.providers.MultiClusterPooledConnectionProviderHelper.onHealthStatusChange;
+import static redis.clients.jedis.mcf.MultiClusterPooledConnectionProviderHelper.onHealthStatusChange;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,8 +15,6 @@ import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.MultiClusterClientConfig;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProviderHelper;
 
 @ExtendWith(MockitoExtension.class)
 class PeriodicFailbackTest {

--- a/src/test/java/redis/clients/jedis/mcf/RedisRestAPIIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/RedisRestAPIIntegrationTest.java
@@ -27,6 +27,7 @@ import redis.clients.jedis.Endpoint;
 import redis.clients.jedis.EndpointConfig;
 import redis.clients.jedis.HostAndPorts;
 import redis.clients.jedis.RedisCredentials;
+import redis.clients.jedis.scenario.RestEndpointUtil;
 
 @Tags({ @Tag("failover"), @Tag("scenario") })
 public class RedisRestAPIIntegrationTest {
@@ -60,7 +61,7 @@ public class RedisRestAPIIntegrationTest {
         HttpsURLConnection.setDefaultHostnameVerifier((hostname, session) -> true);
 
       } catch (Exception e) {
-        e.printStackTrace();
+        log.error("Failed to disable SSL verification", e);
       }
     }
 
@@ -84,7 +85,7 @@ public class RedisRestAPIIntegrationTest {
   public static void beforeClass() {
     try {
       endpointConfig = HostAndPorts.getRedisEndpoint("re-active-active");
-      restAPIEndpoint = getRestAPIEndpoint(endpointConfig);
+      restAPIEndpoint = RestEndpointUtil.getRestAPIEndpoint(endpointConfig);
       credentialsSupplier = () -> new DefaultRedisCredentials("test@redis.com", "test123");
       SSLBypass.disableSSLVerification();
     } catch (IllegalArgumentException e) {
@@ -122,26 +123,6 @@ public class RedisRestAPIIntegrationTest {
     String firstBdbUid = bdbs.get(0).getUid();
     assertTrue(api.checkBdbAvailability(firstBdbUid, false));
     assertFalse(api.checkBdbAvailability(firstBdbUid, true));
-  }
-
-  private static Endpoint getRestAPIEndpoint(EndpointConfig config) {
-    return new Endpoint() {
-      @Override
-      public String getHost() {
-        // convert this to Redis FQDN by removing the node prefix
-        // "dns":"redis-10232.c1.taki-active-active-test-c114170a.cto.redislabs.com"
-        String host = config.getHost();
-        // trim until the first dot
-        String fqdn = host.substring(host.indexOf('.') + 1);
-        return fqdn;
-      }
-
-      @Override
-      public int getPort() {
-        // default port for REST API
-        return 9443;
-      }
-    };
   }
 
 }

--- a/src/test/java/redis/clients/jedis/mcf/TestHealthCheckStrategy.java
+++ b/src/test/java/redis/clients/jedis/mcf/TestHealthCheckStrategy.java
@@ -1,0 +1,66 @@
+package redis.clients.jedis.mcf;
+
+import java.util.function.Function;
+
+import redis.clients.jedis.Endpoint;
+
+public class TestHealthCheckStrategy implements HealthCheckStrategy {
+
+  private int interval;
+  private int timeout;
+  private int probes;
+  private int delay;
+  private Function<Endpoint, HealthStatus> healthCheck;
+  private ProbingPolicy policy;
+
+  public TestHealthCheckStrategy(int interval, int timeout, int probes, ProbingPolicy policy,
+      int delay, Function<Endpoint, HealthStatus> healthCheck) {
+    this.interval = interval;
+    this.timeout = timeout;
+    this.probes = probes;
+    this.delay = delay;
+    this.healthCheck = healthCheck;
+    this.policy = policy;
+  }
+
+  public TestHealthCheckStrategy(HealthCheckStrategy.Config config,
+      Function<Endpoint, HealthStatus> healthCheck) {
+    this(config.getInterval(), config.getTimeout(), config.getNumProbes(), config.getPolicy(),
+        config.getDelayInBetweenProbes(), healthCheck);
+  }
+
+  public TestHealthCheckStrategy(Function<Endpoint, HealthStatus> healthCheck) {
+    this(HealthCheckStrategy.Config.create(), healthCheck);
+  }
+
+  @Override
+  public int getInterval() {
+    return interval;
+  }
+
+  @Override
+  public int getTimeout() {
+    return timeout;
+  }
+
+  @Override
+  public int getNumProbes() {
+    return probes;
+  }
+
+  @Override
+  public ProbingPolicy getPolicy() {
+    return policy;
+  }
+
+  @Override
+  public int getDelayInBetweenProbes() {
+    return delay;
+  }
+
+  @Override
+  public HealthStatus doHealthCheck(Endpoint endpoint) {
+    return healthCheck.apply(endpoint);
+  }
+
+};

--- a/src/test/java/redis/clients/jedis/misc/AutomaticFailoverTest.java
+++ b/src/test/java/redis/clients/jedis/misc/AutomaticFailoverTest.java
@@ -18,8 +18,9 @@ import redis.clients.jedis.*;
 import redis.clients.jedis.exceptions.JedisAccessControlException;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.mcf.ClusterSwitchEventArgs;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProviderHelper;
 import redis.clients.jedis.mcf.SwitchReason;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
 import redis.clients.jedis.util.IOUtils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -75,7 +76,8 @@ public class AutomaticFailoverTest {
       AbstractPipeline pipe = client.pipelined();
       pipe.set("pstr", "foobar");
       pipe.hset("phash", "foo", "bar");
-      provider.iterateActiveCluster(SwitchReason.HEALTH_CHECK);
+      MultiClusterPooledConnectionProviderHelper.iterateActiveCluster(provider,
+        SwitchReason.HEALTH_CHECK);
       pipe.sync();
     }
 
@@ -94,7 +96,8 @@ public class AutomaticFailoverTest {
       AbstractTransaction tx = client.multi();
       tx.set("tstr", "foobar");
       tx.hset("thash", "foo", "bar");
-      provider.iterateActiveCluster(SwitchReason.HEALTH_CHECK);
+      MultiClusterPooledConnectionProviderHelper.iterateActiveCluster(provider,
+        SwitchReason.HEALTH_CHECK);
       assertEquals(Arrays.asList("OK", 1L), tx.exec());
     }
 
@@ -151,8 +154,8 @@ public class AutomaticFailoverTest {
     MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(
         getClusterConfigs(clientConfig, hostPortWithFailure, workingEndpoint.getHostAndPort()))
             .retryMaxAttempts(retryMaxAttempts) // Default
-                                 // is
-                                 // 3
+            // is
+            // 3
             .circuitBreakerSlidingWindowMinCalls(slidingWindowMinCalls)
             .circuitBreakerSlidingWindowSize(slidingWindowSize);
 

--- a/src/test/java/redis/clients/jedis/misc/AutomaticFailoverTest.java
+++ b/src/test/java/redis/clients/jedis/misc/AutomaticFailoverTest.java
@@ -76,8 +76,8 @@ public class AutomaticFailoverTest {
       AbstractPipeline pipe = client.pipelined();
       pipe.set("pstr", "foobar");
       pipe.hset("phash", "foo", "bar");
-      MultiClusterPooledConnectionProviderHelper.iterateActiveCluster(provider,
-        SwitchReason.HEALTH_CHECK);
+      MultiClusterPooledConnectionProviderHelper.switchToHealthyCluster(provider,
+        SwitchReason.HEALTH_CHECK, provider.getCluster());
       pipe.sync();
     }
 
@@ -96,8 +96,8 @@ public class AutomaticFailoverTest {
       AbstractTransaction tx = client.multi();
       tx.set("tstr", "foobar");
       tx.hset("thash", "foo", "bar");
-      MultiClusterPooledConnectionProviderHelper.iterateActiveCluster(provider,
-        SwitchReason.HEALTH_CHECK);
+      MultiClusterPooledConnectionProviderHelper.switchToHealthyCluster(provider,
+        SwitchReason.HEALTH_CHECK, provider.getCluster());
       assertEquals(Arrays.asList("OK", 1L), tx.exec());
     }
 

--- a/src/test/java/redis/clients/jedis/providers/MultiClusterPooledConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/providers/MultiClusterPooledConnectionProviderTest.java
@@ -15,6 +15,7 @@ import redis.clients.jedis.exceptions.JedisValidationException;
 import redis.clients.jedis.mcf.HealthCheckStrategy;
 import redis.clients.jedis.mcf.HealthStatus;
 import redis.clients.jedis.mcf.SwitchReason;
+import redis.clients.jedis.mcf.ProbingPolicy.BuiltIn;
 import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider.Cluster;
 
 import java.util.Arrays;
@@ -210,28 +211,13 @@ public class MultiClusterPooledConnectionProviderTest {
     AtomicInteger healthCheckCount = new AtomicInteger(0);
 
     // Custom strategy that counts health checks
-    HealthCheckStrategy countingStrategy = new HealthCheckStrategy() {
-      @Override
-      public int getInterval() {
-        return 5;
-      } // Fast interval for testing
-
-      @Override
-      public int getTimeout() {
-        return 50;
-      }
-
-      @Override
-      public HealthStatus doHealthCheck(Endpoint endpoint) {
-        healthCheckCount.incrementAndGet();
-        return HealthStatus.HEALTHY;
-      }
-
-      @Override
-      public void close() {
-        // No-op for test
-      }
-    };
+    HealthCheckStrategy countingStrategy = new redis.clients.jedis.mcf.TestHealthCheckStrategy(
+        redis.clients.jedis.mcf.HealthCheckStrategy.Config.builder().interval(5).timeout(50)
+            .policy(BuiltIn.ANY_SUCCESS).build(),
+        e -> {
+          healthCheckCount.incrementAndGet();
+          return HealthStatus.HEALTHY;
+        });
 
     // Create new provider with health check strategy (don't use the setUp() provider)
     ClusterConfig config = ClusterConfig

--- a/src/test/java/redis/clients/jedis/providers/MultiClusterProviderHealthStatusChangeEventTest.java
+++ b/src/test/java/redis/clients/jedis/providers/MultiClusterProviderHealthStatusChangeEventTest.java
@@ -16,6 +16,8 @@ import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.MultiClusterClientConfig;
 import redis.clients.jedis.mcf.HealthStatus;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProviderHelper;
 
 /**
  * Tests for MultiClusterPooledConnectionProvider event handling behavior during initialization and

--- a/src/test/java/redis/clients/jedis/scenario/ActiveActiveFailoverTest.java
+++ b/src/test/java/redis/clients/jedis/scenario/ActiveActiveFailoverTest.java
@@ -10,9 +10,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.*;
 import redis.clients.jedis.MultiClusterClientConfig.ClusterConfig;
-import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.mcf.ClusterSwitchEventArgs;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider;
 
 import java.io.IOException;
 import java.time.Duration;

--- a/src/test/java/redis/clients/jedis/scenario/LagAwareStrategySslIT.java
+++ b/src/test/java/redis/clients/jedis/scenario/LagAwareStrategySslIT.java
@@ -1,0 +1,198 @@
+package redis.clients.jedis.scenario;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import redis.clients.jedis.DefaultRedisCredentials;
+import redis.clients.jedis.Endpoint;
+import redis.clients.jedis.EndpointConfig;
+import redis.clients.jedis.HostAndPorts;
+import redis.clients.jedis.RedisCredentials;
+import redis.clients.jedis.SslOptions;
+import redis.clients.jedis.SslVerifyMode;
+import redis.clients.jedis.mcf.HealthStatus;
+import redis.clients.jedis.mcf.LagAwareStrategy;
+import redis.clients.jedis.util.TlsUtil;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Test class demonstrating SSL configuration for LagAwareStrategy
+ */
+@Tag("scenario")
+public class LagAwareStrategySslIT {
+  private static EndpointConfig endpointConfig;
+  private static Endpoint restEndpoint;
+  private static Supplier<RedisCredentials> credentialsSupplier;
+  private static final String trustStoreName = LagAwareStrategySslIT.class.getSimpleName() + ".jks";
+  private static final String certificateAlias = "redis-enterprise";
+  private static final char[] trustStorePassword = "changeit".toCharArray();
+
+  @BeforeAll
+  public static void beforeClass() {
+
+    endpointConfig = HostAndPorts.getRedisEndpoint("re-active-active");
+    restEndpoint = RestEndpointUtil.getRestAPIEndpoint(endpointConfig);
+    credentialsSupplier = () -> new DefaultRedisCredentials("test@redis.com", "test123");
+    try {
+      createTestTruststore(restEndpoint.getHost(), restEndpoint.getPort(), trustStoreName,
+        certificateAlias, trustStorePassword);
+    } catch (Exception e) {
+      fail("Failed to create test truststore", e);
+    }
+  }
+
+  @ParameterizedTest(name = "SSL mode {0} should be HEALTHY")
+  @EnumSource(value = SslVerifyMode.class, names = { "FULL", "CA", "INSECURE" })
+  public void healthyWhenUsingCustomTruststore(SslVerifyMode sslVerifyMode) throws Exception {
+    // Create SSL options with custom truststore
+    SslOptions sslOptions = SslOptions.builder()
+        .truststore(new File(trustStoreName), trustStorePassword).sslVerifyMode(sslVerifyMode)
+        .build();
+
+    // Create LagAwareStrategy config with SSL support using builder
+    LagAwareStrategy.Config config = LagAwareStrategy.Config
+        .builder(restEndpoint, credentialsSupplier).sslOptions(sslOptions).build();
+
+    try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+      assertEquals(HealthStatus.HEALTHY,
+        lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
+    }
+  }
+
+  @ParameterizedTest(name = "SSL mode {0} should result in {1}")
+  @CsvSource({ "FULL, UNHEALTHY", "CA, UNHEALTHY", "INSECURE, HEALTHY" })
+  void usingDefaultTruststoreWithUntrustedCertificate(SslVerifyMode sslVerifyMode,
+      HealthStatus expected) {
+    // Create SSL options without specifying truststore
+    SslOptions sslOptions = SslOptions.builder().sslVerifyMode(sslVerifyMode).build();
+
+    // Create LagAwareStrategy config with SSL support using builder
+    LagAwareStrategy.Config config = LagAwareStrategy.Config
+        .builder(restEndpoint, credentialsSupplier).sslOptions(sslOptions).build();
+
+    try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+      assertEquals(expected, lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
+    }
+  }
+
+  @ParameterizedTest(name = "SSL mode {0} should result in {1}")
+  @CsvSource({ "FULL, HEALTHY", "CA, HEALTHY", "INSECURE, HEALTHY" })
+  void healthyWhenUsingDefaultTruststoreWithTrustedCertificate(SslVerifyMode sslVerifyMode,
+      HealthStatus expected) {
+    // Create SSL options without specifying truststore
+    SslOptions sslOptions = SslOptions.builder().sslVerifyMode(sslVerifyMode).build();
+
+    // Create LagAwareStrategy config with SSL support using builder
+    LagAwareStrategy.Config config = LagAwareStrategy.Config
+        .builder(restEndpoint, credentialsSupplier).sslOptions(sslOptions).build();
+
+    // Verify configuration - trusted cert should pass
+    // Default SSL context is used if no user defined trust store is configured
+    // Configure default SSL context to trust our custom CA
+    // and reinitialize default SSL context for HttpsURLConnection
+    TlsUtil.setCustomTrustStore(new File(trustStoreName).toPath(), new String(trustStorePassword));
+    SSLSocketFactory orig = HttpsURLConnection.getDefaultSSLSocketFactory();
+    try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+      HttpsURLConnection
+          .setDefaultSSLSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
+      assertEquals(expected, lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
+    } finally {
+      TlsUtil.restoreOriginalTrustStore();
+      HttpsURLConnection.setDefaultSSLSocketFactory(orig);
+    }
+  }
+
+  @Test
+  public void fallbackToDefaultSslContextWhenSslOptionsAreNull() {
+    // Test that SSL options can be null
+    // If SSL options are null, we should fallback to default SSL context
+    LagAwareStrategy.Config config = LagAwareStrategy.Config
+        .builder(restEndpoint, credentialsSupplier).build();
+
+    // Verify configuration - untrusted cert should fail
+    try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+      assertEquals(HealthStatus.UNHEALTHY,
+        lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
+    }
+
+    // Verify configuration - trusted cert should pass
+    // Default SSL context is used if no SSL options are provided
+    // Configure default SSL context to trust our custom CA
+    // and reinitialize default SSL context for HttpsURLConnection
+    TlsUtil.setCustomTrustStore(new File(trustStoreName).toPath(), new String(trustStorePassword));
+    SSLSocketFactory orig = HttpsURLConnection.getDefaultSSLSocketFactory();
+    try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+      HttpsURLConnection
+          .setDefaultSSLSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
+      assertEquals(HealthStatus.HEALTHY,
+        lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
+    } finally {
+      TlsUtil.restoreOriginalTrustStore();
+      HttpsURLConnection.setDefaultSSLSocketFactory(orig);
+    }
+  }
+
+  /**
+   * Downloads the server certificate from a host and stores it as a JKS file.
+   * @param host host to connect to (e.g., redis.example.com)
+   * @param port TLS port (e.g., 9443)
+   * @param jks path where the JKS file will be created
+   * @param alias alias to store the certificate under
+   * @param password password for the JKS
+   */
+  static void createTestTruststore(String host, int port, String jks, String alias, char[] password)
+      throws Exception {
+    // Use SSL socket to fetch server cert
+    // Disable certificate verification
+    TrustManager[] trustAll = new TrustManager[] { new X509TrustManager() {
+      public void checkClientTrusted(X509Certificate[] chain, String authType) {
+      }
+
+      public void checkServerTrusted(X509Certificate[] chain, String authType) {
+      }
+
+      public X509Certificate[] getAcceptedIssuers() {
+        return new X509Certificate[0];
+      }
+    } };
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(null, trustAll, new java.security.SecureRandom());
+    SSLSocketFactory factory = sslContext.getSocketFactory();
+
+    try (SSLSocket socket = (SSLSocket) factory.createSocket(host, port)) {
+      socket.startHandshake();
+      Certificate[] serverCerts = socket.getSession().getPeerCertificates();
+
+      // Create an empty KeyStore
+      KeyStore ks = KeyStore.getInstance("JKS");
+      ks.load(null, password);
+
+      // Add server certificate (first in chain)
+      ks.setCertificateEntry(alias, serverCerts[0]);
+
+      // Write KeyStore to disk
+      try (FileOutputStream fos = new FileOutputStream(jks)) {
+        ks.store(fos, password);
+      }
+    }
+  }
+}

--- a/src/test/java/redis/clients/jedis/scenario/RestEndpointUtil.java
+++ b/src/test/java/redis/clients/jedis/scenario/RestEndpointUtil.java
@@ -1,0 +1,26 @@
+package redis.clients.jedis.scenario;
+
+import redis.clients.jedis.Endpoint;
+import redis.clients.jedis.EndpointConfig;
+
+public class RestEndpointUtil {
+
+  public static Endpoint getRestAPIEndpoint(EndpointConfig config) {
+    return new Endpoint() {
+      @Override
+      public String getHost() {
+        // convert this to Redis FQDN by removing the node prefix
+        // "dns":"redis-10232.c1.taki-active-active-test-c114170a.cto.redislabs.com"
+        String host = config.getHost();
+        // trim until the first dot
+        return host.substring(host.indexOf('.') + 1);
+      }
+
+      @Override
+      public int getPort() {
+        // default port for REST API
+        return 9443;
+      }
+    };
+  }
+}


### PR DESCRIPTION
# Improved failover resilience and health check enhancements for Active-Active deployments

This PR enhances the automatic failover and failback system with improved resilience, better health check probing strategies, and refined exception handling. These changes make the failover system more robust for production Active-Active Redis deployments.

## 🚀 New Features Added

### 1. Configurable Failover Retry Mechanism
- **NEW**: `maxNumFailoverAttempts` configuration - Controls maximum failover attempts before giving up (default: 10)
- **NEW**: `delayInBetweenFailoverAttempts` configuration - Delay between failover attempts in milliseconds (default: 12000ms)
- **NEW**: Failover freeze mechanism to prevent rapid repeated failover attempts
- **NEW**: Automatic failover attempt counter with reset on successful failover

### 2. Enhanced Exception Handling
- **NEW**: `JedisFailoverException` - Base exception for failover-related errors
- **NEW**: `JedisPermanentlyNotAvailableException` - Thrown when max failover attempts exceeded
- **NEW**: `JedisTemporarilyNotAvailableException` - Thrown when clusters temporarily unavailable but retries remain
- **NEW**: `assertOperability()` method to validate cluster health before command execution

### 3. Improved Health Check Probing System
- **NEW**: `ProbingPolicy` interface for flexible health check evaluation strategies
- **NEW**: `ProbingPolicy.BuiltIn.ALL_SUCCESS` - Requires all probes to succeed
- **NEW**: `ProbingPolicy.BuiltIn.MAJORITY` - Requires majority of probes to succeed
- **NEW**: `ProbingPolicy.BuiltIn.AT_LEAST_ONE` - Requires at least one probe to succeed
- **NEW**: `numProbes` configuration - Number of health check probes to execute (replaces `minConsecutiveSuccessCount`)
- **NEW**: `delayInBetweenProbes` configuration - Delay between individual probes in milliseconds (default: 100ms)
- **NEW**: `HealthProbeContext` - Tracks probe execution state and results

### 4. SSL Support for Redis Enterprise REST API
- **NEW**: `SslOptions` support in `LagAwareStrategy` for HTTPS connections to Redis Enterprise
- **NEW**: `sslOptions()` builder method in `LagAwareStrategy.ConfigBuilder`
- **NEW**: `getSslVerifyMode()` method in `SslOptions` class

## 🔧 Core Improvements

### 1. Failover Logic Enhancements
- **CHANGED**: `iterateActiveCluster()` renamed to `switchToHealthyCluster()` for clarity
- **CHANGED**: Failover now accepts source cluster parameter to avoid switching to same cluster
- **CHANGED**: `findWeightedHealthyClusterToIterate()` now excludes the source cluster from candidates
- **CHANGED**: `canIterateOnceMore()` renamed to `canIterateFrom()` with cluster parameter
- **IMPROVED**: Thread-safe failover freeze tracking using `AtomicLong`
- **IMPROVED**: Failover attempt counting with automatic reset on success

### 2. Connection Management
- **FIXED**: Connection leak in `CircuitBreakerCommandExecutor` - Now properly closes connections in finally block
- **IMPROVED**: Connection acquisition error handling - Validates operability before throwing exception
- **IMPROVED**: `forceDisconnect()` now calls `setBroken()` first to prevent race conditions with connection pool

### 3. Health Check System Refactoring
- **CHANGED**: Health check now uses probe-based evaluation instead of consecutive success counting
- **CHANGED**: `minConsecutiveSuccessCount()` replaced with `getNumProbes()`, `getPolicy()`, and `getDelayInBetweenProbes()`
- **IMPROVED**: Health check timeout handling with better error logging
- **IMPROVED**: Probe execution with configurable delays between attempts
- **IMPROVED**: Race condition prevention in health status updates with detailed documentation
- **CHANGED**: `EchoStrategy` now uses `JedisPooled` with connection pool (max 2 connections)
- **CHANGED**: Shared worker thread pool for all health checks instead of per-instance executors

### 4. LagAwareStrategy Enhancements
- **CHANGED**: Now throws `JedisException` when BDB not found instead of returning UNHEALTHY
- **CHANGED**: Throws `JedisException` on availability check errors for better error propagation
- **IMPROVED**: Better error messages and logging
- **NEW**: SSL support for secure REST API connections

## 📦 Package Reorganization

### 1. Multi-Cluster Provider Moved
- **MOVED**: `MultiClusterPooledConnectionProvider` from `redis.clients.jedis.providers` to `redis.clients.jedis.mcf`
- **REASON**: Better package organization - all multi-cluster failover components now in `mcf` package
- **UPDATED**: All import statements across codebase to reflect new package location

## 🔄 API Changes

### 1. MultiClusterClientConfig Builder
```java
// NEW configuration methods
builder.maxNumFailoverAttempts(10)              // Max failover attempts
builder.delayInBetweenFailoverAttempts(12000)   // Delay between attempts (ms)
```

### 2. HealthCheckStrategy Interface
```java
// CHANGED: Old methods removed
- int minConsecutiveSuccessCount()

// NEW: Replaced with probe-based methods
+ int getNumProbes()
+ ProbingPolicy getPolicy()
+ int getDelayInBetweenProbes()
```

### 3. HealthCheckStrategy.Config Builder
```java
// CHANGED: Old builder methods
- minConsecutiveSuccessCount(int)

// NEW: Probe-based configuration
+ numProbes(int)                    // Number of probes (default: 3)
+ policy(ProbingPolicy)             // Probing policy (default: ALL_SUCCESS)
+ delayInBetweenProbes(int)         // Delay between probes (default: 100ms)
```

### 4. LagAwareStrategy.ConfigBuilder
```java
// NEW: SSL configuration for REST API
builder.sslOptions(SslOptions)      // Configure SSL for HTTPS connections
```

## 🐛 Bug Fixes

### 1. Connection Leak Fix
- **FIXED**: `CircuitBreakerCommandExecutor` was not closing connections on exceptions
- **SOLUTION**: Added try-finally block to ensure connection closure
- **IMPACT**: Prevents connection pool exhaustion during failures

### 2. Race Condition in forceDisconnect()
- **FIXED**: Concurrent close attempts could call `returnResource` instead of `returnBrokenResource`
- **SOLUTION**: Call `setBroken()` before closing socket
- **IMPACT**: Proper connection pool state management during fast failover

### 3. Initialization Race Condition
- **FIXED**: Direct assignment to `activeCluster` during initialization could race with health check callbacks
- **SOLUTION**: Use `switchToHealthyCluster()` within lock after initialization complete
- **IMPACT**: Thread-safe cluster switching during startup

### 4. KeyStore Type Handling
- **FIXED**: `SslOptions` could fail when keystore/truststore type is null
- **SOLUTION**: Use `KeyStore.getDefaultType()` when type is null
- **IMPACT**: Better SSL configuration compatibility

## 🎯 Behavioral Changes

### 1. Failover Retry Behavior
**Before:**
- Failover would throw exception immediately if no healthy cluster available
- No retry mechanism for transient failures

**After:**
- Failover attempts up to `maxNumFailoverAttempts` times
- Waits `delayInBetweenFailoverAttempts` between attempts
- Throws `JedisTemporarilyNotAvailableException` while retries remain
- Throws `JedisPermanentlyNotAvailableException` when max attempts exceeded

### 2. Health Check Probing
**Before:**
- Required N consecutive successful health checks
- Single failure reset the counter
- No configurable probing strategy

**After:**
- Executes N probes with configurable delay between them
- Evaluates results based on policy (ALL_SUCCESS, MAJORITY, AT_LEAST_ONE)
- More flexible and faster health determination

### 3. Cluster Removal
**Before:**
- Cluster switch notification sent within lock
- Potential deadlock risk

**After:**
- Notification data collected within lock
- Notification sent after lock released
- Better concurrency and reduced lock contention

## 📊 Configuration Examples

### Basic Failover with Retry
```java
MultiClusterClientConfig config = MultiClusterClientConfig.builder(clusterConfigs)
    .circuitBreakerFailureRateThreshold(50.0f)
    .maxNumFailoverAttempts(10)                    // NEW: Max 10 failover attempts
    .delayInBetweenFailoverAttempts(12000)         // NEW: 12 second delay between attempts
    .build();
```

### Health Check with Probing Policy
```java
HealthCheckStrategy.Config healthConfig = HealthCheckStrategy.Config.builder()
    .interval(5000)                                 // Check every 5 seconds
    .timeout(2000)                                  // 2 second timeout per probe
    .numProbes(5)                                   // NEW: Execute 5 probes
    .policy(ProbingPolicy.BuiltIn.MAJORITY)        // NEW: Require majority success
    .delayInBetweenProbes(200)                     // NEW: 200ms between probes
    .build();
```

### LagAwareStrategy with SSL
```java
SslOptions sslOptions = SslOptions.builder()
    .truststore(truststorePath)
    .truststorePassword(password)
    .build();

LagAwareStrategy.Config lagConfig = LagAwareStrategy.Config.builder(restEndpoint, credentials)
    .sslOptions(sslOptions)                        // NEW: SSL for REST API
    .interval(5000)
    .timeout(3000)
    .numProbes(3)                                  // NEW: Probe-based health checks
    .policy(ProbingPolicy.BuiltIn.ALL_SUCCESS)    // NEW: All probes must succeed
    .build();
```

## 🔍 Technical Details

### Failover Freeze Mechanism
The failover freeze prevents rapid repeated failover attempts:
1. First failover attempt sets freeze until timestamp
2. Subsequent attempts within freeze period reuse same attempt count
3. After freeze period expires, new attempt increments counter
4. Counter resets to 0 on successful failover

### Health Check Probing
The new probing system provides more flexibility:
1. Execute N probes with configurable delays
2. Each probe result (success/failure) recorded in context
3. Policy evaluates context after each probe
4. Early termination when policy determines outcome
5. Final result based on policy decision

### Thread Safety Improvements
- `activeClusterChangeLock` renamed from `activeClusterIndexLock` for clarity
- All `activeCluster` assignments now within lock (except initialization)
- Notification callbacks moved outside locks to prevent deadlocks
- Atomic operations for failover freeze and attempt counting

## ⚠️ Breaking Changes

### API Changes
1. **HealthCheckStrategy interface**:
   - Removed: `int minConsecutiveSuccessCount()`
   - Added: `int getNumProbes()`, `ProbingPolicy getPolicy()`, `int getDelayInBetweenProbes()`

2. **HealthCheckStrategy.Config.Builder**:
   - Removed: `minConsecutiveSuccessCount(int)`
   - Added: `numProbes(int)`, `policy(ProbingPolicy)`, `delayInBetweenProbes(int)`

3. **Package relocation**:
   - `MultiClusterPooledConnectionProvider` moved from `redis.clients.jedis.providers` to `redis.clients.jedis.mcf`

### Migration Guide
```java
// OLD: Consecutive success count
HealthCheckStrategy.Config.builder()
    .minConsecutiveSuccessCount(3)
    .build();

// NEW: Probe-based with policy
HealthCheckStrategy.Config.builder()
    .numProbes(3)
    .policy(ProbingPolicy.BuiltIn.ALL_SUCCESS)
    .delayInBetweenProbes(100)
    .build();
```

## 🧪 Testing

All changes validated with:
- ✅ Unit tests for new probing policies
- ✅ Integration tests for failover retry mechanism
- ✅ Connection leak tests
- ✅ Race condition tests for initialization
- ✅ SSL configuration tests for LagAwareStrategy
- ✅ Multi-threaded failover scenario tests

## 📝 Additional Notes

- Default values maintain backward-compatible behavior for most use cases
- Probing policy `ALL_SUCCESS` with `numProbes=3` equivalent to old `minConsecutiveSuccessCount=3`
- New exception types provide better error handling and retry logic
- SSL support enables secure REST API communication with Redis Enterprise
- Shared worker thread pool reduces resource consumption for health checks

