### PR TITLE
Extract unit tests into separate workflow

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -145,9 +145,9 @@ runs:
 
         # Unit tests are run in a separate workflow (unit-tests.yml), skip them here
         if [ -z "$TESTS" ]; then
-          mvn -B -Dwith-param-names=true -DskipUnitTests=true clean compile verify
+          mvn -B -DskipUnitTests=true clean compile verify
         else
-          mvn -B -Dwith-param-names=true -DskipUnitTests=true -Dtest=$TESTS clean verify
+          mvn -B -DskipUnitTests=true -Dtest=$TESTS clean verify
         fi
       env:
         REDIS_ENV_WORK_DIR: ${{ steps.args.outputs.redis_env_work_dir }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -136,11 +136,6 @@ runs:
       run: |
         mvn -q dependency:go-offline
 
-    - name: Build docs
-      shell: bash
-      run: |
-        mvn javadoc:jar
-
     - name: Run Maven tests
       shell: bash
       run: |

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -147,10 +147,12 @@ runs:
         export TEST_ENV_PROVIDER=oss-docker
         export TEST_WORK_FOLDER=$REDIS_ENV_WORK_DIR
         echo $TEST_WORK_FOLDER
+
+        # Unit tests are run in a separate workflow (unit-tests.yml), skip them here
         if [ -z "$TESTS" ]; then
-          mvn -B -Dwith-param-names=true clean compile verify
+          mvn -B -Dwith-param-names=true -DskipUnitTests=true clean compile verify
         else
-          mvn -B -Dwith-param-names=true -Dtest=$TESTS clean verify
+          mvn -B -Dwith-param-names=true -DskipUnitTests=true -Dtest=$TESTS clean verify
         fi
       env:
         REDIS_ENV_WORK_DIR: ${{ steps.args.outputs.redis_env_work_dir }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run Unit Tests
         run: |
-          mvn -B clean test -DskipIntegrationTests=true
+          mvn -B clean test jacoco:report
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,7 +60,6 @@ jobs:
             target/surefire-reports/**/*.xml
 
       - name: Upload coverage to Codecov
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v5
         with:
           files: ./target/site/jacoco/jacoco.xml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,71 @@
+---
+
+name: Unit Tests
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.rst'
+    branches:
+      - master
+      - '[0-9].*'
+      - 'feature/**'
+      - 'topic/**'
+  pull_request:
+    branches:
+      - master
+      - '[0-9].*'
+      - 'feature/**'
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+          key: jedis-${{hashFiles('**/pom.xml')}}
+
+      - name: Maven offline
+        run: |
+          mvn -q dependency:go-offline
+
+      - name: Build docs
+        run: |
+          mvn javadoc:jar
+
+      - name: Run Unit Tests
+        run: |
+          mvn -B clean test -DskipIntegrationTests=true
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          files: |
+            target/surefire-reports/**/*.xml
+
+      - name: Upload coverage to Codecov
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./target/site/jacoco/jacoco.xml
+          flags: unit-tests
+          name: unit-test-coverage
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run Unit Tests
         run: |
-          mvn -B clean test jacoco:report -Djacoco.dataFile=target/jacoco-ut.exec
+          mvn -B -Dwith-param-names=true clean test jacoco:report -Djacoco.dataFile=target/jacoco-ut.exec
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run Unit Tests
         run: |
-          mvn -B clean test jacoco:report
+          mvn -B clean test jacoco:report -Djacoco.dataFile=target/jacoco-ut.exec
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/src/test/java/redis/clients/jedis/util/EnvCondition.java
+++ b/src/test/java/redis/clients/jedis/util/EnvCondition.java
@@ -60,8 +60,6 @@ public class EnvCondition implements ExecutionCondition {
     if (enabled) {
       // enabled = true: test runs ONLY when environment matches
       if (matches) {
-        logger.debug("Test enabled: current environment '{}' matches one of {}", currentEnv,
-          Arrays.toString(envs));
         return ConditionEvaluationResult
             .enabled("Current environment '" + currentEnv + "' is in the enabled list");
       }
@@ -85,9 +83,6 @@ public class EnvCondition implements ExecutionCondition {
         logger.debug("Test disabled: {}", disabledReason);
         return ConditionEvaluationResult.disabled(disabledReason);
       }
-
-      logger.debug("Test enabled: current environment '{}' is not in disabled list {}", currentEnv,
-        Arrays.toString(envs));
       return ConditionEvaluationResult
           .enabled("Current environment '" + currentEnv + "' is not in the disabled list");
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CI test execution by skipping unit tests in the main docker-based test action and relying on a new `unit-tests.yml` workflow instead; misconfiguration could reduce test coverage or change when failures surface.
> 
> **Overview**
> Extracts Maven *unit test* execution into a dedicated GitHub Actions workflow (`unit-tests.yml`) that runs `mvn ... test` with JaCoCo reporting, publishes JUnit results, and uploads coverage to Codecov.
> 
> Updates the composite `run-tests` action to stop building Javadocs and to run `verify` with `-DskipUnitTests=true` (including for `-Dtest=$TESTS` runs), so the docker-based workflow focuses on non-unit test phases.
> 
> Cleans up noisy logging in `EnvCondition` by removing debug logs for the “enabled” paths while keeping disabled-reason logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c74393eb1752a2ba65e9a0919ec90b5ca810b6b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->