### PR TITLE
fix : [ClusterPipeline] ExecutorService/thread is created and destroyed too frequently in ClusterPipeline

### DIFF
--- a/src/main/java/redis/clients/jedis/ClusterPipeline.java
+++ b/src/main/java/redis/clients/jedis/ClusterPipeline.java
@@ -2,6 +2,8 @@ package redis.clients.jedis;
 
 import java.time.Duration;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import redis.clients.jedis.exceptions.JedisClusterOperationException;
 import redis.clients.jedis.providers.ClusterConnectionProvider;
@@ -90,8 +92,8 @@ public class ClusterPipeline extends MultiNodePipelineBase {
   }
 
   ClusterPipeline(ClusterConnectionProvider provider, ClusterCommandObjects commandObjects,
-      CommandFlagsRegistry commandFlagsRegistry) {
-    super(commandObjects, commandFlagsRegistry);
+          CommandFlagsRegistry commandFlagsRegistry, ExecutorService executorService) {
+    super(commandObjects, commandFlagsRegistry, executorService);
     this.provider = provider;
   }
 

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
@@ -420,10 +421,49 @@ public class JedisCluster extends UnifiedJedis {
   }
   // commands
 
+  /**
+   * Creates a new pipeline for executing commands in a Redis Cluster.
+   *
+   * <p>Pipelining allows batching multiple commands for more efficient execution
+   * by reducing network round-trips. In a cluster environment, commands are routed
+   * to the appropriate nodes based on key hash slots.</p>
+   *
+   * <p>If the pipeline spans multiple nodes, a dedicated {@link ExecutorService} is
+   * created internally to execute requests in parallel and shutdown when the pipeline
+   * is closed.</p>
+   *
+   * @return a new {@link ClusterPipeline} instance
+   * @see #pipelined(ExecutorService)
+   */
   @Override
   public ClusterPipeline pipelined() {
-    return new ClusterPipeline((ClusterConnectionProvider) provider,
-        (ClusterCommandObjects) commandObjects, commandFlagsRegistry);
+    return pipelined(null);
+  }
+
+  /**
+   * Creates a new pipeline for executing commands in a Redis Cluster using the provided executor.
+   *
+   * <p>Pipelining allows batching multiple commands for more efficient execution
+   * by reducing network round-trips. In a cluster environment, commands are routed
+   * to the appropriate nodes based on key hash slots.</p>
+   *
+   * <p>If the pipeline spans multiple nodes, the provided {@link ExecutorService} is
+   * used to execute requests in parallel. The caller is responsible for managing
+   * the lifecycle of this executor (creation, shutdown, etc.).</p>
+   *
+   * <p>If {@code null} is provided, a dedicated executor is created and managed
+   * internally, similar to {@link #pipelined()}.</p>
+   *
+   * @param executorService the executor to use for multi-node execution, or {@code null}
+   * @return a new {@link ClusterPipeline} instance
+   */
+  public ClusterPipeline pipelined(ExecutorService executorService) {
+    return new ClusterPipeline(
+            (ClusterConnectionProvider) provider,
+            (ClusterCommandObjects) commandObjects,
+            commandFlagsRegistry,
+            executorService
+    );
   }
 
   /**

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -430,7 +430,7 @@ public class JedisCluster extends UnifiedJedis {
    *
    * <p>If the pipeline spans multiple nodes, a dedicated {@link ExecutorService} is
    * created internally to execute requests in parallel and shutdown when the pipeline
-   * is closed.</p>
+   * is synced.</p>
    *
    * @return a new {@link ClusterPipeline} instance
    * @see #pipelined(ExecutorService)

--- a/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
@@ -11,8 +11,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
@@ -11,6 +11,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,8 +40,7 @@ public abstract class MultiNodePipelineBase extends AbstractPipeline {
    * External executor service to use for {@code sync()}. If not set, a new executor service will be
    * created for each {@code sync()} call.
    */
