### PR TITLE
Add mTLS tests

### DIFF
--- a/src/test/java/redis/clients/jedis/tls/ClientAuthIT.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthIT.java
@@ -1,0 +1,87 @@
+package redis.clients.jedis.tls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.SslOptions;
+import redis.clients.jedis.UnifiedJedis;
+
+/**
+ * Abstract integration test class for mTLS (mutual TLS) certificate-based authentication.
+ * <p>
+ * Defines common test methods that verify client certificate authentication works correctly across
+ * different Redis deployment types (standalone, cluster).
+ * <p>
+ * Subclasses must implement factory methods to create environment-specific clients and execute
+ * commands.
+ */
+public abstract class ClientAuthIT extends ClientAuthTestBase {
+
+  /**
+   * Creates a client with the specified SSL options.
+   * <p>
+   * Subclasses provide environment-specific implementations (e.g., RedisClient for standalone,
+   * RedisClusterClient for cluster).
+   * @param sslOptions SSL configuration for mTLS
+   * @return UnifiedJedis client configured with mTLS
+   */
+  protected abstract UnifiedJedis createClient(SslOptions sslOptions);
+
+  /**
+   * Executes ACL WHOAMI command and returns the authenticated username.
+   * <p>
+   * Subclasses provide environment-specific implementations to handle different command argument
+   * types (CommandArguments vs ClusterCommandArguments).
+   * @param client the connected client
+   * @return the authenticated username
+   */
+  protected abstract String executeAclWhoAmI(UnifiedJedis client);
+
+  /**
+   * Tests mTLS connection with mtls-user1 certificate.
+   * <p>
+   * Verifies that ACL WHOAMI returns the expected username based on Redis version.
+   */
+  @Test
+  public void connectWithMtlsUser1() {
+    SslOptions sslOptions = createMtlsSslOptionsUser1();
+
+    try (UnifiedJedis client = createClient(sslOptions)) {
+      assertEquals("PONG", client.ping());
+      assertExpectedUsername(client, executeAclWhoAmI(client), MTLS_USER_1);
+    }
+  }
+
+  /**
+   * Tests mTLS connection with mtls-user2 certificate.
+   * <p>
+   * Verifies that a different certificate authenticates as a different user.
+   */
+  @Test
+  public void connectWithMtlsUser2() {
+    SslOptions sslOptions = createMtlsSslOptionsUser2();
+
+    try (UnifiedJedis client = createClient(sslOptions)) {
+      assertEquals("PONG", client.ping());
+      assertExpectedUsername(client, executeAclWhoAmI(client), MTLS_USER_2);
+    }
+  }
+
+  /**
+   * Tests that mTLS authenticated users can perform basic Redis operations.
+   */
+  @Test
+  public void performBasicOperationsWithMtls() {
+    SslOptions sslOptions = createMtlsSslOptionsUser1();
+
+    try (UnifiedJedis client = createClient(sslOptions)) {
+      String key = "mtls-test-key";
+      String value = "mtls-test-value";
+
+      assertEquals("OK", client.set(key, value));
+      assertEquals(value, client.get(key));
+      assertEquals(1, client.del(key));
+    }
+  }
+}

--- a/src/test/java/redis/clients/jedis/tls/ClientAuthIT.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthIT.java
@@ -69,6 +69,22 @@ public abstract class ClientAuthIT extends ClientAuthTestBase {
   }
 
   /**
+   * Tests mTLS connection with mtls-user-without-acl certificate.
+   * <p>
+   * Verifies that when using a certificate for a user without a corresponding ACL user configured
+   * in Redis, the connection succeeds and ACL WHOAMI returns "default".
+   */
+  @Test
+  public void connectWithMtlsUserWithoutAcl() {
+    SslOptions sslOptions = createMtlsSslOptionsUserWithoutAcl();
+
+    try (UnifiedJedis client = createClient(sslOptions)) {
+      assertEquals("PONG", client.ping());
+      assertEquals("default", executeAclWhoAmI(client));
+    }
+  }
+
+  /**
    * Tests that mTLS authenticated users can perform basic Redis operations.
    */
   @Test

--- a/src/test/java/redis/clients/jedis/tls/ClientAuthJedisIT.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthJedisIT.java
@@ -1,0 +1,84 @@
+package redis.clients.jedis.tls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.SslOptions;
+
+/**
+ * Integration tests for mTLS (mutual TLS) certificate-based authentication with Jedis.
+ * <p>
+ * These tests verify that: - Client certificate authentication works correctly with Jedis - The
+ * authenticated user matches the certificate CN (Redis 8.6+) or is "default" (older versions) -
+ * Different client certificates authenticate as different users
+ */
+public class ClientAuthJedisIT extends ClientAuthTestBase {
+
+  /**
+   * Tests mTLS connection with mtls-user1 certificate using Jedis. Verifies that ACL WHOAMI returns
+   * the expected username based on Redis version.
+   */
+  @Test
+  public void connectWithMtlsUser1() {
+    SslOptions sslOptions = createMtlsSslOptionsUser1();
+
+    try (Jedis jedis = new Jedis(standaloneEndpoint.getHostAndPort(),
+        DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())) {
+      assertEquals("PONG", jedis.ping());
+      // Verify username based on Redis version
+      assertExpectedUsername(jedis, jedis.aclWhoAmI(), MTLS_USER_1);
+    }
+  }
+
+  /**
+   * Tests mTLS connection with mtls-user2 certificate using Jedis. Verifies that a different
+   * certificate authenticates as a different user.
+   */
+  @Test
+  public void connectWithMtlsUser2() {
+    SslOptions sslOptions = createMtlsSslOptionsUser2();
+
+    try (Jedis jedis = new Jedis(standaloneEndpoint.getHostAndPort(),
+        DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())) {
+      assertEquals("PONG", jedis.ping());
+      // Verify username based on Redis version
+      assertExpectedUsername(jedis, jedis.aclWhoAmI(), MTLS_USER_2);
+    }
+  }
+
+  /**
+   * Tests mTLS connection using host and port separately.
+   */
+  @Test
+  public void connectWithHostAndPort() {
+    SslOptions sslOptions = createMtlsSslOptionsUser1();
+
+    try (Jedis jedis = new Jedis(standaloneEndpoint.getHost(), standaloneEndpoint.getPort(),
+        DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())) {
+      assertEquals("PONG", jedis.ping());
+      assertExpectedUsername(jedis, jedis.aclWhoAmI(), MTLS_USER_1);
+    }
+  }
+
+  /**
+   * Tests that mTLS authenticated users can perform basic Redis operations with Jedis.
+   */
+  @Test
+  public void performBasicOperationsWithMtls() {
+    SslOptions sslOptions = createMtlsSslOptionsUser1();
+
+    try (Jedis jedis = new Jedis(standaloneEndpoint.getHostAndPort(),
+        DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())) {
+      // Test basic operations
+      String key = "mtls-jedis-test-key";
+      String value = "mtls-jedis-test-value";
+
+      assertEquals("OK", jedis.set(key, value));
+      assertEquals(value, jedis.get(key));
+      assertEquals(1, jedis.del(key));
+    }
+  }
+}

