### PR TITLE
[churn] Attempt to fix flaky JedisPubSubBaseTest

### DIFF
--- a/src/test/java/redis/clients/jedis/JedisPubSubBaseTest.java
+++ b/src/test/java/redis/clients/jedis/JedisPubSubBaseTest.java
@@ -55,6 +55,6 @@ public class JedisPubSubBaseTest  {
         });
         thread.start();
 
-        assertTrue(countDownLatch.await(10, TimeUnit.MILLISECONDS));
+        assertTrue(countDownLatch.await(30, TimeUnit.MILLISECONDS));
     }
 }


### PR DESCRIPTION

```
Error:  redis.clients.jedis.JedisPubSubBaseTest.testProceed_givenThreadInterrupt_exitLoop -- Time elapsed: 0.030 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
```