### PR TITLE
[automatic failover] Adding failover tests for all unhealthy

### DIFF
--- a/src/test/java/redis/clients/jedis/mcf/MultiDbConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiDbConnectionProviderTest.java
@@ -426,9 +426,6 @@ public class MultiDbConnectionProviderTest {
       // Reset circuit breaker to allow connections
       db1.getCircuitBreaker().transitionToClosedState();
 
-      // Wait a bit to ensure no automatic recovery happens (failback is disabled)
-      Thread.sleep(1000);
-
       // Verify that automatic recovery does NOT happen
       // The system knows there's a healthy database available (db1), but the active database
       // is still the disabled one (db0), so commands will fail with JedisConnectionException
@@ -449,9 +446,6 @@ public class MultiDbConnectionProviderTest {
       // Verify continued operation
       jedis.set("test-key", "final-value");
       assertEquals("final-value", jedis.get("test-key"));
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      fail("Test interrupted: " + e.getMessage());
     }
   }
 }


### PR DESCRIPTION
Adding tests for recovery cases that all endpoints gets unhealthy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes; main risk is increased integration test flakiness due to timing/awaitility-based assertions.
> 
> **Overview**
> Adds two new integration tests in `MultiDbConnectionProviderTest` covering recovery after the provider enters `JedisPermanentlyNotAvailableException` when **all databases become disabled/unhealthy**.
> 
> The new cases assert (1) with `failbackSupported(true)` the client automatically fails back to the higher-weight database once it is re-enabled, and (2) with `failbackSupported(false)` recovery requires manual intervention (`setActiveDatabase`) even after a database is made healthy again.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2c02d4f108a0a260c3fd8364b8ff669c6d082c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->