### PR TITLE
Fix connection leak in scanIteration with JedisSentineled #4323 (#4328)

### DIFF
--- a/src/main/java/redis/clients/jedis/providers/SentineledConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/SentineledConnectionProvider.java
@@ -2,7 +2,9 @@ package redis.clients.jedis.providers;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
@@ -24,6 +26,7 @@ import redis.clients.jedis.csc.Cache;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.util.IOUtils;
+import redis.clients.jedis.util.Pool;
 
 public class SentineledConnectionProvider implements ConnectionProvider {
 
@@ -110,6 +113,16 @@ public class SentineledConnectionProvider implements ConnectionProvider {
   @Override
   public Connection getConnection(CommandArguments args) {
     return pool.getResource();
+  }
+
+  @Override
+  public Map<?, Pool<Connection>> getConnectionMap() {
+    return Collections.singletonMap(currentMaster, pool);
+  }
+
+  @Override
+  public Map<?, Pool<Connection>> getPrimaryNodesConnectionMap() {
+    return Collections.singletonMap(currentMaster, pool);
   }
 
   @Override

--- a/src/test/java/redis/clients/jedis/commands/unified/sentinel/SentinelAllKindOfValuesCommandsIT.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/sentinel/SentinelAllKindOfValuesCommandsIT.java
@@ -1,0 +1,57 @@
+package redis.clients.jedis.commands.unified.sentinel;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.EndpointConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.HostAndPorts;
+import redis.clients.jedis.JedisClientConfig;
+import redis.clients.jedis.JedisSentineled;
+import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.commands.unified.AllKindOfValuesCommandsTestBase;
+import redis.clients.jedis.util.EnabledOnCommandCondition;
+import redis.clients.jedis.util.RedisVersionCondition;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+@ParameterizedClass
+@MethodSource("redis.clients.jedis.commands.CommandsTestsParameters#respVersions")
+public class SentinelAllKindOfValuesCommandsIT extends AllKindOfValuesCommandsTestBase {
+
+  static final HostAndPort sentinel1 = HostAndPorts.getSentinelServers().get(1);
+
+  static final HostAndPort sentinel2 = HostAndPorts.getSentinelServers().get(3);
+
+  static final Set<HostAndPort> sentinels = new HashSet<>(Arrays.asList(sentinel1, sentinel2));
+
+  static final JedisClientConfig sentinelClientConfig = DefaultJedisClientConfig.builder().build();
+
+  static final EndpointConfig primary = HostAndPorts.getRedisEndpoint("standalone2-primary");
+
+  @RegisterExtension
+  public RedisVersionCondition versionCondition = new RedisVersionCondition(
+      primary.getHostAndPort(), primary.getClientConfigBuilder().build());
+
+  @RegisterExtension
+  public EnabledOnCommandCondition enabledOnCommandCondition = new EnabledOnCommandCondition(
+      primary.getHostAndPort(), primary.getClientConfigBuilder().build());
+
+  public SentinelAllKindOfValuesCommandsIT(RedisProtocol protocol) {
+    super(protocol);
+  }
+
+  @Override
+  protected UnifiedJedis createTestClient() {
+
+    return JedisSentineled.builder()
+        .clientConfig(primary.getClientConfigBuilder().protocol(protocol).build())
+        .sentinels(sentinels).sentinelClientConfig(sentinelClientConfig).masterName("mymaster")
+        .build();
+  }
+
+}


### PR DESCRIPTION
Original issue: https://github.com/redis/jedis/issues/4323
Original PR: https://github.com/redis/jedis/pull/4328

* Fix connection leak in scanIteration with JedisSentineled

Override getConnectionMap() in SentineledConnectionProvider to return the pool instead of a raw connection. This prevents connection leaks when using scanIteration() with JedisSentineled.

(cherry picked from commit 4ddd7f4839411a49fb8b12c3729c0537c08702f9)
Fixes: #4351 