### PR TITLE
Add missing command deprecations

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -985,7 +985,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @param value
    * @return 1 if the key was set 0 if the key was not set
    * @deprecated Use {@link Jedis#set(byte[], byte[], redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#nx()}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -1005,7 +1005,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @param value
    * @return OK
    * @deprecated Use {@link Jedis#set(byte[], byte[], redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#ex(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -1218,7 +1218,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @param end
    * @return Bulk reply
    * @deprecated Use {@link Jedis#getrange(byte[], long, long)} instead.
-   * Deprecated since Redis 2.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.0.0.
    */
   @Deprecated
   @Override
@@ -1316,7 +1316,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @param hash
    * @return OK
    * @deprecated Use {@link Jedis#hset(byte[], Map)} instead.
-   * Deprecated since Redis 4.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 4.0.0.
    */
   @Deprecated
   @Override
@@ -1815,7 +1815,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @return Bulk reply
    * @deprecated Use {@link Jedis#lmove(byte[], byte[], ListDirection, ListDirection)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -3865,7 +3865,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * Pop a value from a list, push it to another list and return it; or block until one is available
    * @deprecated Use {@link Jedis#blmove(byte[], byte[], ListDirection, ListDirection, double)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -4143,7 +4143,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @param value
    * @return OK
    * @deprecated Use {@link Jedis#set(byte[], byte[], redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#px(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -5640,7 +5640,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @param value
    * @return 1 if the key was set, 0 if the key was not set
    * @deprecated Use {@link Jedis#set(String, String, redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#nx()}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -5660,7 +5660,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @param value
    * @return OK
    * @deprecated Use {@link Jedis#set(String, String, redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#ex(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -5868,7 +5868,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @param end
    * @return The substring
    * @deprecated Use {@link Jedis#getrange(String, long, long)} instead.
-   * Deprecated since Redis 2.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.0.0.
    */
   @Deprecated
   @Override
@@ -5966,7 +5966,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @param hash
    * @return Return OK or Exception if hash is empty
    * @deprecated Use {@link Jedis#hset(String, Map)} instead.
-   * Deprecated since Redis 4.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 4.0.0.
    */
   @Deprecated
   @Override
@@ -6425,7 +6425,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @return Bulk reply
    * @deprecated Use {@link Jedis#lmove(String, String, ListDirection, ListDirection)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -6937,7 +6937,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -6954,7 +6954,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7499,7 +7499,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @param max a double or Double.POSITIVE_INFINITY for "+inf"
    * @return A list of elements in the specified score range
    * @deprecated Use {@link Jedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7510,7 +7510,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7568,7 +7568,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @param count
    * @return A list of elements in the specified score range
    * @deprecated Use {@link Jedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7580,7 +7580,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7637,7 +7637,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @param max
    * @return A list of elements in the specified score range
    * @deprecated Use {@link Jedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7648,7 +7648,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7706,7 +7706,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @param count
    * @return A list of elements in the specified score range
    * @deprecated Use {@link Jedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7718,7 +7718,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7730,7 +7730,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7741,7 +7741,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7752,7 +7752,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7764,7 +7764,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7775,7 +7775,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7787,7 +7787,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7799,7 +7799,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -7811,7 +7811,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -8082,7 +8082,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -8093,7 +8093,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -8105,7 +8105,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -8116,7 +8116,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -8222,7 +8222,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @return The element
    * @deprecated Use {@link Jedis#blmove(String, String, ListDirection, ListDirection, double)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -8825,7 +8825,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * @param value
    * @return OK
    * @deprecated Use {@link Jedis#set(String, String, redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#px(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -9507,7 +9507,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#geosearch(String, GeoSearchParam)} instead.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -9519,7 +9519,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#geosearch(String, GeoSearchParam)} instead.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -9531,7 +9531,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#geosearch(String, GeoSearchParam)} instead.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -9543,7 +9543,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#geosearchStore(String, String, GeoSearchParam)} instead.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -9555,7 +9555,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#geosearch(String, GeoSearchParam)} instead.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -9567,7 +9567,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#geosearch(String, GeoSearchParam)} instead.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -9579,7 +9579,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#geosearch(String, GeoSearchParam)} instead.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -9591,7 +9591,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#geosearch(String, GeoSearchParam)} instead.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -9603,7 +9603,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#geosearchStore(String, String, GeoSearchParam)} instead.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -9615,7 +9615,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   /**
    * @deprecated Use {@link Jedis#geosearch(String, GeoSearchParam)} instead.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override

--- a/src/main/java/redis/clients/jedis/PipeliningBase.java
+++ b/src/main/java/redis/clients/jedis/PipeliningBase.java
@@ -321,7 +321,7 @@ public abstract class PipeliningBase
 
   /**
    * @deprecated Use {@link PipeliningBase#set(String, String, redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#nx()}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -331,7 +331,7 @@ public abstract class PipeliningBase
 
   /**
    * @deprecated Use {@link PipeliningBase#set(String, String, redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#ex(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -341,7 +341,7 @@ public abstract class PipeliningBase
 
   /**
    * @deprecated Use {@link PipeliningBase#set(String, String, redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#px(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -401,7 +401,7 @@ public abstract class PipeliningBase
 
   /**
    * @deprecated Use {@link PipeliningBase#getrange(String, long, long)} instead.
-   * Deprecated since Redis 2.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.0.0.
    */
   @Deprecated
   @Override
@@ -603,7 +603,7 @@ public abstract class PipeliningBase
   /**
    * @deprecated Use {@link PipeliningBase#lmove(String, String, ListDirection, ListDirection)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -614,7 +614,7 @@ public abstract class PipeliningBase
   /**
    * @deprecated Use {@link PipeliningBase#blmove(String, String, ListDirection, ListDirection, double)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -740,7 +740,7 @@ public abstract class PipeliningBase
 
   /**
    * @deprecated Use {@link PipeliningBase#hset(String, Map)} instead.
-   * Deprecated since Redis 4.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 4.0.0.
    */
   @Deprecated
   @Override
@@ -2177,7 +2177,7 @@ public abstract class PipeliningBase
 
   /**
    * @deprecated Use {@link PipeliningBase#hset(byte[], Map)} instead.
-   * Deprecated since Redis 4.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 4.0.0.
    */
   @Deprecated
   @Override
@@ -2688,7 +2688,7 @@ public abstract class PipeliningBase
   /**
    * @deprecated Use {@link PipeliningBase#lmove(byte[], byte[], ListDirection, ListDirection)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2699,7 +2699,7 @@ public abstract class PipeliningBase
   /**
    * @deprecated Use {@link PipeliningBase#blmove(byte[], byte[], ListDirection, ListDirection, double)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -3574,7 +3574,7 @@ public abstract class PipeliningBase
 
   /**
    * @deprecated Use {@link PipeliningBase#set(byte[], byte[], redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#nx()}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -3584,7 +3584,7 @@ public abstract class PipeliningBase
 
   /**
    * @deprecated Use {@link PipeliningBase#set(byte[], byte[], redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#ex(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -3594,7 +3594,7 @@ public abstract class PipeliningBase
 
   /**
    * @deprecated Use {@link PipeliningBase#set(byte[], byte[], redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#px(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -3654,7 +3654,7 @@ public abstract class PipeliningBase
 
   /**
    * @deprecated Use {@link PipeliningBase#getrange(byte[], long, long)} instead.
-   * Deprecated since Redis 2.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.0.0.
    */
   @Deprecated
   @Override

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -936,7 +936,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#set(String, String, redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#nx()}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -946,7 +946,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#set(String, String, redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#ex(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -956,7 +956,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#set(String, String, redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#px(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -975,7 +975,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#set(byte[], byte[], redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#nx()}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -985,7 +985,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#set(byte[], byte[], redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#ex(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -995,7 +995,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#set(byte[], byte[], redis.clients.jedis.params.SetParams)} with {@link redis.clients.jedis.params.SetParams#px(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   @Override
@@ -1100,7 +1100,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#getrange(String, long, long)} instead.
-   * Deprecated since Redis 2.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.0.0.
    */
   @Deprecated
   @Override
@@ -1120,7 +1120,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#getrange(byte[], long, long)} instead.
-   * Deprecated since Redis 2.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.0.0.
    */
   @Deprecated
   @Override
@@ -1468,7 +1468,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   /**
    * @deprecated Use {@link UnifiedJedis#lmove(String, String, ListDirection, ListDirection)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -1479,7 +1479,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   /**
    * @deprecated Use {@link UnifiedJedis#blmove(String, String, ListDirection, ListDirection, double)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -1490,7 +1490,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   /**
    * @deprecated Use {@link UnifiedJedis#lmove(byte[], byte[], ListDirection, ListDirection)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -1501,7 +1501,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   /**
    * @deprecated Use {@link UnifiedJedis#blmove(byte[], byte[], ListDirection, ListDirection, double)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -1613,7 +1613,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#hset(String, Map)} instead.
-   * Deprecated since Redis 4.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 4.0.0.
    */
   @Deprecated
   @Override
@@ -1668,7 +1668,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#hset(byte[], Map)} instead.
-   * Deprecated since Redis 4.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 4.0.0.
    */
   @Deprecated
   @Override
@@ -2402,7 +2402,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2417,7 +2417,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2442,7 +2442,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2452,7 +2452,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2462,7 +2462,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2472,7 +2472,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2482,7 +2482,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2492,7 +2492,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2502,7 +2502,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2512,7 +2512,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2522,7 +2522,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2532,7 +2532,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2542,7 +2542,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2552,7 +2552,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2562,7 +2562,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2572,7 +2572,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2582,7 +2582,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2592,7 +2592,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2607,7 +2607,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2622,7 +2622,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2647,7 +2647,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2657,7 +2657,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2667,7 +2667,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2677,7 +2677,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2687,7 +2687,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2697,7 +2697,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2707,7 +2707,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2717,7 +2717,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2727,7 +2727,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2737,7 +2737,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2747,7 +2747,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2757,7 +2757,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2767,7 +2767,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2777,7 +2777,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2787,7 +2787,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2797,7 +2797,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2842,7 +2842,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2852,7 +2852,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2862,7 +2862,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2872,7 +2872,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2892,7 +2892,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2902,7 +2902,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2912,7 +2912,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -2922,7 +2922,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -3221,7 +3221,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#geosearch(String, GeoSearchParam)} instead.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -3241,7 +3241,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#geosearch(String, GeoSearchParam)} instead.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -3376,7 +3376,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#geosearch(byte[], GeoSearchParam)} instead.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override
@@ -3396,7 +3396,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   /**
    * @deprecated Use {@link UnifiedJedis#geosearch(byte[], GeoSearchParam)} instead.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   @Override

--- a/src/main/java/redis/clients/jedis/commands/HashBinaryCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/HashBinaryCommands.java
@@ -76,7 +76,7 @@ public interface HashBinaryCommands {
 
   /**
    * @deprecated Use {@link HashBinaryCommands#hset(byte[], Map)}.
-   * Deprecated since Redis 4.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 4.0.0.
    */
   @Deprecated
   String hmset(byte[] key, Map<byte[], byte[]> hash);

--- a/src/main/java/redis/clients/jedis/commands/HashCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/HashCommands.java
@@ -76,7 +76,7 @@ public interface HashCommands {
 
   /**
    * @deprecated Use {@link HashCommands#hset(String, Map)}.
-   * Deprecated since Redis 4.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 4.0.0.
    */
   @Deprecated
   String hmset(String key, Map<String, String> hash);

--- a/src/main/java/redis/clients/jedis/commands/ListBinaryCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/ListBinaryCommands.java
@@ -56,7 +56,7 @@ public interface ListBinaryCommands {
   /**
    * @deprecated Use {@link ListBinaryCommands#lmove(byte[], byte[], ListDirection, ListDirection)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   byte[] rpoplpush(byte[] srckey, byte[] dstkey);
@@ -64,7 +64,7 @@ public interface ListBinaryCommands {
   /**
    * @deprecated Use {@link ListBinaryCommands#blmove(byte[], byte[], ListDirection, ListDirection, double)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   byte[] brpoplpush(byte[] source, byte[] destination, int timeout);

--- a/src/main/java/redis/clients/jedis/commands/ListCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/ListCommands.java
@@ -356,7 +356,7 @@ public interface ListCommands {
    * @return Bulk reply
    * @deprecated Use {@link ListCommands#lmove(String, String, ListDirection, ListDirection)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   String rpoplpush(String srckey, String dstkey);
@@ -374,7 +374,7 @@ public interface ListCommands {
    * @return The element being popped from source and pushed to destination
    * @deprecated Use {@link ListCommands#blmove(String, String, ListDirection, ListDirection, double)} with
    * {@link ListDirection#RIGHT} and {@link ListDirection#LEFT}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   String brpoplpush(String source, String destination, int timeout);

--- a/src/main/java/redis/clients/jedis/commands/SortedSetBinaryCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/SortedSetBinaryCommands.java
@@ -39,7 +39,7 @@ public interface SortedSetBinaryCommands {
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<byte[]> zrevrange(byte[] key, long start, long stop);
@@ -48,7 +48,7 @@ public interface SortedSetBinaryCommands {
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrevrangeWithScores(byte[] key, long start, long stop);
@@ -85,112 +85,112 @@ public interface SortedSetBinaryCommands {
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<byte[]> zrangeByScore(byte[] key, double min, double max);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<byte[]> zrangeByScore(byte[] key, byte[] min, byte[] max);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<byte[]> zrevrangeByScore(byte[] key, double max, double min);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<byte[]> zrangeByScore(byte[] key, double min, double max, int offset, int count);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<byte[]> zrevrangeByScore(byte[] key, byte[] max, byte[] min);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<byte[]> zrangeByScore(byte[] key, byte[] min, byte[] max, int offset, int count);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<byte[]> zrevrangeByScore(byte[] key, double max, double min, int offset, int count);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrangeByScoreWithScores(byte[] key, double min, double max);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrevrangeByScoreWithScores(byte[] key, double max, double min);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrangeByScoreWithScores(byte[] key, double min, double max, int offset, int count);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<byte[]> zrevrangeByScore(byte[] key, byte[] max, byte[] min, int offset, int count);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrangeByScoreWithScores(byte[] key, byte[] min, byte[] max);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrevrangeByScoreWithScores(byte[] key, byte[] max, byte[] min);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrangeByScoreWithScores(byte[] key, byte[] min, byte[] max, int offset, int count);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrevrangeByScoreWithScores(byte[] key, double max, double min, int offset, int count);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrangeWithScores(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrevrangeByScoreWithScores(byte[] key, byte[] max, byte[] min, int offset, int count);
@@ -205,28 +205,28 @@ public interface SortedSetBinaryCommands {
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(byte[], byte[])}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<byte[]> zrangeByLex(byte[] key, byte[] min, byte[] max);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(byte[], byte[])}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<byte[]> zrangeByLex(byte[] key, byte[] min, byte[] max, int offset, int count);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(byte[], byte[])} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<byte[]> zrevrangeByLex(byte[] key, byte[] max, byte[] min);
 
   /**
    * @deprecated Use {@link SortedSetBinaryCommands#zrange(byte[], ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(byte[], byte[])} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<byte[]> zrevrangeByLex(byte[] key, byte[] max, byte[] min, int offset, int count);

--- a/src/main/java/redis/clients/jedis/commands/SortedSetCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/SortedSetCommands.java
@@ -194,7 +194,7 @@ public interface SortedSetCommands {
    * @param stop the maximum index
    * @return A List of Strings in the specified range
    * @deprecated Use {@link SortedSetCommands#zrange(String, ZRangeParams)} with {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<String> zrevrange(String key, long start, long stop);
@@ -217,7 +217,7 @@ public interface SortedSetCommands {
    * @param stop the maximum index
    * @return A List of Tuple in the specified range (elements names and their scores)
    * @deprecated Use {@link SortedSetCommands#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrevrangeWithScores(String key, long start, long stop);
@@ -382,7 +382,7 @@ public interface SortedSetCommands {
    * @param max maximum score
    * @return A List of elements in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<String> zrangeByScore(String key, double min, double max);
@@ -391,7 +391,7 @@ public interface SortedSetCommands {
    * Similar to {@link SortedSetCommands#zrangeByScore(String, double, double) ZRANGE} but with <i>exclusive</i> range.
    * @see SortedSetCommands#zrangeByScore(String, double, double)
    * @deprecated Use {@link SortedSetCommands#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<String> zrangeByScore(String key, String min, String max);
@@ -411,7 +411,7 @@ public interface SortedSetCommands {
    * @param min minimum score
    * @return A List of elements in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<String> zrevrangeByScore(String key, double max, double min);
@@ -426,7 +426,7 @@ public interface SortedSetCommands {
    * @param count count of the sub-range. A negative count returns all elements from the offset
    * @return A List of elements in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<String> zrangeByScore(String key, double min, double max, int offset, int count);
@@ -435,7 +435,7 @@ public interface SortedSetCommands {
    * Similar to {@link SortedSetCommands#zrevrangeByScore(String, double, double) ZREVRANGE} but with <i>exclusive</i> range.
    * @see SortedSetCommands#zrevrangeByScore(String, double, double)
    * @deprecated Use {@link SortedSetCommands#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<String> zrevrangeByScore(String key, String max, String min);
@@ -451,7 +451,7 @@ public interface SortedSetCommands {
    * @param count count of the sub-range. A negative count returns all elements from the offset
    * @return A List of elements in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<String> zrangeByScore(String key, String min, String max, int offset, int count);
@@ -466,7 +466,7 @@ public interface SortedSetCommands {
    * @param count count of the sub-range. A negative count returns all elements from the offset
    * @return A List of elements in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<String> zrevrangeByScore(String key, double max, double min, int offset, int count);
@@ -480,7 +480,7 @@ public interface SortedSetCommands {
    * @param max maximum score
    * @return A List of elements with scores in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrangeByScoreWithScores(String key, double min, double max);
@@ -494,7 +494,7 @@ public interface SortedSetCommands {
    * @param min minimum score
    * @return A List of elements with scores in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrevrangeByScoreWithScores(String key, double max, double min);
@@ -510,7 +510,7 @@ public interface SortedSetCommands {
    * @param count count of the sub-range. A negative count returns all elements from the offset
    * @return A List of elements in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrangeByScoreWithScores(String key, double min, double max, int offset, int count);
@@ -526,7 +526,7 @@ public interface SortedSetCommands {
    * @param count count of the sub-range. A negative count returns all elements from the offset
    * @return A List of elements in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<String> zrevrangeByScore(String key, String max, String min, int offset, int count);
@@ -536,7 +536,7 @@ public interface SortedSetCommands {
    * and return with scores.
    * @see SortedSetCommands#zrangeByScore(String, double, double)
    * @deprecated Use {@link SortedSetCommands#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrangeByScoreWithScores(String key, String min, String max);
@@ -546,7 +546,7 @@ public interface SortedSetCommands {
    * and return with scores.
    * @see SortedSetCommands#zrevrangeByScore(String, double, double)
    * @deprecated Use {@link SortedSetCommands#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrevrangeByScoreWithScores(String key, String max, String min);
@@ -562,7 +562,7 @@ public interface SortedSetCommands {
    * @param count count of the sub-range. A negative count returns all elements from the offset
    * @return A List of elements in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrangeByScoreWithScores(String key, String min, String max, int offset, int count);
@@ -578,7 +578,7 @@ public interface SortedSetCommands {
    * @param count count of the sub-range. A negative count returns all elements from the offset
    * @return A List of elements in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrevrangeByScoreWithScores(String key, double max, double min, int offset, int count);
@@ -594,7 +594,7 @@ public interface SortedSetCommands {
    * @param count count of the sub-range. A negative count returns all elements from the offset
    * @return A List of elements in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrangeWithScores(String, ZRangeParams)} with {@link ZRangeParams#zrangeByScoreParams(double, double)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<Tuple> zrevrangeByScoreWithScores(String key, String max, String min, int offset, int count);
@@ -657,7 +657,7 @@ public interface SortedSetCommands {
    * @param max maximum value
    * @return A List of elements in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<String> zrangeByLex(String key, String min, String max);
@@ -672,7 +672,7 @@ public interface SortedSetCommands {
    * @param count count of the sub-range. A negative count returns all elements from the offset
    * @return A List of elements in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<String> zrangeByLex(String key, String min, String max, int offset, int count);
@@ -688,7 +688,7 @@ public interface SortedSetCommands {
    * @param min minimum value
    * @return A List of elements in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<String> zrevrangeByLex(String key, String max, String min);
@@ -703,7 +703,7 @@ public interface SortedSetCommands {
    * @param count count of the sub-range. A negative count returns all elements from the offset
    * @return A List of elements in the specified score range
    * @deprecated Use {@link SortedSetCommands#zrange(String, ZRangeParams)} with {@link ZRangeParams#zrangeByLexParams(String, String)} and {@link ZRangeParams#rev()}.
-   * Deprecated since Redis 6.2.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 6.2.0.
    */
   @Deprecated
   List<String> zrevrangeByLex(String key, String max, String min, int offset, int count);

--- a/src/main/java/redis/clients/jedis/commands/StringBinaryCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/StringBinaryCommands.java
@@ -37,21 +37,21 @@ public interface StringBinaryCommands extends BitBinaryCommands {
 
   /**
    * @deprecated Use {@link StringBinaryCommands#set(byte[], byte[], SetParams)} with {@link SetParams#nx()}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   long setnx(byte[] key, byte[] value);
 
   /**
    * @deprecated Use {@link StringBinaryCommands#set(byte[], byte[], SetParams)} with {@link SetParams#ex(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   String setex(byte[] key, long seconds, byte[] value);
 
   /**
    * @deprecated Use {@link StringBinaryCommands#set(byte[], byte[], SetParams)} with {@link SetParams#px(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   String psetex(byte[] key, long milliseconds, byte[] value);
@@ -98,7 +98,7 @@ public interface StringBinaryCommands extends BitBinaryCommands {
 
   /**
    * @deprecated Use {@link StringBinaryCommands#getrange(byte[], long, long)}.
-   * Deprecated since Redis 2.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.0.0.
    */
   @Deprecated
   byte[] substr(byte[] key, int start, int end);

--- a/src/main/java/redis/clients/jedis/commands/StringCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/StringCommands.java
@@ -133,7 +133,7 @@ public interface StringCommands extends BitCommands {
    * @param value
    * @return 1 if the key was set, 0 otherwise
    * @deprecated Use {@link StringCommands#set(String, String, SetParams)} with {@link SetParams#nx()}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   long setnx(String key, String value);
@@ -150,7 +150,7 @@ public interface StringCommands extends BitCommands {
    * @param value
    * @return OK
    * @deprecated Use {@link StringCommands#set(String, String, SetParams)} with {@link SetParams#ex(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   String setex(String key, long seconds, String value);
@@ -166,7 +166,7 @@ public interface StringCommands extends BitCommands {
    * @param value
    * @return OK
    * @deprecated Use {@link StringCommands#set(String, String, SetParams)} with {@link SetParams#px(long)}.
-   * Deprecated since Redis 2.6.12.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   String psetex(String key, long milliseconds, String value);
@@ -364,7 +364,7 @@ public interface StringCommands extends BitCommands {
    * @param end
    * @return The substring
    * @deprecated Use {@link StringCommands#getrange(String, long, long)}.
-   * Deprecated since Redis 2.0.0.
+   * Deprecated in Jedis 8.0.0. Mirrors Redis deprecation since 2.0.0.
    */
   @Deprecated
   String substr(String key, int start, int end);


### PR DESCRIPTION
# Redis Deprecated Commands and Arguments

**Source:** [Redis Commands JSON](https://github.com/redis/docs/blob/main/data/commands.json)  
**Generated:** January 2026

---

## Deprecated Commands

The following **21 commands** have been deprecated across all Redis versions:

| Command | Deprecated Since | Replacement | Description |
|---------|------------------|-------------|-------------|
| `SUBSTR` | 2.0.0 | `GETRANGE` | Returns a substring from a string value. |
| `PSETEX` | 2.6.12 | `SET` with the `PX` argument | Sets both string value and expiration time in milliseconds of a key. The key is created if it doesn't exist. |
| `SETEX` | 2.6.12 | `SET` with the `EX` argument | Sets the string value and expiration time of a key. Creates the key if it doesn't exist. |
| `SETNX` | 2.6.12 | `SET` with the `NX` argument | Set the string value of a key only when the key doesn't exist. |
| `HMSET` | 4.0.0 | `HSET` with multiple field-value pairs | Sets the values of multiple fields. |
| `CLUSTER SLAVES` | 5.0.0 | `CLUSTER REPLICAS` | Lists the replica nodes of a master node. |
| `SLAVEOF` | 5.0.0 | `REPLICAOF` | Sets a Redis server as a replica of another, or promotes it to being a master. |
| `BRPOPLPUSH` | 6.2.0 | `BLMOVE` with the `RIGHT` and `LEFT` arguments | Pops an element from a list, pushes it to another list and returns it. Block until an element is available otherwise. Deletes the list if the last element was popped. |
| `GEORADIUS` | 6.2.0 | `GEOSEARCH` and `GEOSEARCHSTORE` with the `BYRADIUS` argument | Queries a geospatial index for members within a distance from a coordinate, optionally stores the result. |
| `GEORADIUSBYMEMBER` | 6.2.0 | `GEOSEARCH` and `GEOSEARCHSTORE` with the `BYRADIUS` and `FROMMEMBER` arguments | Queries a geospatial index for members within a distance from a member, optionally stores the result. |
| `GEORADIUSBYMEMBER_RO` | 6.2.0 | `GEOSEARCH` with the `BYRADIUS` and `FROMMEMBER` arguments | Returns members from a geospatial index that are within a distance from a member. |
| `GEORADIUS_RO` | 6.2.0 | `GEOSEARCH` with the `BYRADIUS` argument | Returns members from a geospatial index that are within a distance from a coordinate. |
| `GETSET` | 6.2.0 | `SET` with the `GET` argument | Returns the previous string value of a key after setting it to a new value. |
| `RPOPLPUSH` | 6.2.0 | `LMOVE` with the `RIGHT` and `LEFT` arguments | Returns the last element of a list after removing and pushing it to another list. Deletes the list if the last element was popped. |
| `ZRANGEBYLEX` | 6.2.0 | `ZRANGE` with the `BYLEX` argument | Returns members in a sorted set within a lexicographical range. |
| `ZRANGEBYSCORE` | 6.2.0 | `ZRANGE` with the `BYSCORE` argument | Returns members in a sorted set within a range of scores. |
| `ZREVRANGE` | 6.2.0 | `ZRANGE` with the `REV` argument | Returns members in a sorted set within a range of indexes in reverse order. |
| `ZREVRANGEBYLEX` | 6.2.0 | `ZRANGE` with the `REV` and `BYLEX` arguments | Returns members in a sorted set within a lexicographical range in reverse order. |
| `ZREVRANGEBYSCORE` | 6.2.0 | `ZRANGE` with the `REV` and `BYSCORE` arguments | Returns members in a sorted set within a range of scores in reverse order. |
| `CLUSTER SLOTS` | 7.0.0 | `CLUSTER SHARDS` | Returns the mapping of cluster slots to nodes. |
| `QUIT` | 7.2.0 | Just closing the connection | Closes the connection. |

### Summary by Version

| Version | Number of Deprecated Commands |
|---------|-------------------------------|
| 2.0.0 | 1 |
| 2.6.12 | 3 |
| 4.0.0 | 1 |
| 5.0.0 | 2 |
| 6.2.0 | 12 |
| 7.0.0 | 1 |
| 7.2.0 | 1 |
| **Total** | **21** |

---

## Deprecated Command Arguments

The following **1 command argument** has been deprecated:

| Parent Command | Argument Name | Deprecated Since | Replacement |
|----------------|---------------|------------------|-------------|
| `CLIENT KILL` | `old-format` | 2.8.12 | N/A |

### Details

#### CLIENT KILL - `old-format` argument

- **Deprecated Since:** Redis 2.8.12
- **Replacement:** Not specified
- **Notes:** The old format for `CLIENT KILL` used a simple `ip:port` syntax. The newer format uses keyword-based arguments like `ID`, `TYPE`, `ADDR`, `LADDR`, `SKIPME`, etc.

---

## Migration Recommendations

When upgrading Redis versions, consider the following migration strategies:

### String Commands
- Replace `SUBSTR` → `GETRANGE`
- Replace `SETEX key seconds value` → `SET key value EX seconds`
- Replace `PSETEX key milliseconds value` → `SET key value PX milliseconds`
- Replace `SETNX key value` → `SET key value NX`
- Replace `GETSET key value` → `SET key value GET`

### Hash Commands
- Replace `HMSET key field value [field value ...]` → `HSET key field value [field value ...]`

### List Commands
- Replace `RPOPLPUSH source destination` → `LMOVE source destination RIGHT LEFT`
- Replace `BRPOPLPUSH source destination timeout` → `BLMOVE source destination RIGHT LEFT timeout`

### Sorted Set Commands
- Replace `ZRANGEBYLEX key min max` → `ZRANGE key min max BYLEX`
- Replace `ZRANGEBYSCORE key min max` → `ZRANGE key min max BYSCORE`
- Replace `ZREVRANGE key start stop` → `ZRANGE key start stop REV`
- Replace `ZREVRANGEBYLEX key max min` → `ZRANGE key max min REV BYLEX`
- Replace `ZREVRANGEBYSCORE key max min` → `ZRANGE key max min REV BYSCORE`

### Geospatial Commands
- Replace `GEORADIUS` → `GEOSEARCH` with `BYRADIUS`
- Replace `GEORADIUS_RO` → `GEOSEARCH` with `BYRADIUS`
- Replace `GEORADIUSBYMEMBER` → `GEOSEARCH` with `BYRADIUS` and `FROMMEMBER`
- Replace `GEORADIUSBYMEMBER_RO` → `GEOSEARCH` with `BYRADIUS` and `FROMMEMBER`

### Replication Commands
- Replace `SLAVEOF host port` → `REPLICAOF host port`
- Replace `CLUSTER SLAVES node-id` → `CLUSTER REPLICAS node-id`

### Cluster Commands (Redis 7.0+)
- Replace `CLUSTER SLOTS` → `CLUSTER SHARDS`

### Connection Commands (Redis 7.2+)
- Replace `QUIT` → Simply close the connection directly

---

## Notes

1. **Deprecated ≠ Removed:** Deprecated commands are still functional but may be removed in future Redis versions.
2. **Backward Compatibility:** Most deprecated commands continue to work for backward compatibility, but new code should use the recommended replacements.
3. **Performance:** In most cases, the replacement commands offer the same or better performance.
4. **Version Awareness:** When writing Redis client libraries or applications, consider checking the Redis server version to use appropriate commands.