--- a/src/test/java/redis/clients/jedis/tls/ClientAuthJedisIT.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthJedisIT.java
@@ -2,9 +2,11 @@ package redis.clients.jedis.tls;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.Endpoints;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.SslOptions;
 
@@ -17,6 +19,12 @@ import redis.clients.jedis.SslOptions;
  */
 public class ClientAuthJedisIT extends ClientAuthTestBase {
 
+  @BeforeAll
+  public static void setUpStandaloneMtlsStores() {
+    endpoint = Endpoints.getRedisEndpoint("standalone-mtls");
+    setUpMtlsStoresForEndpoint(endpoint, ClientAuthJedisIT.class.getSimpleName());
+  }
+
   /**
    * Tests mTLS connection with mtls-user1 certificate using Jedis. Verifies that ACL WHOAMI returns
    * the expected username based on Redis version.
@@ -25,7 +33,7 @@ public class ClientAuthJedisIT extends ClientAuthTestBase {
   public void connectWithMtlsUser1() {
     SslOptions sslOptions = createMtlsSslOptionsUser1();
 
-    try (Jedis jedis = new Jedis(standaloneEndpoint.getHostAndPort(),
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
         DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())) {
       assertEquals("PONG", jedis.ping());
       // Verify username based on Redis version
@@ -41,7 +49,7 @@ public class ClientAuthJedisIT extends ClientAuthTestBase {
   public void connectWithMtlsUser2() {
     SslOptions sslOptions = createMtlsSslOptionsUser2();
 
-    try (Jedis jedis = new Jedis(standaloneEndpoint.getHostAndPort(),
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
         DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())) {
       assertEquals("PONG", jedis.ping());
       // Verify username based on Redis version
@@ -56,7 +64,7 @@ public class ClientAuthJedisIT extends ClientAuthTestBase {
   public void connectWithHostAndPort() {
     SslOptions sslOptions = createMtlsSslOptionsUser1();
 
-    try (Jedis jedis = new Jedis(standaloneEndpoint.getHost(), standaloneEndpoint.getPort(),
+    try (Jedis jedis = new Jedis(endpoint.getHost(), endpoint.getPort(),
         DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())) {
       assertEquals("PONG", jedis.ping());
       assertExpectedUsername(jedis, jedis.aclWhoAmI(), MTLS_USER_1);
@@ -70,7 +78,7 @@ public class ClientAuthJedisIT extends ClientAuthTestBase {
   public void performBasicOperationsWithMtls() {
     SslOptions sslOptions = createMtlsSslOptionsUser1();
 
-    try (Jedis jedis = new Jedis(standaloneEndpoint.getHostAndPort(),
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
         DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())) {
       // Test basic operations
       String key = "mtls-jedis-test-key";

--- a/src/test/java/redis/clients/jedis/tls/ClientAuthJedisIT.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthJedisIT.java
@@ -58,6 +58,22 @@ public class ClientAuthJedisIT extends ClientAuthTestBase {
   }
 
   /**
+   * Tests mTLS connection with mtls-user-without-acl certificate using Jedis. Verifies that when
+   * using a certificate for a user without a corresponding ACL user configured in Redis, the
+   * connection succeeds and ACL WHOAMI returns "default".
+   */
+  @Test
+  public void connectWithMtlsUserWithoutAcl() {
+    SslOptions sslOptions = createMtlsSslOptionsUserWithoutAcl();
+
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
+        DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())) {
+      assertEquals("PONG", jedis.ping());
+      assertEquals("default", jedis.aclWhoAmI());
+    }
+  }
+
+  /**
    * Tests mTLS connection using host and port separately.
    */
   @Test

--- a/src/test/java/redis/clients/jedis/tls/ClientAuthRedisClientIT.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthRedisClientIT.java
@@ -1,0 +1,92 @@
+package redis.clients.jedis.tls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.*;
+
+/**
+ * Integration tests for mTLS (mutual TLS) certificate-based authentication with standalone Redis.
+ * <p>
+ * These tests verify that: - Client certificate authentication works correctly - The authenticated
+ * user matches the certificate CN (Redis 8.6+) or is "default" (older versions) - Different client
+ * certificates authenticate as different users
+ */
+public class ClientAuthRedisClientIT extends ClientAuthTestBase {
+
+  /**
+   * Executes ACL WHOAMI command and returns the username.
+   */
+  private String aclWhoAmI(RedisClient client) {
+    return client.executeCommand(new CommandObject<>(
+        new CommandArguments(Protocol.Command.ACL).add("WHOAMI"), BuilderFactory.STRING));
+  }
+
+  /**
+   * Tests mTLS connection with mtls-user1 certificate. Verifies that ACL WHOAMI returns the
+   * expected username based on Redis version.
+   */
+  @Test
+  public void connectWithMtlsUser1() {
+    SslOptions sslOptions = createMtlsSslOptionsUser1();
+
+    try (RedisClient client = RedisClient.builder()
+        .hostAndPort(standaloneEndpoint.getHost(), standaloneEndpoint.getPort())
+        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build()).build()) {
+      assertEquals("PONG", client.ping());
+      // Verify username based on Redis version
+      assertExpectedUsername(client, aclWhoAmI(client), MTLS_USER_1);
+    }
+  }
+
+  /**
+   * Tests mTLS connection with mtls-user2 certificate. Verifies that a different certificate
+   * authenticates as a different user.
+   */
+  @Test
+  public void connectWithMtlsUser2() {
+    SslOptions sslOptions = createMtlsSslOptionsUser2();
+
+    try (RedisClient client = RedisClient.builder()
+        .hostAndPort(standaloneEndpoint.getHost(), standaloneEndpoint.getPort())
+        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build()).build()) {
+      assertEquals("PONG", client.ping());
+      // Verify username based on Redis version
+      assertExpectedUsername(client, aclWhoAmI(client), MTLS_USER_2);
+    }
+  }
+
+  /**
+   * Tests mTLS connection using HostAndPort object.
+   */
+  @Test
+  public void connectWithHostAndPort() {
+    SslOptions sslOptions = createMtlsSslOptionsUser1();
+
+    try (RedisClient client = RedisClient.builder().hostAndPort(standaloneEndpoint.getHostAndPort())
+        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build()).build()) {
+      assertEquals("PONG", client.ping());
+      assertExpectedUsername(client, aclWhoAmI(client), MTLS_USER_1);
+    }
+  }
+
+  /**
+   * Tests that mTLS authenticated users can perform basic Redis operations.
+   */
+  @Test
+  public void performBasicOperationsWithMtls() {
+    SslOptions sslOptions = createMtlsSslOptionsUser1();
+
+    try (RedisClient client = RedisClient.builder().hostAndPort(standaloneEndpoint.getHostAndPort())
+        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build()).build()) {
+      // Test basic operations
+      String key = "mtls-test-key";
+      String value = "mtls-test-value";
+
+      assertEquals("OK", client.set(key, value));
+      assertEquals(value, client.get(key));
+      assertEquals(1, client.del(key));
+    }
+  }
+}