-  private final ExecutorService executorService;
-  private final boolean sharedExecutor;
+  private final ExecutorService sharedExecutorService;
 
   public MultiNodePipelineBase(CommandObjects commandObjects) {
     this(commandObjects, StaticCommandFlagsRegistry.registry());
@@ -54,14 +55,7 @@ public abstract class MultiNodePipelineBase extends AbstractPipeline {
     this.commandFlagsRegistry = commandFlagsRegistry;
     pipelinedResponses = new LinkedHashMap<>();
     connections = new LinkedHashMap<>();
-
-    if (executorService != null) {
-      this.executorService = executorService;
-      sharedExecutor = true;
-    } else {
-      this.executorService = null;
-      sharedExecutor = false;
-    }
+    this.sharedExecutorService = executorService;
   }
 
 
@@ -118,8 +112,10 @@ public abstract class MultiNodePipelineBase extends AbstractPipeline {
 
     boolean multiNode = pipelinedResponses.size() > 1;
     Executor executor;
+    ExecutorService executorService = null;
     if (multiNode) {
-      executor = acquireExecutorService();
+      executorService = getPipelineExecutor();
+      executor = executorService;
     } else {
       executor = Runnable::run;
     }
@@ -162,24 +158,51 @@ public abstract class MultiNodePipelineBase extends AbstractPipeline {
         log.error("Thread is interrupted during sync.", e);
       }
 
-      releaseExecutorService(executorService);
+      releasePipelineExecutor(executorService);
     }
 
     syncing = false;
   }
 
