### PR TITLE
Add DELEX and DIGEST commands to pipeline interfaces

### DIFF
--- a/src/main/java/redis/clients/jedis/PipeliningBase.java
+++ b/src/main/java/redis/clients/jedis/PipeliningBase.java
@@ -22,6 +22,7 @@ import redis.clients.jedis.search.aggr.AggregationBuilder;
 import redis.clients.jedis.search.aggr.AggregationResult;
 import redis.clients.jedis.search.schemafields.SchemaField;
 import redis.clients.jedis.timeseries.*;
+import redis.clients.jedis.util.CompareCondition;
 import redis.clients.jedis.util.KeyValue;
 
 public abstract class PipeliningBase
@@ -2473,6 +2474,26 @@ public abstract class PipeliningBase
   @Override
   public Response<Long> del(byte[]... keys) {
     return appendCommand(commandObjects.del(keys));
+  }
+
+  @Override
+  public Response<Long> delex(byte[] key, CompareCondition condition) {
+    return appendCommand(commandObjects.delex(key, condition));
+  }
+
+  @Override
+  public Response<Long> delex(String key, CompareCondition condition) {
+    return appendCommand(commandObjects.delex(key, condition));
+  }
+
+  @Override
+  public Response<byte[]> digestKey(byte[] key) {
+    return appendCommand(commandObjects.digestKey(key));
+  }
+
+  @Override
+  public Response<String> digestKey(String key) {
+    return appendCommand(commandObjects.digestKey(key));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/commands/KeyPipelineBinaryCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/KeyPipelineBinaryCommands.java
@@ -10,6 +10,7 @@ import redis.clients.jedis.params.RestoreParams;
 import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.params.SortingParams;
 import redis.clients.jedis.resps.ScanResult;
+import redis.clients.jedis.util.CompareCondition;
 
 public interface KeyPipelineBinaryCommands {
 
@@ -64,6 +65,10 @@ public interface KeyPipelineBinaryCommands {
   Response<Long> del(byte[] key);
 
   Response<Long> del(byte[]... keys);
+
+  Response<Long> delex(byte[] key, CompareCondition condition);
+
+  Response<byte[]> digestKey(byte[] key);
 
   Response<Long> unlink(byte[] key);
 

--- a/src/main/java/redis/clients/jedis/commands/KeyPipelineCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/KeyPipelineCommands.java
@@ -10,6 +10,7 @@ import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.params.SortingParams;
 import redis.clients.jedis.resps.ScanResult;
 import redis.clients.jedis.Response;
+import redis.clients.jedis.util.CompareCondition;
 
 public interface KeyPipelineCommands {
 
@@ -66,6 +67,10 @@ public interface KeyPipelineCommands {
   Response<List<String>> sortReadonly(String key, SortingParams sortingParams);
 
   Response<Long> del(String key);
+
+  Response<Long> delex(String key, CompareCondition condition);
+
+  Response<String> digestKey(String key);
 
   Response<Long> del(String... keys);
 

--- a/src/test/java/redis/clients/jedis/mocked/pipeline/PipeliningBaseGenericCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/mocked/pipeline/PipeliningBaseGenericCommandsTest.java
@@ -16,6 +16,7 @@ import redis.clients.jedis.params.RestoreParams;
 import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.params.SortingParams;
 import redis.clients.jedis.resps.ScanResult;
+import redis.clients.jedis.util.CompareCondition;
 import redis.clients.jedis.util.KeyValue;
 
 public class PipeliningBaseGenericCommandsTest extends PipeliningBaseMockedTestBase {
@@ -88,6 +89,56 @@ public class PipeliningBaseGenericCommandsTest extends PipeliningBaseMockedTestB
     Response<Long> response = pipeliningBase.del(key1, key2);
 
     assertThat(commands, contains(longCommandObject));
+    assertThat(response, is(predefinedResponse));
+  }
+
+  @Test
+  public void testDelexBinary() {
+    byte[] key = "key".getBytes();
+    CompareCondition condition = CompareCondition.valueEq("value");
+
+    when(commandObjects.delex(key, condition)).thenReturn(longCommandObject);
+
+    Response<Long> response = pipeliningBase.delex(key, condition);
+
+    assertThat(commands, contains(longCommandObject));
+    assertThat(response, is(predefinedResponse));
+  }
+
+  @Test
+  public void testDelex() {
+    String key = "key";
+    CompareCondition condition = CompareCondition.valueEq("value");
+
+    when(commandObjects.delex(key, condition)).thenReturn(longCommandObject);
+
+    Response<Long> response = pipeliningBase.delex(key, condition);
+
+    assertThat(commands, contains(longCommandObject));
+    assertThat(response, is(predefinedResponse));
+  }
+
+  @Test
+  public void testDigestKeyBinary() {
+    byte[] key = "key".getBytes();
+
+    when(commandObjects.digestKey(key)).thenReturn(bytesCommandObject);
+
+    Response<byte[]> response = pipeliningBase.digestKey(key);
+
+    assertThat(commands, contains(bytesCommandObject));
+    assertThat(response, is(predefinedResponse));
+  }
+
+  @Test
+  public void testDigestKey() {
+    String key = "key";
+
+    when(commandObjects.digestKey(key)).thenReturn(stringCommandObject);
+
+    Response<String> response = pipeliningBase.digestKey(key);
+
+    assertThat(commands, contains(stringCommandObject));
     assertThat(response, is(predefinedResponse));
   }
 


### PR DESCRIPTION
Add pipeline support for Redis 8.4 commands DELEX and DIGEST commands

Changes:
- Add delex() and digestKey() to KeyPipelineBinaryCommands
- Add delex() and digestKey() to KeyPipelineCommands
- Add implementations in PipeliningBase
- Add unit tests for all new pipeline methods