--- a/src/test/java/redis/clients/jedis/tls/ClientAuthRedisClientIT.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthRedisClientIT.java
@@ -1,92 +1,33 @@
 package redis.clients.jedis.tls;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
 
 import redis.clients.jedis.*;
 
 /**
  * Integration tests for mTLS (mutual TLS) certificate-based authentication with standalone Redis.
  * <p>
- * These tests verify that: - Client certificate authentication works correctly - The authenticated
- * user matches the certificate CN (Redis 8.6+) or is "default" (older versions) - Different client
- * certificates authenticate as different users
+ * Extends {@link ClientAuthIT} to provide standalone-specific client creation and command
+ * execution.
  */
-public class ClientAuthRedisClientIT extends ClientAuthTestBase {
+public class ClientAuthRedisClientIT extends ClientAuthIT {
 
-  /**
-   * Executes ACL WHOAMI command and returns the username.
-   */
-  private String aclWhoAmI(RedisClient client) {
-    return client.executeCommand(new CommandObject<>(
+  @BeforeAll
+  public static void setUpStandaloneMtlsStores() {
+    endpoint = Endpoints.getRedisEndpoint("standalone-mtls");
+    setUpMtlsStoresForEndpoint(endpoint, ClientAuthRedisClientIT.class.getSimpleName());
+  }
+
+  @Override
+  protected UnifiedJedis createClient(SslOptions sslOptions) {
+    return RedisClient.builder().hostAndPort(endpoint.getHostAndPort())
+        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build()).build();
+  }
+
+  @Override
+  protected String executeAclWhoAmI(UnifiedJedis client) {
+    RedisClient redisClient = (RedisClient) client;
+    return redisClient.executeCommand(new CommandObject<>(
         new CommandArguments(Protocol.Command.ACL).add("WHOAMI"), BuilderFactory.STRING));
-  }
-
-  /**
-   * Tests mTLS connection with mtls-user1 certificate. Verifies that ACL WHOAMI returns the
-   * expected username based on Redis version.
-   */
-  @Test
-  public void connectWithMtlsUser1() {
-    SslOptions sslOptions = createMtlsSslOptionsUser1();
-
-    try (RedisClient client = RedisClient.builder()
-        .hostAndPort(standaloneEndpoint.getHost(), standaloneEndpoint.getPort())
-        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build()).build()) {
-      assertEquals("PONG", client.ping());
-      // Verify username based on Redis version
-      assertExpectedUsername(client, aclWhoAmI(client), MTLS_USER_1);
-    }
-  }
-
-  /**
-   * Tests mTLS connection with mtls-user2 certificate. Verifies that a different certificate
-   * authenticates as a different user.
-   */
-  @Test
-  public void connectWithMtlsUser2() {
-    SslOptions sslOptions = createMtlsSslOptionsUser2();
-
-    try (RedisClient client = RedisClient.builder()
-        .hostAndPort(standaloneEndpoint.getHost(), standaloneEndpoint.getPort())
-        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build()).build()) {
-      assertEquals("PONG", client.ping());
-      // Verify username based on Redis version
-      assertExpectedUsername(client, aclWhoAmI(client), MTLS_USER_2);
-    }
-  }
-
-  /**
-   * Tests mTLS connection using HostAndPort object.
-   */
-  @Test
-  public void connectWithHostAndPort() {
-    SslOptions sslOptions = createMtlsSslOptionsUser1();
-
-    try (RedisClient client = RedisClient.builder().hostAndPort(standaloneEndpoint.getHostAndPort())
-        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build()).build()) {
-      assertEquals("PONG", client.ping());
-      assertExpectedUsername(client, aclWhoAmI(client), MTLS_USER_1);
-    }
-  }
-
-  /**
-   * Tests that mTLS authenticated users can perform basic Redis operations.
-   */
-  @Test
-  public void performBasicOperationsWithMtls() {
-    SslOptions sslOptions = createMtlsSslOptionsUser1();
-
-    try (RedisClient client = RedisClient.builder().hostAndPort(standaloneEndpoint.getHostAndPort())
-        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build()).build()) {
-      // Test basic operations
-      String key = "mtls-test-key";
-      String value = "mtls-test-value";
-
-      assertEquals("OK", client.set(key, value));
-      assertEquals(value, client.get(key));
-      assertEquals(1, client.del(key));
-    }
   }
 }

