### PR TITLE
[Backport] Reduce log level to warn on reconnect in JedisSentinelPool 

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -407,8 +407,8 @@ public class JedisSentinelPool extends Pool<Jedis> {
         } catch (JedisException e) {
 
           if (running.get()) {
-            LOG.error("Lost connection to Sentinel at {}:{}. Sleeping 5000ms and retrying.", host,
-              port, e);
+            LOG.warn("Lost connection to Sentinel {}:{}. Sleeping {}ms and retrying.", host, port, subscribeRetryWaitTimeMillis,
+                    e);
             try {
               Thread.sleep(subscribeRetryWaitTimeMillis);
             } catch (InterruptedException e1) {

--- a/src/main/java/redis/clients/jedis/providers/SentineledConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/SentineledConnectionProvider.java
@@ -310,7 +310,7 @@ public class SentineledConnectionProvider implements ConnectionProvider {
         } catch (JedisException e) {
 
           if (running.get()) {
-            LOG.error("Lost connection to sentinel {}. Sleeping {}ms and retrying.", node,
+            LOG.error("Lost connection to Sentinel {}. Sleeping {}ms and retrying.", node,
                 subscribeRetryWaitTimeMillis, e);
             try {
               Thread.sleep(subscribeRetryWaitTimeMillis);


### PR DESCRIPTION
Original issue: https://github.com/redis/jedis/issues/4330
Original PR: https://github.com/redis/jedis/pull/4336

 Losing connection to a Sentinel is a normal operational event. Sentinels can be restarted for maintenance, or because of
 network hiccups. The code automatically retries and recovers

---------


(cherry picked from commit e7bf717b04bc8f3672242be44ee0a722f9856608)