### PR TITLE
Bump snapshot version to 7.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>jar</packaging>
 	<groupId>redis.clients</groupId>
 	<artifactId>jedis</artifactId>
-	<version>7.4.0-SNAPSHOT</version>
+	<version>7.5.0-SNAPSHOT</version>
 	<name>Jedis</name>
 	<description>Jedis is a blazingly small and sane Redis java client.</description>
 	<url>https://github.com/redis/jedis</url>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only updates the Maven project version and does not change runtime code or dependencies.
> 
> **Overview**
> Bumps the Maven `pom.xml` project snapshot version from `7.4.0-SNAPSHOT` to `7.5.0-SNAPSHOT` for the next development iteration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67344db4666dac18b2e7fa366aac402416f7948f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->