--- a/src/test/java/redis/clients/jedis/tls/ClientAuthRedisClusterClientIT.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthRedisClusterClientIT.java
@@ -1,0 +1,184 @@
+package redis.clients.jedis.tls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import io.redis.test.annotations.ConditionalOnEnv;
+import io.redis.test.utils.RedisVersion;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import redis.clients.jedis.*;
+import redis.clients.jedis.util.EnvCondition;
+import redis.clients.jedis.util.RedisVersionUtil;
+import redis.clients.jedis.util.TestEnvUtil;
+import redis.clients.jedis.util.TlsUtil;
+
+/**
+ * Integration tests for mTLS (mutual TLS) certificate-based authentication with Redis Cluster.
+ * <p>
+ * These tests verify that: - Client certificate authentication works correctly with Redis cluster -
+ * The authenticated user matches the certificate CN - Cluster operations work correctly with mTLS
+ */
+@ConditionalOnEnv(value = TestEnvUtil.ENV_OSS_SOURCE, enabled = false)
+public class ClientAuthRedisClusterClientIT {
+
+  private static final String TRUSTSTORE_PASSWORD = "changeit";
+  private static final String KEYSTORE_PASSWORD = "changeit";
+  private static final int DEFAULT_REDIRECTIONS = 5;
+  private static final ConnectionPoolConfig DEFAULT_POOL_CONFIG = new ConnectionPoolConfig();
+
+  protected static final String MTLS_USER_1 = "mtls-user1";
+  protected static final String MTLS_USER_2 = "mtls-user2";
+
+  @RegisterExtension
+  public static EnvCondition envCondition = new EnvCondition();
+
+  protected static EndpointConfig clusterEndpoint;
+  protected static Path trustStorePath;
+  protected static Path keyStorePath1;
+  protected static Path keyStorePath2;
+
+  @BeforeAll
+  public static void setUpMtlsStores() {
+    clusterEndpoint = Endpoints.getRedisEndpoint("cluster-mtls");
+
+    // Create truststore with CA certificate for server verification
+    List<Path> trustedCertLocation = Collections
+        .singletonList(clusterEndpoint.getCertificatesLocation());
+    trustStorePath = TlsUtil.createAndSaveTestTruststore(
+      ClientAuthRedisClusterClientIT.class.getSimpleName(), trustedCertLocation,
+      TRUSTSTORE_PASSWORD);
+    TlsUtil.setCustomTrustStore(trustStorePath, TRUSTSTORE_PASSWORD);
+
+    // Use pre-generated PKCS12 keystores from Docker container
+    // The container generates .p12 files with password "changeit" for each TLS_CLIENT_CNS entry
+    Path certLocation = clusterEndpoint.getCertificatesLocation();
+    keyStorePath1 = TlsUtil.clientKeystorePath(certLocation, MTLS_USER_1);
+    keyStorePath2 = TlsUtil.clientKeystorePath(certLocation, MTLS_USER_2);
+  }
+
+  @AfterAll
+  public static void tearDownMtlsStores() {
+    TlsUtil.restoreOriginalTrustStore();
+  }
+
+  private static SslOptions createMtlsSslOptions(Path keystorePath) {
+    return SslOptions.builder().truststore(trustStorePath.toFile()).trustStoreType("jceks")
+        .keystore(keystorePath.toFile(), KEYSTORE_PASSWORD.toCharArray()).keyStoreType("PKCS12")
+        .sslVerifyMode(SslVerifyMode.CA).build();
+  }
+
+  /**
+   * Executes ACL WHOAMI command and returns the username.
+   */
+  private String aclWhoAmI(RedisClusterClient cluster) {
+    return cluster.executeCommand(new CommandObject<>(
+        new ClusterCommandArguments(Protocol.Command.ACL).add("WHOAMI"), BuilderFactory.STRING));
+  }
+
+  /**
+   * Asserts the expected username based on Redis version.
+   */
+  private void assertExpectedUsername(UnifiedJedis jedis, String actualUsername,
+      String expectedCertUser) {
+    RedisVersion version = RedisVersionUtil.getRedisVersion(jedis);
+    if (version.isGreaterThanOrEqualTo(RedisVersion.V8_6_0)) {
+      assertEquals(expectedCertUser, actualUsername,
+        "Redis " + version + " supports cert-based auth, expected username from certificate CN");
+    } else {
+      List<String> allowedUsers = Arrays.asList("default", expectedCertUser);
+      assertTrue(allowedUsers.contains(actualUsername),
+        "Redis " + version + " does not support cert-based auth, expected 'default' or '"
+            + expectedCertUser + "' but was '" + actualUsername + "'");
+    }
+  }
+
+  /**
+   * Tests mTLS connection to cluster with mtls-user1 certificate. Verifies cluster node discovery
+   * and ACL WHOAMI based on Redis version.
+   */
+  @Test
+  public void connectWithMtlsUser1() {
+    SslOptions sslOptions = createMtlsSslOptions(keyStorePath1);
+
+    try (RedisClusterClient cluster = RedisClusterClient.builder()
+        .nodes(new HashSet<>(clusterEndpoint.getHostsAndPorts()))
+        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())
+        .maxAttempts(DEFAULT_REDIRECTIONS).poolConfig(DEFAULT_POOL_CONFIG).build()) {
+      assertEquals("PONG", cluster.ping());
+      assertExpectedUsername(cluster, aclWhoAmI(cluster), MTLS_USER_1);
+    }
+  }
+
+  /**
+   * Tests mTLS connection to cluster with mtls-user2 certificate.
+   */
+  @Test
+  public void connectWithMtlsUser2() {
+    SslOptions sslOptions = createMtlsSslOptions(keyStorePath2);
+
+    try (RedisClusterClient cluster = RedisClusterClient.builder()
+        .nodes(new HashSet<>(clusterEndpoint.getHostsAndPorts()))
+        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())
+        .maxAttempts(DEFAULT_REDIRECTIONS).poolConfig(DEFAULT_POOL_CONFIG).build()) {
+      assertEquals("PONG", cluster.ping());
+      assertExpectedUsername(cluster, aclWhoAmI(cluster), MTLS_USER_2);
+    }
+  }
+
+  /**
+   * Tests that cluster node discovery works with mTLS.
+   */
+  @Test
+  public void discoverClusterNodesWithMtls() {
+    SslOptions sslOptions = createMtlsSslOptions(keyStorePath1);
+
+    try (RedisClusterClient cluster = RedisClusterClient.builder()
+        .nodes(Collections.singleton(clusterEndpoint.getHostAndPort()))
+        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())
+        .maxAttempts(DEFAULT_REDIRECTIONS).poolConfig(DEFAULT_POOL_CONFIG).build()) {
+      Map<String, ?> clusterNodes = cluster.getClusterNodes();
+      // Should discover all 3 cluster nodes
+      assertEquals(3, clusterNodes.size());
+      assertTrue(clusterNodes.containsKey(clusterEndpoint.getHostAndPort(0).toString()));
+      assertTrue(clusterNodes.containsKey(clusterEndpoint.getHostAndPort(1).toString()));
+      assertTrue(clusterNodes.containsKey(clusterEndpoint.getHostAndPort(2).toString()));
+    }
+  }
+
+  /**
+   * Tests basic cluster operations with mTLS authentication.
+   */
+  @Test
+  public void performClusterOperationsWithMtls() {
+    SslOptions sslOptions = createMtlsSslOptions(keyStorePath1);
+
+    try (RedisClusterClient cluster = RedisClusterClient.builder()
+        .nodes(new HashSet<>(clusterEndpoint.getHostsAndPorts()))
+        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())
+        .maxAttempts(DEFAULT_REDIRECTIONS).poolConfig(DEFAULT_POOL_CONFIG).build()) {
+
+      // Test basic operations across cluster
+      String key1 = "mtls-cluster-key1";
+      String key2 = "mtls-cluster-key2";
+      String value = "mtls-cluster-value";
+
+      assertEquals("OK", cluster.set(key1, value));
+      assertEquals("OK", cluster.set(key2, value));
+      assertEquals(value, cluster.get(key1));
+      assertEquals(value, cluster.get(key2));
+      assertEquals(1, cluster.del(key1));
+      assertEquals(1, cluster.del(key2));
+    }
+  }
+}

--- a/src/test/java/redis/clients/jedis/tls/ClientAuthRedisClusterClientIT.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthRedisClusterClientIT.java
@@ -3,182 +3,63 @@ package redis.clients.jedis.tls;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 
-import io.redis.test.annotations.ConditionalOnEnv;
-import io.redis.test.utils.RedisVersion;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import redis.clients.jedis.*;
-import redis.clients.jedis.util.EnvCondition;
-import redis.clients.jedis.util.RedisVersionUtil;
-import redis.clients.jedis.util.TestEnvUtil;
-import redis.clients.jedis.util.TlsUtil;
 
 /**
  * Integration tests for mTLS (mutual TLS) certificate-based authentication with Redis Cluster.
  * <p>
- * These tests verify that: - Client certificate authentication works correctly with Redis cluster -
- * The authenticated user matches the certificate CN - Cluster operations work correctly with mTLS
+ * Extends {@link ClientAuthIT} to provide cluster-specific client creation and command execution.
+ * Also includes cluster-specific tests like node discovery.
  */
