### PR TITLE
docs: document required optional dependency `resilience4j-all`

### DIFF
--- a/docs/failover.md
+++ b/docs/failover.md
@@ -63,6 +63,11 @@ To use failover, add the following dependencies to your project:
 ```xml
 <dependency>
     <groupId>io.github.resilience4j</groupId>
+    <artifactId>resilience4j-all</artifactId>
+    <version>1.7.1</version>
+</dependency>
+<dependency>
+    <groupId>io.github.resilience4j</groupId>
     <artifactId>resilience4j-circuitbreaker</artifactId>
     <version>1.7.1</version>
 </dependency>


### PR DESCRIPTION
Update 'Installing optional dependencies' documentation in https://redis.github.io/jedis/failover/

`resilience4j-all` is also required when using the Failover API (MultiDbClient), because of usage of `Decorator`