-  private ExecutorService acquireExecutorService() {
-    if (sharedExecutor) {
-      return this.executorService;
-    } else {
-      return Executors.newFixedThreadPool(MULTI_NODE_PIPELINE_SYNC_WORKERS);
+  /**
+   * Acquires the executor service to run multi-node pipeline commands.
+   * <p>
+   * If a shared executor is provided by the user, it is returned.
+   * Otherwise, a new dedicated executor is created for this pipeline.
+   * </p>
+   */
+  private ExecutorService getPipelineExecutor() {
+    return isUsingSharedExecutor()
+            ? this.sharedExecutorService
+            : createDedicatedPipelineExecutor();
+  }
+
+  /**
+   * Releases the executor service used by the pipeline.
+   * <p>
+   * Dedicated executors are shut down after use.
+   * Shared executors are managed externally and not shut down.
+   * </p>
+   */
+  private void releasePipelineExecutor(ExecutorService executorService) {
+    if (!isUsingSharedExecutor()) {
+      executorService.shutdownNow();
     }
   }
 
-  private void releaseExecutorService(ExecutorService executorService) {
-    if (!sharedExecutor) {
-      executorService.shutdownNow();
-    }
+  /**
+   * Returns true if this pipeline is using a shared executor service
+   * provided externally.
+   */
+  private boolean isUsingSharedExecutor() {
+    return this.sharedExecutorService != null;
+  }
+
+  /**
+   * Creates a new dedicated executor for multi-node pipeline execution.
+   */
+  private ExecutorService createDedicatedPipelineExecutor() {
+    return Executors.newFixedThreadPool(MULTI_NODE_PIPELINE_SYNC_WORKERS);
   }
 
   /**

--- a/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
@@ -169,7 +169,7 @@ public abstract class MultiNodePipelineBase extends AbstractPipeline {
   }
 
   private ExecutorService acquireExecutorService() {
-    if (this.executorService != null) {
+    if (sharedExecutor) {
       return this.executorService;
     } else {
       return Executors.newFixedThreadPool(MULTI_NODE_PIPELINE_SYNC_WORKERS);

--- a/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
@@ -34,16 +34,36 @@ public abstract class MultiNodePipelineBase extends AbstractPipeline {
   private volatile boolean syncing = false;
   protected final CommandFlagsRegistry commandFlagsRegistry;
 
+  /**
+   * External executor service to use for {@code sync()}. If not set, a new executor service will be
+   * created for each {@code sync()} call.
+   */
+  private final ExecutorService executorService;
+  private final boolean sharedExecutor;
+
   public MultiNodePipelineBase(CommandObjects commandObjects) {
     this(commandObjects, StaticCommandFlagsRegistry.registry());
   }
 
   protected MultiNodePipelineBase(CommandObjects commandObjects, CommandFlagsRegistry commandFlagsRegistry) {
+    this(commandObjects, commandFlagsRegistry, null);
+  }
+
+  MultiNodePipelineBase(CommandObjects commandObjects, CommandFlagsRegistry commandFlagsRegistry, ExecutorService executorService) {
     super(commandObjects);
     this.commandFlagsRegistry = commandFlagsRegistry;
     pipelinedResponses = new LinkedHashMap<>();
     connections = new LinkedHashMap<>();
+
+    if (executorService != null) {
+      this.executorService = executorService;
+      sharedExecutor = true;
+    } else {
+      this.executorService = null;
+      sharedExecutor = false;
+    }
   }
+
 
   protected abstract HostAndPort getNodeKey(CommandArguments args);
 
@@ -98,10 +118,8 @@ public abstract class MultiNodePipelineBase extends AbstractPipeline {
 
     boolean multiNode = pipelinedResponses.size() > 1;
     Executor executor;
-    ExecutorService executorService = null;
     if (multiNode) {
-      executorService = Executors.newFixedThreadPool(MULTI_NODE_PIPELINE_SYNC_WORKERS);
-      executor = executorService;
+      executor = acquireExecutorService();
     } else {
       executor = Runnable::run;
     }
@@ -144,10 +162,24 @@ public abstract class MultiNodePipelineBase extends AbstractPipeline {
         log.error("Thread is interrupted during sync.", e);
       }
 
-      executorService.shutdownNow();
+      releaseExecutorService(executorService);
     }
 
     syncing = false;
+  }
+
+  private ExecutorService acquireExecutorService() {
+    if (this.executorService != null) {
+      return this.executorService;
+    } else {
+      return Executors.newFixedThreadPool(MULTI_NODE_PIPELINE_SYNC_WORKERS);
+    }
+  }
+
+  private void releaseExecutorService(ExecutorService executorService) {
+    if (!sharedExecutor) {
+      executorService.shutdownNow();
+    }
   }
 
   /**

--- a/src/main/java/redis/clients/jedis/RedisClusterClient.java
+++ b/src/main/java/redis/clients/jedis/RedisClusterClient.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import redis.clients.jedis.builders.ClusterClientBuilder;
 import redis.clients.jedis.executors.ClusterCommandExecutor;
@@ -190,12 +191,50 @@ public class RedisClusterClient extends UnifiedJedis {
   }
   // commands
 
+  /**
+   * Creates a new pipeline for executing commands in a Redis Cluster.
+   *
+   * <p>Pipelining allows batching multiple commands for more efficient execution
+   * by reducing network round-trips. In a cluster environment, commands are routed
+   * to the appropriate nodes based on key hash slots.</p>
+   *
+   * <p>If the pipeline spans multiple nodes, a dedicated {@link ExecutorService} is
+   * created internally to execute requests in parallel and shutdown when the pipeline
+   * is closed.</p>
+   *
+   * @return a new {@link ClusterPipeline} instance
+   * @see #pipelined(ExecutorService)
+   */
   @Override
   public ClusterPipeline pipelined() {
-    return new ClusterPipeline((ClusterConnectionProvider) provider,
-        (ClusterCommandObjects) commandObjects, commandFlagsRegistry);
+    return pipelined(null);
   }
 
+  /**
+   * Creates a new pipeline for executing commands in a Redis Cluster using the provided executor.
+   *
+   * <p>Pipelining allows batching multiple commands for more efficient execution
+   * by reducing network round-trips. In a cluster environment, commands are routed
+   * to the appropriate nodes based on key hash slots.</p>
+   *
+   * <p>If the pipeline spans multiple nodes, the provided {@link ExecutorService} is
+   * used to execute requests in parallel. The caller is responsible for managing
+   * the lifecycle of this executor (creation, shutdown, etc.).</p>
+   *
+   * <p>If {@code null} is provided, a dedicated executor is created and managed
+   * internally, similar to {@link #pipelined()}.</p>
+   *
+   * @param executorService the executor to use for multi-node execution, or {@code null}
+   * @return a new {@link ClusterPipeline} instance
+   */
+  public ClusterPipeline pipelined(ExecutorService executorService) {
+    return new ClusterPipeline(
+            (ClusterConnectionProvider) provider,
+            (ClusterCommandObjects) commandObjects,
+            commandFlagsRegistry,
+            executorService
+    );
+  }
   /**
    * @param doMulti param
    * @return nothing

--- a/src/main/java/redis/clients/jedis/RedisClusterClient.java
+++ b/src/main/java/redis/clients/jedis/RedisClusterClient.java
@@ -200,7 +200,7 @@ public class RedisClusterClient extends UnifiedJedis {
    *
    * <p>If the pipeline spans multiple nodes, a dedicated {@link ExecutorService} is
    * created internally to execute requests in parallel and shutdown when the pipeline
-   * is closed.</p>
+   * is synced.</p>
    *
    * @return a new {@link ClusterPipeline} instance
    * @see #pipelined(ExecutorService)

--- a/src/test/java/redis/clients/jedis/ClusterPipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/ClusterPipeliningTest.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -13,6 +14,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static redis.clients.jedis.Protocol.CLUSTER_HASHSLOTS;
 
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -1254,4 +1259,103 @@ public class ClusterPipeliningTest {
           "Error message should mention MULTI_SHARD policy or multiple slots");
     }
   }
+
+
+  @Test
+  public void pipelineDoesNotShutdownSharedExecutor() {
+    ExecutorService executorService = Executors.newFixedThreadPool(3);
+    try ( RedisClusterClient cluster = RedisClusterClient.builder().nodes(nodes).clientConfig(DEFAULT_CLIENT_CONFIG).build()){
+      try (ClusterPipeline pipeline = cluster.pipelined(executorService)) {
+        pipeline.set("key", "value");
+        pipeline.sync();
+      }
+    } finally {
+      assertFalse(executorService.isShutdown());
+      executorService.shutdown();
+    }
+  }
+
+  @Test
+  @Timeout(10)
+  public void sharedExecutorConcurrentPipelinesNoDeadlock() throws Exception {
+    // This test verifies that multiple pipelines using the same shared executor
+    // concurrently do not deadlock, even when the executor has fewer threads
+    // than concurrent pipelines
+    final int EXECUTOR_THREADS = 3;
+    final int CONCURRENT_PIPELINES = 10; // More pipelines than executor threads
+    final int OPERATIONS_PER_PIPELINE = 20;
+
+    ExecutorService sharedExecutor = Executors.newFixedThreadPool(EXECUTOR_THREADS);
+    ExecutorService testExecutor = Executors.newFixedThreadPool(CONCURRENT_PIPELINES);
+
+    try (RedisClusterClient cluster = RedisClusterClient.builder().nodes(nodes).clientConfig(DEFAULT_CLIENT_CONFIG).build()) {
+
+      CountDownLatch startLatch = new CountDownLatch(1);
+      CountDownLatch completionLatch = new CountDownLatch(CONCURRENT_PIPELINES);
+      List<Future<Integer>> futures = new ArrayList<>();
+
+      // Launch multiple pipelines concurrently
+      for (int pipelineId = 0; pipelineId < CONCURRENT_PIPELINES; pipelineId++) {
+        final int id = pipelineId;
+        Future<Integer> future = testExecutor.submit(() -> {
+          try {
+            // Wait for all threads to be ready before starting
+            startLatch.await();
+
+            int successCount = 0;
+            try (ClusterPipeline pipeline = cluster.pipelined(sharedExecutor)) {
+              List<Response<String>> responses = new ArrayList<>();
+
+              // Perform operations on different keys to ensure multi-node pipeline
+              for (int i = 0; i < OPERATIONS_PER_PIPELINE; i++) {
+                String key = "pipeline" + id + "_key" + i;
+                String value = "value" + i;
+                pipeline.set(key, value);
+                responses.add(pipeline.get(key));
+              }
+
+              // This sync() will use the shared executor
+              pipeline.sync();
+
+              // Verify all responses
+              for (int i = 0; i < OPERATIONS_PER_PIPELINE; i++) {
+                String expected = "value" + i;
+                String actual = responses.get(i).get();
+                if (expected.equals(actual)) {
+                  successCount++;
+                }
+              }
+            }
+            return successCount;
+          } finally {
+            completionLatch.countDown();
+          }
+        });
+        futures.add(future);
+      }
+
+      // Release all threads to start concurrently
+      startLatch.countDown();
+
+      boolean completed = completionLatch.await(5, SECONDS);
+      assertTrue(completed, "All concurrent pipelines should complete without deadlock");
+
+      // Verify all operations succeeded
+      for (int i = 0; i < CONCURRENT_PIPELINES; i++) {
+        Integer successCount = futures.get(i).get();
+        assertEquals(OPERATIONS_PER_PIPELINE, successCount.intValue(),
+            "Pipeline " + i + " should have all operations succeed");
+      }
+
+      // Verify shared executor is still active
+      assertFalse(sharedExecutor.isShutdown(), "Shared executor should not be shut down");
+
+    } finally {
+      testExecutor.shutdown();
+      testExecutor.awaitTermination(5, SECONDS);
+      sharedExecutor.shutdown();
+      sharedExecutor.awaitTermination(5, SECONDS);
+    }
+  }
+
 }

--- a/src/test/java/redis/clients/jedis/ClusterPipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/ClusterPipeliningTest.java
@@ -1266,7 +1266,10 @@ public class ClusterPipeliningTest {
     ExecutorService executorService = Executors.newFixedThreadPool(3);
     try ( RedisClusterClient cluster = RedisClusterClient.builder().nodes(nodes).clientConfig(DEFAULT_CLIENT_CONFIG).build()){
       try (ClusterPipeline pipeline = cluster.pipelined(executorService)) {
-        pipeline.set("key", "value");
+        // multiple keys at different slots, to ensure multi-node pipeline
+        pipeline.set("key1", "value1");
+        pipeline.set("key2", "value2");
+        pipeline.set("key3", "value3");
         pipeline.sync();
       }
     } finally {

--- a/src/test/java/redis/clients/jedis/ClusterPipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/ClusterPipeliningTest.java
@@ -1262,7 +1262,7 @@ public class ClusterPipeliningTest {
 
 
   @Test
-  public void pipelineDoesNotShutdownSharedExecutor() {
+  public void sharedExecutorPipelineDoesNotShutdownSharedExecutor() {
     ExecutorService executorService = Executors.newFixedThreadPool(3);
     try ( RedisClusterClient cluster = RedisClusterClient.builder().nodes(nodes).clientConfig(DEFAULT_CLIENT_CONFIG).build()){
       try (ClusterPipeline pipeline = cluster.pipelined(executorService)) {
@@ -1272,6 +1272,44 @@ public class ClusterPipeliningTest {
     } finally {
       assertFalse(executorService.isShutdown());
       executorService.shutdown();
+    }
+  }
+  @Test
+  public void sharedExecutorPipelineKeysAtSameNode() {
+    try (RedisClusterClient cluster = RedisClusterClient.builder().nodes(nodes).clientConfig(DEFAULT_CLIENT_CONFIG).build()) {
+      ExecutorService executorService = Executors.newFixedThreadPool(3);
+      // test simple key
+      cluster.set("foo", "bar");
+
+      try (ClusterPipeline pipeline = cluster.pipelined(executorService)) {
+        Response<String> foo = pipeline.get("foo");
+        pipeline.sync();
+
+        assertEquals("bar", foo.get());
+      }
+
+      // test multi key but at same node
+      int cnt = 3;
+      String prefix = "{foo}:";
+      for (int i = 0; i < cnt; i++) {
+        String key = prefix + i;
+        cluster.set(key, String.valueOf(i));
+      }
+
+      try (ClusterPipeline pipeline = cluster.pipelined(executorService)) {
+        List<Response<String>> results = new ArrayList<>();
+        for (int i = 0; i < cnt; i++) {
+          String key = prefix + i;
+          results.add(pipeline.get(key));
+        }
+
+        pipeline.sync();
+        int idx = 0;
+        for (Response<String> res : results) {
+          assertEquals(String.valueOf(idx), res.get());
+          idx++;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
### Problem
Multi-node cluster pipelines create a new `ExecutorService` on every `sync()` call, causing significant overhead in high-throughput scenarios.

### Solution
Added support for externally managed `ExecutorService` in cluster pipelines:
 
- **New API**: `cluster.pipelined(ExecutorService)` - allows users to provide a shared executor
- **Backward compatible**: `cluster.pipelined()` retains existing auto-managed behavior

### Implementation
- Modified `MultiNodePipelineBase` to accept optional `ExecutorService`
- Added `pipelined(ExecutorService)` methods to `RedisClusterClient` and `JedisCluster`

**Usage Example:**
```java
ExecutorService executor = Executors.newFixedThreadPool(3);
try (RedisClusterClient cluster = ...) {
    // Reuse executor across multiple pipelines
    try (ClusterPipeline pipeline = cluster.pipelined(executor)) {
        pipeline.set("key", "value");
        pipeline.sync();
    }
} finally {
    executor.shutdown(); // User controls lifecycle
}
```

Closes #4141

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the concurrency/executor lifecycle for multi-node cluster pipelining; incorrect executor management or shared-executor contention could impact performance or cause hangs, though behavior is covered by new integration tests.
> 
> **Overview**
> **Cluster pipelining can now reuse a caller-provided `ExecutorService` instead of creating/shutting down a thread pool on every multi-node `sync()`.**
> 
> `MultiNodePipelineBase` accepts an optional shared executor and only shuts down internally-created executors, while `JedisCluster` and `RedisClusterClient` add `pipelined(ExecutorService)` (with `pipelined()` delegating to it) to pass the executor through to `ClusterPipeline`. New integration tests verify the shared executor is not shut down and that many concurrent pipelines sharing a small executor complete without deadlock.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38fa2a5593bfa7a0fd53cc6402cc6218cac32019. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->