-@ConditionalOnEnv(value = TestEnvUtil.ENV_OSS_SOURCE, enabled = false)
-public class ClientAuthRedisClusterClientIT {
+public class ClientAuthRedisClusterClientIT extends ClientAuthIT {
 
-  private static final String TRUSTSTORE_PASSWORD = "changeit";
-  private static final String KEYSTORE_PASSWORD = "changeit";
   private static final int DEFAULT_REDIRECTIONS = 5;
   private static final ConnectionPoolConfig DEFAULT_POOL_CONFIG = new ConnectionPoolConfig();
 
-  protected static final String MTLS_USER_1 = "mtls-user1";
-  protected static final String MTLS_USER_2 = "mtls-user2";
-
-  @RegisterExtension
-  public static EnvCondition envCondition = new EnvCondition();
-
-  protected static EndpointConfig clusterEndpoint;
-  protected static Path trustStorePath;
-  protected static Path keyStorePath1;
-  protected static Path keyStorePath2;
-
   @BeforeAll
-  public static void setUpMtlsStores() {
-    clusterEndpoint = Endpoints.getRedisEndpoint("cluster-mtls");
-
-    // Create truststore with CA certificate for server verification
-    List<Path> trustedCertLocation = Collections
-        .singletonList(clusterEndpoint.getCertificatesLocation());
-    trustStorePath = TlsUtil.createAndSaveTestTruststore(
-      ClientAuthRedisClusterClientIT.class.getSimpleName(), trustedCertLocation,
-      TRUSTSTORE_PASSWORD);
-    TlsUtil.setCustomTrustStore(trustStorePath, TRUSTSTORE_PASSWORD);
-
-    // Use pre-generated PKCS12 keystores from Docker container
-    // The container generates .p12 files with password "changeit" for each TLS_CLIENT_CNS entry
-    Path certLocation = clusterEndpoint.getCertificatesLocation();
-    keyStorePath1 = TlsUtil.clientKeystorePath(certLocation, MTLS_USER_1);
-    keyStorePath2 = TlsUtil.clientKeystorePath(certLocation, MTLS_USER_2);
+  public static void setUpClusterMtlsStores() {
+    endpoint = Endpoints.getRedisEndpoint("cluster-mtls");
+    setUpMtlsStoresForEndpoint(endpoint, ClientAuthRedisClusterClientIT.class.getSimpleName());
   }
 
-  @AfterAll
-  public static void tearDownMtlsStores() {
-    TlsUtil.restoreOriginalTrustStore();
+  @Override
+  protected UnifiedJedis createClient(SslOptions sslOptions) {
+    return RedisClusterClient.builder().nodes(new HashSet<>(endpoint.getHostsAndPorts()))
+        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())
+        .maxAttempts(DEFAULT_REDIRECTIONS).poolConfig(DEFAULT_POOL_CONFIG).build();
   }
 
-  private static SslOptions createMtlsSslOptions(Path keystorePath) {
-    return SslOptions.builder().truststore(trustStorePath.toFile()).trustStoreType("jceks")
-        .keystore(keystorePath.toFile(), KEYSTORE_PASSWORD.toCharArray()).keyStoreType("PKCS12")
-        .sslVerifyMode(SslVerifyMode.FULL).build();
-  }
-
-  /**
-   * Executes ACL WHOAMI command and returns the username.
-   */
-  private String aclWhoAmI(RedisClusterClient cluster) {
-    return cluster.executeCommand(new CommandObject<>(
+  @Override
+  protected String executeAclWhoAmI(UnifiedJedis client) {
+    RedisClusterClient clusterClient = (RedisClusterClient) client;
+    return clusterClient.executeCommand(new CommandObject<>(
         new ClusterCommandArguments(Protocol.Command.ACL).add("WHOAMI"), BuilderFactory.STRING));
   }
 
   /**
-   * Asserts the expected username based on Redis version.
-   */
-  private void assertExpectedUsername(UnifiedJedis jedis, String actualUsername,
-      String expectedCertUser) {
-    RedisVersion version = RedisVersionUtil.getRedisVersion(jedis);
-    if (version.isGreaterThanOrEqualTo(RedisVersion.V8_6_0)) {
-      assertEquals(expectedCertUser, actualUsername,
-        "Redis " + version + " supports cert-based auth, expected username from certificate CN");
-    } else {
-      List<String> allowedUsers = Arrays.asList("default", expectedCertUser);
-      assertTrue(allowedUsers.contains(actualUsername),
-        "Redis " + version + " does not support cert-based auth, expected 'default' or '"
-            + expectedCertUser + "' but was '" + actualUsername + "'");
-    }
-  }
-
-  /**
-   * Tests mTLS connection to cluster with mtls-user1 certificate. Verifies cluster node discovery
-   * and ACL WHOAMI based on Redis version.
-   */
-  @Test
-  public void connectWithMtlsUser1() {
-    SslOptions sslOptions = createMtlsSslOptions(keyStorePath1);
-
-    try (RedisClusterClient cluster = RedisClusterClient.builder()
-        .nodes(new HashSet<>(clusterEndpoint.getHostsAndPorts()))
-        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())
-        .maxAttempts(DEFAULT_REDIRECTIONS).poolConfig(DEFAULT_POOL_CONFIG).build()) {
-      assertEquals("PONG", cluster.ping());
-      assertExpectedUsername(cluster, aclWhoAmI(cluster), MTLS_USER_1);
-    }
-  }
-
-  /**
-   * Tests mTLS connection to cluster with mtls-user2 certificate.
-   */
-  @Test
-  public void connectWithMtlsUser2() {
-    SslOptions sslOptions = createMtlsSslOptions(keyStorePath2);
-
-    try (RedisClusterClient cluster = RedisClusterClient.builder()
-        .nodes(new HashSet<>(clusterEndpoint.getHostsAndPorts()))
-        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())
-        .maxAttempts(DEFAULT_REDIRECTIONS).poolConfig(DEFAULT_POOL_CONFIG).build()) {
-      assertEquals("PONG", cluster.ping());
-      assertExpectedUsername(cluster, aclWhoAmI(cluster), MTLS_USER_2);
-    }
-  }
-
-  /**
-   * Tests that cluster node discovery works with mTLS.
+   * Cluster-specific test: Verifies that cluster node discovery works with mTLS.
    */
   @Test
   public void discoverClusterNodesWithMtls() {
-    SslOptions sslOptions = createMtlsSslOptions(keyStorePath1);
+    SslOptions sslOptions = createMtlsSslOptionsUser1();
 
     try (RedisClusterClient cluster = RedisClusterClient.builder()
-        .nodes(Collections.singleton(clusterEndpoint.getHostAndPort()))
+        .nodes(Collections.singleton(endpoint.getHostAndPort()))
         .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())
         .maxAttempts(DEFAULT_REDIRECTIONS).poolConfig(DEFAULT_POOL_CONFIG).build()) {
       Map<String, ?> clusterNodes = cluster.getClusterNodes();
       // Should discover all 3 cluster nodes
       assertEquals(3, clusterNodes.size());
-      assertTrue(clusterNodes.containsKey(clusterEndpoint.getHostAndPort(0).toString()));
-      assertTrue(clusterNodes.containsKey(clusterEndpoint.getHostAndPort(1).toString()));
-      assertTrue(clusterNodes.containsKey(clusterEndpoint.getHostAndPort(2).toString()));
-    }
-  }
-
-  /**
-   * Tests basic cluster operations with mTLS authentication.
-   */
-  @Test
-  public void performClusterOperationsWithMtls() {
-    SslOptions sslOptions = createMtlsSslOptions(keyStorePath1);
-
-    try (RedisClusterClient cluster = RedisClusterClient.builder()
-        .nodes(new HashSet<>(clusterEndpoint.getHostsAndPorts()))
-        .clientConfig(DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())
-        .maxAttempts(DEFAULT_REDIRECTIONS).poolConfig(DEFAULT_POOL_CONFIG).build()) {
-
-      // Test basic operations across cluster
-      String key1 = "mtls-cluster-key1";
-      String key2 = "mtls-cluster-key2";
-      String value = "mtls-cluster-value";
-
-      assertEquals("OK", cluster.set(key1, value));
-      assertEquals("OK", cluster.set(key2, value));
-      assertEquals(value, cluster.get(key1));
-      assertEquals(value, cluster.get(key2));
-      assertEquals(1, cluster.del(key1));
-      assertEquals(1, cluster.del(key2));
+      assertTrue(clusterNodes.containsKey(endpoint.getHostAndPort(0).toString()));
+      assertTrue(clusterNodes.containsKey(endpoint.getHostAndPort(1).toString()));
+      assertTrue(clusterNodes.containsKey(endpoint.getHostAndPort(2).toString()));
     }
   }
 }

--- a/src/test/java/redis/clients/jedis/tls/ClientAuthRedisClusterClientIT.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthRedisClusterClientIT.java
@@ -75,7 +75,7 @@ public class ClientAuthRedisClusterClientIT {
   private static SslOptions createMtlsSslOptions(Path keystorePath) {
     return SslOptions.builder().truststore(trustStorePath.toFile()).trustStoreType("jceks")
         .keystore(keystorePath.toFile(), KEYSTORE_PASSWORD.toCharArray()).keyStoreType("PKCS12")
-        .sslVerifyMode(SslVerifyMode.CA).build();
+        .sslVerifyMode(SslVerifyMode.FULL).build();
   }
 
   /**

--- a/src/test/java/redis/clients/jedis/tls/ClientAuthTestBase.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthTestBase.java
@@ -42,6 +42,7 @@ public abstract class ClientAuthTestBase {
   /** Default mTLS user for testing */
   protected static final String MTLS_USER_1 = "mtls-user1";
   protected static final String MTLS_USER_2 = "mtls-user2";
+  protected static final String MTLS_USER_WITHOUT_ACL = "mtls-user-without-acl";
 
   @RegisterExtension
   public static EnvCondition envCondition = new EnvCondition();
@@ -50,6 +51,7 @@ public abstract class ClientAuthTestBase {
   protected static Path trustStorePath;
   protected static Path keyStorePath1;
   protected static Path keyStorePath2;
+  protected static Path keyStorePathUserWithoutAcl;
 
   /**
    * Sets up mTLS stores for a specific targetEndpioint. Should be called by subclasses in
@@ -71,6 +73,7 @@ public abstract class ClientAuthTestBase {
     Path certLocation = targetEndpioint.getCertificatesLocation();
     keyStorePath1 = TlsUtil.clientKeystorePath(certLocation, MTLS_USER_1);
     keyStorePath2 = TlsUtil.clientKeystorePath(certLocation, MTLS_USER_2);
+    keyStorePathUserWithoutAcl = TlsUtil.clientKeystorePath(certLocation, MTLS_USER_WITHOUT_ACL);
   }
 
   @AfterAll
@@ -101,6 +104,13 @@ public abstract class ClientAuthTestBase {
    */
   protected static SslOptions createMtlsSslOptionsUser2() {
     return createMtlsSslOptions(keyStorePath2);
+  }
+
+  /**
+   * Creates SslOptions for mtls-user-without-acl.
+   */
+  protected static SslOptions createMtlsSslOptionsUserWithoutAcl() {
+    return createMtlsSslOptions(keyStorePathUserWithoutAcl);
   }
 
   /**

--- a/src/test/java/redis/clients/jedis/tls/ClientAuthTestBase.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthTestBase.java
@@ -46,27 +46,27 @@ public abstract class ClientAuthTestBase {
   @RegisterExtension
   public static EnvCondition envCondition = new EnvCondition();
 
-  protected static EndpointConfig standaloneEndpoint;
-  protected static EndpointConfig clusterEndpoint;
+  protected static EndpointConfig endpoint;
   protected static Path trustStorePath;
   protected static Path keyStorePath1;
   protected static Path keyStorePath2;
 
-  @BeforeAll
-  public static void setUpMtlsStores() {
-    standaloneEndpoint = Endpoints.getRedisEndpoint("standalone-mtls");
-    clusterEndpoint = Endpoints.getRedisEndpoint("cluster-mtls");
-
+  /**
+   * Sets up mTLS stores for a specific targetEndpioint. Should be called by subclasses in their @BeforeAll
+   * method.
+   * @param targetEndpioint the targetEndpioint to configure mTLS for
+   * @param testClassName the test class name for truststore naming
+   */
+  protected static void setUpMtlsStoresForEndpoint(EndpointConfig targetEndpioint, String testClassName) {
     // Create truststore with CA certificate for server verification
-    List<Path> trustedCertLocation = Collections
-        .singletonList(standaloneEndpoint.getCertificatesLocation());
-    trustStorePath = TlsUtil.createAndSaveTestTruststore(ClientAuthTestBase.class.getSimpleName(),
-      trustedCertLocation, TRUSTSTORE_PASSWORD);
+    List<Path> trustedCertLocation = Collections.singletonList(targetEndpioint.getCertificatesLocation());
+    trustStorePath = TlsUtil.createAndSaveTestTruststore(testClassName, trustedCertLocation,
+      TRUSTSTORE_PASSWORD);
     TlsUtil.setCustomTrustStore(trustStorePath, TRUSTSTORE_PASSWORD);
 
     // Use pre-generated PKCS12 keystores from Docker container
     // The container generates .p12 files with password "changeit" for each TLS_CLIENT_CNS entry
-    Path certLocation = standaloneEndpoint.getCertificatesLocation();
+    Path certLocation = targetEndpioint.getCertificatesLocation();
     keyStorePath1 = TlsUtil.clientKeystorePath(certLocation, MTLS_USER_1);
     keyStorePath2 = TlsUtil.clientKeystorePath(certLocation, MTLS_USER_2);
   }

--- a/src/test/java/redis/clients/jedis/tls/ClientAuthTestBase.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthTestBase.java
@@ -52,14 +52,16 @@ public abstract class ClientAuthTestBase {
   protected static Path keyStorePath2;
 
   /**
-   * Sets up mTLS stores for a specific targetEndpioint. Should be called by subclasses in their @BeforeAll
-   * method.
+   * Sets up mTLS stores for a specific targetEndpioint. Should be called by subclasses in
+   * their @BeforeAll method.
    * @param targetEndpioint the targetEndpioint to configure mTLS for
    * @param testClassName the test class name for truststore naming
    */
-  protected static void setUpMtlsStoresForEndpoint(EndpointConfig targetEndpioint, String testClassName) {
+  protected static void setUpMtlsStoresForEndpoint(EndpointConfig targetEndpioint,
+      String testClassName) {
     // Create truststore with CA certificate for server verification
-    List<Path> trustedCertLocation = Collections.singletonList(targetEndpioint.getCertificatesLocation());
+    List<Path> trustedCertLocation = Collections
+        .singletonList(targetEndpioint.getCertificatesLocation());
     trustStorePath = TlsUtil.createAndSaveTestTruststore(testClassName, trustedCertLocation,
       TRUSTSTORE_PASSWORD);
     TlsUtil.setCustomTrustStore(trustStorePath, TRUSTSTORE_PASSWORD);

--- a/src/test/java/redis/clients/jedis/tls/ClientAuthTestBase.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthTestBase.java
@@ -1,0 +1,145 @@
+package redis.clients.jedis.tls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import io.redis.test.annotations.ConditionalOnEnv;
+import io.redis.test.utils.RedisVersion;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import redis.clients.jedis.EndpointConfig;
+import redis.clients.jedis.Endpoints;
+import redis.clients.jedis.SslOptions;
+import redis.clients.jedis.SslVerifyMode;
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.util.EnvCondition;
+import redis.clients.jedis.util.RedisVersionUtil;
+import redis.clients.jedis.util.TestEnvUtil;
+import redis.clients.jedis.util.TlsUtil;
+
+/**
+ * Abstract base class for mTLS (mutual TLS) authentication tests.
+ * <p>
+ * This class provides common setup for tests that verify certificate-based client authentication.
+ * It configures both truststore (for server verification) and keystore (for client authentication).
+ * <p>
+ * The mTLS setup requires: - A truststore containing the CA certificate to verify the Redis server
+ * - A keystore containing the client certificate and private key for client authentication
+ */
+@ConditionalOnEnv(value = TestEnvUtil.ENV_OSS_SOURCE, enabled = false)
+public abstract class ClientAuthTestBase {
+
+  private static final String TRUSTSTORE_PASSWORD = "changeit";
+  private static final String KEYSTORE_PASSWORD = "changeit";
+
+  /** Default mTLS user for testing */
+  protected static final String MTLS_USER_1 = "mtls-user1";
+  protected static final String MTLS_USER_2 = "mtls-user2";
+
+  @RegisterExtension
+  public static EnvCondition envCondition = new EnvCondition();
+
+  protected static EndpointConfig standaloneEndpoint;
+  protected static EndpointConfig clusterEndpoint;
+  protected static Path trustStorePath;
+  protected static Path keyStorePath1;
+  protected static Path keyStorePath2;
+
+  @BeforeAll
+  public static void setUpMtlsStores() {
+    standaloneEndpoint = Endpoints.getRedisEndpoint("standalone-mtls");
+    clusterEndpoint = Endpoints.getRedisEndpoint("cluster-mtls");
+
+    // Create truststore with CA certificate for server verification
+    List<Path> trustedCertLocation = Collections
+        .singletonList(standaloneEndpoint.getCertificatesLocation());
+    trustStorePath = TlsUtil.createAndSaveTestTruststore(ClientAuthTestBase.class.getSimpleName(),
+      trustedCertLocation, TRUSTSTORE_PASSWORD);
+    TlsUtil.setCustomTrustStore(trustStorePath, TRUSTSTORE_PASSWORD);
+
+    // Use pre-generated PKCS12 keystores from Docker container
+    // The container generates .p12 files with password "changeit" for each TLS_CLIENT_CNS entry
+    Path certLocation = standaloneEndpoint.getCertificatesLocation();
+    keyStorePath1 = TlsUtil.clientKeystorePath(certLocation, MTLS_USER_1);
+    keyStorePath2 = TlsUtil.clientKeystorePath(certLocation, MTLS_USER_2);
+  }
+
+  @AfterAll
+  public static void tearDownMtlsStores() {
+    TlsUtil.restoreOriginalTrustStore();
+  }
+
+  /**
+   * Creates SslOptions configured for mTLS with the specified client keystore.
+   * @param keystorePath path to the client keystore
+   * @return SslOptions configured for mTLS
+   */
+  protected static SslOptions createMtlsSslOptions(Path keystorePath) {
+    return SslOptions.builder().truststore(trustStorePath.toFile()).trustStoreType("jceks")
+        .keystore(keystorePath.toFile(), KEYSTORE_PASSWORD.toCharArray()).keyStoreType("PKCS12")
+        .sslVerifyMode(SslVerifyMode.FULL).build();
+  }
+
+  /**
+   * Creates SslOptions for mtls-user1.
+   */
+  protected static SslOptions createMtlsSslOptionsUser1() {
+    return createMtlsSslOptions(keyStorePath1);
+  }
+
+  /**
+   * Creates SslOptions for mtls-user2.
+   */
+  protected static SslOptions createMtlsSslOptionsUser2() {
+    return createMtlsSslOptions(keyStorePath2);
+  }
+
+  /**
+   * Asserts the expected username based on Redis version.
+   * <p>
+   * Redis 8.6+ supports automatic certificate-based authentication via tls-auth-clients-user CN,
+   * where the username is extracted from the client certificate's Common Name. For Redis versions
+   * below 8.6, the user will be "default" since cert-based auth is not supported.
+   * @param jedis the connected Jedis client to check version
+   * @param actualUsername the actual username from ACL WHOAMI
+   * @param expectedCertUser the expected username from client certificate CN
+   */
+  protected static void assertExpectedUsername(redis.clients.jedis.Jedis jedis,
+      String actualUsername, String expectedCertUser) {
+    RedisVersion version = RedisVersionUtil.getRedisVersion(jedis);
+    assertUsernameForVersion(version, actualUsername, expectedCertUser);
+  }
+
+  /**
+   * Asserts the expected username based on Redis version for UnifiedJedis clients (RedisClient,
+   * RedisClusterClient, etc.).
+   * @param jedis the connected UnifiedJedis client to check version
+   * @param actualUsername the actual username from ACL WHOAMI
+   * @param expectedCertUser the expected username from client certificate CN
+   */
+  protected static void assertExpectedUsername(UnifiedJedis jedis, String actualUsername,
+      String expectedCertUser) {
+    RedisVersion version = RedisVersionUtil.getRedisVersion(jedis);
+    assertUsernameForVersion(version, actualUsername, expectedCertUser);
+  }
+
+  private static void assertUsernameForVersion(RedisVersion version, String actualUsername,
+      String expectedCertUser) {
+    if (version.isGreaterThanOrEqualTo(RedisVersion.V8_6_0)) {
+      assertEquals(expectedCertUser, actualUsername,
+        "Redis " + version + " supports cert-based auth, expected username from certificate CN");
+    } else {
+      List<String> allowedUsers = Arrays.asList("default", expectedCertUser);
+      assertTrue(allowedUsers.contains(actualUsername),
+        "Redis " + version + " does not support cert-based auth, expected 'default' or '"
+            + expectedCertUser + "' but was '" + actualUsername + "'");
+    }
+  }
+}

--- a/src/test/java/redis/clients/jedis/util/TlsUtil.java
+++ b/src/test/java/redis/clients/jedis/util/TlsUtil.java
@@ -107,6 +107,21 @@ public class TlsUtil {
         return Paths.get(TEST_WORK_FOLDER, certLocation.toString(), TEST_SERVER_CERT);
     }
 
+    /**
+     * Resolves the path to a pre-generated PKCS12 keystore for mTLS client authentication.
+     * The Docker container generates .p12 files for each TLS_CLIENT_CNS entry.
+     *
+     * @param certLocation the certificate location from EndpointConfig
+     * @param clientName the name of the client certificate (without extension)
+     * @return the absolute path to the .p12 keystore file
+     */
+    public static Path clientKeystorePath(Path certLocation, String clientName) {
+        if (certLocation.isAbsolute()) {
+            return certLocation.resolve(clientName + ".p12");
+        }
+        return Paths.get(TEST_WORK_FOLDER, certLocation.toString(), clientName + ".p12");
+    }
+
     public static Path testTruststorePath(String name) {
         return Paths.get(TEST_WORK_FOLDER, name  + '-' + TEST_TRUSTSTORE);
     }

--- a/src/test/resources/endpoints.json
+++ b/src/test/resources/endpoints.json
@@ -175,5 +175,21 @@
       "redis://127.0.0.1:16480",
       "redis://127.0.0.1:16481"
     ]
+  },
+  "standalone-mtls": {
+    "tls": true,
+    "tls_cert_path": "standalone-mtls/work/tls",
+    "endpoints": [
+      "rediss://localhost:6790"
+    ]
+  },
+  "cluster-mtls": {
+    "tls": true,
+    "tls_cert_path": "cluster-mtls/work/tls",
+    "endpoints": [
+      "rediss://localhost:8579",
+      "rediss://localhost:8580",
+      "rediss://localhost:8581"
+    ]
   }
 }

--- a/src/test/resources/env/docker-compose.yml
+++ b/src/test/resources/env/docker-compose.yml
@@ -176,3 +176,87 @@ services:
 #    volumes:
 #      - "./redis_uds/config/node-0/redis.conf:/etc/redis.conf"
 #      - "./work/redis_uds/work:/tmp/docker/"
+
+  # Standalone Redis instance with mTLS (mutual TLS) authentication
+  # Uses TLS_CLIENT_CNS to generate client certificates for mTLS users
+  # TLS_AUTH_CLIENTS_USER=CN (default) extracts username from client certificate CN
+  # ACL users matching client certificate CNs are configured via --user directives
+  standalone-mtls:
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=1
+    <<: *client-libs-image
+    container_name: standalone-mtls
+    command:
+      - "--save"
+      - ""
+      - "--user"
+      - "mtls-user1"
+      - "on"
+      - "nopass"
+      - "~*"
+      - "&*"
+      - "+@all"
+      - "--user"
+      - "mtls-user2"
+      - "on"
+      - "nopass"
+      - "~*"
+      - "&*"
+      - "+@all"
+    environment:
+      - REDIS_CLUSTER=no
+      - TLS_ENABLED=yes
+      - TLS_PORT=6790
+      - PORT=6789
+      - TLS_CLIENT_CNS=mtls-user1 mtls-user2
+    ports:
+      # We don't expose non-TLS port on purpose
+      - "6790:6790"
+    volumes:
+      - ${REDIS_ENV_WORK_DIR}/standalone-mtls/work:/redis/work:rw
+
+  # Redis cluster with mTLS (mutual TLS) authentication
+  # 3 nodes without replicas to minimize memory footprint
+  # TLS_AUTH_CLIENTS_USER=CN (default) extracts username from client certificate CN
+  # ACL users matching client certificate CNs are configured via --user directives
+  cluster-mtls:
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=1
+    <<: *client-libs-image
+    container_name: cluster-mtls
+    command:
+      - "--cluster-preferred-endpoint-type"
+      - "hostname"
+      - "--cluster-announce-hostname"
+      - "localhost"
+      - "--cluster-node-timeout"
+      - "150"
+      - "--save"
+      - ""
+      - "--user"
+      - "mtls-user1"
+      - "on"
+      - "nopass"
+      - "~*"
+      - "&*"
+      - "+@all"
+      - "--user"
+      - "mtls-user2"
+      - "on"
+      - "nopass"
+      - "~*"
+      - "&*"
+      - "+@all"
+    environment:
+      - REDIS_CLUSTER=yes
+      - TLS_ENABLED=yes
+      - TLS_PORT=8579
+      - PORT=7579
+      - NODES=3
+      - REPLICAS=0
+      - TLS_CLIENT_CNS=mtls-user1 mtls-user2
+    ports:
+      # We don't expose non-TLS ports on purpose
+      - "8579-8581:8579-8581"
+    volumes:
+      - ${REDIS_ENV_WORK_DIR}/cluster-mtls/work:/redis/work:rw

--- a/src/test/resources/env/docker-compose.yml
+++ b/src/test/resources/env/docker-compose.yml
@@ -208,7 +208,7 @@ services:
       - TLS_ENABLED=yes
       - TLS_PORT=6790
       - PORT=6789
-      - TLS_CLIENT_CNS=mtls-user1 mtls-user2
+      - TLS_CLIENT_CNS=mtls-user1 mtls-user2 mtls-user-without-acl
     ports:
       # We don't expose non-TLS port on purpose
       - "6790:6790"
@@ -254,7 +254,7 @@ services:
       - PORT=7579
       - NODES=3
       - REPLICAS=0
-      - TLS_CLIENT_CNS=mtls-user1 mtls-user2
+      - TLS_CLIENT_CNS=mtls-user1 mtls-user2 mtls-user-without-acl
     ports:
       # We don't expose non-TLS ports on purpose
       - "8579-8581:8579-8581"


### PR DESCRIPTION
Add basic mTLS tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new docker-compose Redis services/endpoints and integration tests around TLS client-auth, which may affect CI environment setup and port/resource usage. No production code paths are changed beyond test utilities.
> 
> **Overview**
> Adds **mTLS (client-certificate) integration tests** covering `Jedis`, `RedisClient` (standalone), and `RedisClusterClient` (including cluster node discovery), validating `ACL WHOAMI` behavior across Redis versions and basic read/write operations.
> 
> Extends test infrastructure to support these scenarios by introducing a shared `ClientAuthTestBase`, adding `TlsUtil.clientKeystorePath(...)` for locating pre-generated PKCS#12 client keystores, and registering new `standalone-mtls` / `cluster-mtls` endpoints plus matching Docker services configured to generate client certs and ACL users.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfb7a5852de5cd668adff332bb5c67a6b9e379b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->