### PR TITLE
Mark StaticCommandFlagsRegistry as internal

### DIFF
--- a/src/main/java/redis/clients/jedis/StaticCommandFlagsRegistry.java
+++ b/src/main/java/redis/clients/jedis/StaticCommandFlagsRegistry.java
@@ -13,7 +13,7 @@ import java.util.Map;
  * Static implementation of CommandFlagsRegistry.
  */
 @Internal
-class StaticCommandFlagsRegistry implements CommandFlagsRegistry {
+public class StaticCommandFlagsRegistry implements CommandFlagsRegistry {
 
   // Empty flags constant for commands with no flags
   public static final EnumSet<CommandFlag> EMPTY_FLAGS = EnumSet.noneOf(CommandFlag.class);


### PR DESCRIPTION
Mark newly introduced StaticCommandFlagsRegistry for internal usage only