### PR TITLE
docs: Correct builder to use hostAndPort method

### DIFF
--- a/docs/migration-guides/v6-to-v7.md
+++ b/docs/migration-guides/v6-to-v7.md
@@ -191,8 +191,7 @@ Jedis 7.0.0 introduces a fluent builder pattern for creating client instances, m
 **New in v7.0.0:**
 ```java
 JedisPooled jedis = JedisPooled.builder()
-    .host("localhost")
-    .port(6379)
+    .hostAndPort("localhost", 6379)
     .clientConfig(DefaultJedisClientConfig.builder()
         .user("myuser")
         .password("mypassword")


### PR DESCRIPTION
I just noticed that `hostAndPort` did not actually exist when upgrading my project to 7.0. I presume this is the recommended alternative.

I see no notes in the CONTRIBUTING.md about a CLA or anything similar, but sorry if I'm missing something standard for this project!