### PR TITLE
[churn] Attempt to fix flaky StatusTrackerTest

### DIFF
--- a/src/test/java/redis/clients/jedis/mcf/StatusTrackerTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/StatusTrackerTest.java
@@ -72,8 +72,8 @@ public class StatusTrackerTest {
     });
     waitingThread.start();
 
-    await().atMost(Duration.ofMillis(100L)).pollInterval(Duration.ofMillis(5L))
-            .untilAsserted(() -> assertNotNull(capturedListener[0], "Listener should have been registered"));
+    await().atMost(Duration.ofMillis(100L)).pollInterval(Duration.ofMillis(5L)).untilAsserted(
+      () -> assertNotNull(capturedListener[0], "Listener should have been registered"));
 
     HealthStatusChangeEvent event = new HealthStatusChangeEvent(testEndpoint, HealthStatus.UNKNOWN,
         HealthStatus.HEALTHY);


### PR DESCRIPTION
Error:  redis.clients.jedis.mcf.StatusTrackerTest.testWaitForHealthStatus_EventDriven -- Time elapsed: 0.130 s <<< FAILURE!
org.opentest4j.AssertionFailedError: Listener should have been registered ==> expected: not <null>
..
	at redis.clients.jedis.mcf.StatusTrackerTest.testWaitForHealthStatus_EventDriven(StatusTrackerTest.java:78)