### PR TITLE
Fix ClusterTopologyRefreshIT

### DIFF
--- a/src/test/java/redis/clients/jedis/scenario/ClusterTopologyRefreshIT.java
+++ b/src/test/java/redis/clients/jedis/scenario/ClusterTopologyRefreshIT.java
@@ -58,8 +58,7 @@ public class ClusterTopologyRefreshIT {
         .clientConfig(config).maxAttempts(RecommendedSettings.MAX_RETRIES)
         .maxTotalRetriesDuration(RecommendedSettings.MAX_TOTAL_RETRIES_DURATION).build()) {
       Set<String> initialNodes = client.getClusterNodes().keySet();
-      // assertEquals(1, initialNodes.size(),
-      // "Was this BDB used to run this test before?");
+      assertEquals(1, initialNodes.size(), "Was this BDB used to run this test before?");
 
       AtomicLong commandsExecuted = new AtomicLong();
 


### PR DESCRIPTION

Error:  redis.clients.jedis.scenario.ClusterTopologyRefreshIT.testWithPool -- Time elapsed: 1.378 s <<< ERROR!
java.lang.IllegalArgumentException: At least one cluster node must be specified for cluster mode
at redis.clients.jedis.builders.ClusterClientBuilder.validateSpecificConfiguration(ClusterClientBuilder.java:131)
at redis.clients.jedis.builders.AbstractClientBuilder.build(AbstractClientBuilder.java:134)
at redis.clients.jedis.scenario.ClusterTopologyRefreshIT.testWithPool(ClusterTopologyRefreshIT.java:59)
at java.lang.reflect.Method.invoke(Method.java:498)
at java.util.ArrayList.forEach(ArrayList.java:1259)
at java.util.ArrayList.forEach(ArrayList.java:1259)