### PR TITLE
backport: [ClusterPipeline] ExecutorService/thread is created and destroyed too frequently in ClusterPipeline

### DIFF
--- a/src/main/java/redis/clients/jedis/ClusterPipeline.java
+++ b/src/main/java/redis/clients/jedis/ClusterPipeline.java
@@ -2,6 +2,8 @@ package redis.clients.jedis;
 
 import java.time.Duration;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import redis.clients.jedis.providers.ClusterConnectionProvider;
 import redis.clients.jedis.util.IOUtils;
@@ -37,6 +39,12 @@ public class ClusterPipeline extends MultiNodePipelineBase {
 
   public ClusterPipeline(ClusterConnectionProvider provider, ClusterCommandObjects commandObjects) {
     super(commandObjects);
+    this.provider = provider;
+  }
+
+  ClusterPipeline(ClusterConnectionProvider provider, ClusterCommandObjects commandObjects,
+          ExecutorService executorService) {
+    super(commandObjects, executorService);
     this.provider = provider;
   }
 

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
@@ -412,11 +413,49 @@ public class JedisCluster extends UnifiedJedis {
   }
   // commands
 
+  /**
+   * Creates a new pipeline for executing commands in a Redis Cluster.
+   *
+   * <p>Pipelining allows batching multiple commands for more efficient execution
+   * by reducing network round-trips. In a cluster environment, commands are routed
+   * to the appropriate nodes based on key hash slots.</p>
+   *
+   * <p>If the pipeline spans multiple nodes, a dedicated {@link ExecutorService} is
+   * created internally to execute requests in parallel and shutdown when the pipeline
+   * is synced.</p>
+   *
+   * @return a new {@link ClusterPipeline} instance
+   * @see #pipelined(ExecutorService)
+   */
   @Override
   public ClusterPipeline pipelined() {
-    return new ClusterPipeline((ClusterConnectionProvider) provider, (ClusterCommandObjects) commandObjects);
+      return pipelined(null);
   }
 
+    /**
+     * Creates a new pipeline for executing commands in a Redis Cluster using the provided executor.
+     *
+     * <p>Pipelining allows batching multiple commands for more efficient execution
+     * by reducing network round-trips. In a cluster environment, commands are routed
+     * to the appropriate nodes based on key hash slots.</p>
+     *
+     * <p>If the pipeline spans multiple nodes, the provided {@link ExecutorService} is
+     * used to execute requests in parallel. The caller is responsible for managing
+     * the lifecycle of this executor (creation, shutdown, etc.).</p>
+     *
+     * <p>If {@code null} is provided, a dedicated executor is created and managed
+     * internally, similar to {@link #pipelined()}.</p>
+     *
+     * @param executorService the executor to use for multi-node execution, or {@code null}
+     * @return a new {@link ClusterPipeline} instance
+     */
+    public ClusterPipeline pipelined(ExecutorService executorService) {
+        return new ClusterPipeline(
+                (ClusterConnectionProvider) provider,
+                (ClusterCommandObjects) commandObjects,
+                executorService
+        );
+    }
   /**
    * @param doMulti param
    * @return nothing

--- a/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
@@ -32,11 +32,23 @@ public abstract class MultiNodePipelineBase extends AbstractPipeline {
   private final Map<HostAndPort, Connection> connections;
   private volatile boolean syncing = false;
 
+  /**
+   * External executor service to use for {@code sync()}. If not set, a new executor service will be
+   * created for each {@code sync()} call.
+   */
+  private final ExecutorService sharedExecutorService;
+
   public MultiNodePipelineBase(CommandObjects commandObjects) {
-    super(commandObjects);
-    pipelinedResponses = new LinkedHashMap<>();
-    connections = new LinkedHashMap<>();
+    this(commandObjects, null);
   }
+
+  MultiNodePipelineBase(CommandObjects commandObjects, ExecutorService executorService) {
+        super(commandObjects);
+        pipelinedResponses = new LinkedHashMap<>();
+        connections = new LinkedHashMap<>();
+        this.sharedExecutorService = executorService;
+  }
+
 
   protected abstract HostAndPort getNodeKey(CommandArguments args);
 
@@ -90,7 +102,7 @@ public abstract class MultiNodePipelineBase extends AbstractPipeline {
     Executor executor;
     ExecutorService executorService = null;
     if (multiNode) {
-      executorService = Executors.newFixedThreadPool(MULTI_NODE_PIPELINE_SYNC_WORKERS);
+      executorService = getPipelineExecutor();
       executor = executorService;
     } else {
       executor = Runnable::run;
@@ -134,10 +146,51 @@ public abstract class MultiNodePipelineBase extends AbstractPipeline {
         log.error("Thread is interrupted during sync.", e);
       }
 
-      executorService.shutdownNow();
+      releasePipelineExecutor(executorService);
     }
 
     syncing = false;
+  }
+
+  /**
+   * Acquires the executor service to run multi-node pipeline commands.
+   * <p>
+   * If a shared executor is provided by the user, it is returned.
+   * Otherwise, a new dedicated executor is created for this pipeline.
+   * </p>
+   */
+  private ExecutorService getPipelineExecutor() {
+    return isUsingSharedExecutor()
+            ? this.sharedExecutorService
+            : createDedicatedPipelineExecutor();
+  }
+
+  /**
+   * Releases the executor service used by the pipeline.
+   * <p>
+   * Dedicated executors are shut down after use.
+   * Shared executors are managed externally and not shut down.
+   * </p>
+   */
+  private void releasePipelineExecutor(ExecutorService executorService) {
+    if (!isUsingSharedExecutor()) {
+      executorService.shutdownNow();
+    }
+  }
+
+  /**
+   * Returns true if this pipeline is using a shared executor service
+   * provided externally.
+   */
+  private boolean isUsingSharedExecutor() {
+    return this.sharedExecutorService != null;
+  }
+
+  /**
+   * Creates a new dedicated executor for multi-node pipeline execution.
+   */
+  private ExecutorService createDedicatedPipelineExecutor() {
+    return Executors.newFixedThreadPool(MULTI_NODE_PIPELINE_SYNC_WORKERS);
   }
 
   @Deprecated

--- a/src/main/java/redis/clients/jedis/RedisClusterClient.java
+++ b/src/main/java/redis/clients/jedis/RedisClusterClient.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import redis.clients.jedis.builders.ClusterClientBuilder;
 import redis.clients.jedis.executors.ClusterCommandExecutor;
@@ -184,12 +185,49 @@ public class RedisClusterClient extends UnifiedJedis {
   }
   // commands
 
+  /**
+   * Creates a new pipeline for executing commands in a Redis Cluster.
+   *
+   * <p>Pipelining allows batching multiple commands for more efficient execution
+   * by reducing network round-trips. In a cluster environment, commands are routed
+   * to the appropriate nodes based on key hash slots.</p>
+   *
+   * <p>If the pipeline spans multiple nodes, a dedicated {@link ExecutorService} is
+   * created internally to execute requests in parallel and shutdown when the pipeline
+   * is synced.</p>
+   *
+   * @return a new {@link ClusterPipeline} instance
+   * @see #pipelined(ExecutorService)
+   */
   @Override
   public ClusterPipeline pipelined() {
-    return new ClusterPipeline((ClusterConnectionProvider) provider,
-        (ClusterCommandObjects) commandObjects);
+    return pipelined(null);
   }
 
+  /**
+   * Creates a new pipeline for executing commands in a Redis Cluster using the provided executor.
+   *
+   * <p>Pipelining allows batching multiple commands for more efficient execution
+   * by reducing network round-trips. In a cluster environment, commands are routed
+   * to the appropriate nodes based on key hash slots.</p>
+   *
+   * <p>If the pipeline spans multiple nodes, the provided {@link ExecutorService} is
+   * used to execute requests in parallel. The caller is responsible for managing
+   * the lifecycle of this executor (creation, shutdown, etc.).</p>
+   *
+   * <p>If {@code null} is provided, a dedicated executor is created and managed
+   * internally, similar to {@link #pipelined()}.</p>
+   *
+   * @param executorService the executor to use for multi-node execution, or {@code null}
+   * @return a new {@link ClusterPipeline} instance
+   */
+  public ClusterPipeline pipelined(ExecutorService executorService) {
+      return new ClusterPipeline(
+            (ClusterConnectionProvider) provider,
+            (ClusterCommandObjects) commandObjects,
+            executorService
+    );
+  }
   /**
    * @param doMulti param
    * @return nothing

--- a/src/test/java/redis/clients/jedis/ClusterPipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/ClusterPipeliningTest.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -13,6 +14,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static redis.clients.jedis.Protocol.CLUSTER_HASHSLOTS;
 
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -1171,4 +1176,142 @@ public class ClusterPipeliningTest {
         .count();
     MatcherAssert.assertThat(count, Matchers.lessThanOrEqualTo(20));
   }
+
+    @Test
+    public void sharedExecutorPipelineDoesNotShutdownSharedExecutor() {
+        ExecutorService executorService = Executors.newFixedThreadPool(3);
+        try ( RedisClusterClient cluster = RedisClusterClient.builder().nodes(nodes).clientConfig(DEFAULT_CLIENT_CONFIG).build()){
+            try (ClusterPipeline pipeline = cluster.pipelined(executorService)) {
+                // multiple keys at different slots, to ensure multi-node pipeline
+                pipeline.set("key1", "value1");
+                pipeline.set("key2", "value2");
+                pipeline.set("key3", "value3");
+                pipeline.sync();
+            }
+        } finally {
+            assertFalse(executorService.isShutdown());
+            executorService.shutdown();
+        }
+    }
+    @Test
+    public void sharedExecutorPipelineKeysAtSameNode() {
+        try (RedisClusterClient cluster = RedisClusterClient.builder().nodes(nodes).clientConfig(DEFAULT_CLIENT_CONFIG).build()) {
+            ExecutorService executorService = Executors.newFixedThreadPool(3);
+            // test simple key
+            cluster.set("foo", "bar");
+
+            try (ClusterPipeline pipeline = cluster.pipelined(executorService)) {
+                Response<String> foo = pipeline.get("foo");
+                pipeline.sync();
+
+                assertEquals("bar", foo.get());
+            }
+
+            // test multi key but at same node
+            int cnt = 3;
+            String prefix = "{foo}:";
+            for (int i = 0; i < cnt; i++) {
+                String key = prefix + i;
+                cluster.set(key, String.valueOf(i));
+            }
+
+            try (ClusterPipeline pipeline = cluster.pipelined(executorService)) {
+                List<Response<String>> results = new ArrayList<>();
+                for (int i = 0; i < cnt; i++) {
+                    String key = prefix + i;
+                    results.add(pipeline.get(key));
+                }
+
+                pipeline.sync();
+                int idx = 0;
+                for (Response<String> res : results) {
+                    assertEquals(String.valueOf(idx), res.get());
+                    idx++;
+                }
+            }
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    public void sharedExecutorConcurrentPipelinesNoDeadlock() throws Exception {
+        // This test verifies that multiple pipelines using the same shared executor
+        // concurrently do not deadlock, even when the executor has fewer threads
+        // than concurrent pipelines
+        final int EXECUTOR_THREADS = 3;
+        final int CONCURRENT_PIPELINES = 10; // More pipelines than executor threads
+        final int OPERATIONS_PER_PIPELINE = 20;
+
+        ExecutorService sharedExecutor = Executors.newFixedThreadPool(EXECUTOR_THREADS);
+        ExecutorService testExecutor = Executors.newFixedThreadPool(CONCURRENT_PIPELINES);
+
+        try (RedisClusterClient cluster = RedisClusterClient.builder().nodes(nodes).clientConfig(DEFAULT_CLIENT_CONFIG).build()) {
+
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch completionLatch = new CountDownLatch(CONCURRENT_PIPELINES);
+            List<Future<Integer>> futures = new ArrayList<>();
+
+            // Launch multiple pipelines concurrently
+            for (int pipelineId = 0; pipelineId < CONCURRENT_PIPELINES; pipelineId++) {
+                final int id = pipelineId;
+                Future<Integer> future = testExecutor.submit(() -> {
+                    try {
+                        // Wait for all threads to be ready before starting
+                        startLatch.await();
+
+                        int successCount = 0;
+                        try (ClusterPipeline pipeline = cluster.pipelined(sharedExecutor)) {
+                            List<Response<String>> responses = new ArrayList<>();
+
+                            // Perform operations on different keys to ensure multi-node pipeline
+                            for (int i = 0; i < OPERATIONS_PER_PIPELINE; i++) {
+                                String key = "pipeline" + id + "_key" + i;
+                                String value = "value" + i;
+                                pipeline.set(key, value);
+                                responses.add(pipeline.get(key));
+                            }
+
+                            // This sync() will use the shared executor
+                            pipeline.sync();
+
+                            // Verify all responses
+                            for (int i = 0; i < OPERATIONS_PER_PIPELINE; i++) {
+                                String expected = "value" + i;
+                                String actual = responses.get(i).get();
+                                if (expected.equals(actual)) {
+                                    successCount++;
+                                }
+                            }
+                        }
+                        return successCount;
+                    } finally {
+                        completionLatch.countDown();
+                    }
+                });
+                futures.add(future);
+            }
+
+            // Release all threads to start concurrently
+            startLatch.countDown();
+
+            boolean completed = completionLatch.await(5, SECONDS);
+            assertTrue(completed, "All concurrent pipelines should complete without deadlock");
+
+            // Verify all operations succeeded
+            for (int i = 0; i < CONCURRENT_PIPELINES; i++) {
+                Integer successCount = futures.get(i).get();
+                assertEquals(OPERATIONS_PER_PIPELINE, successCount.intValue(),
+                        "Pipeline " + i + " should have all operations succeed");
+            }
+
+            // Verify shared executor is still active
+            assertFalse(sharedExecutor.isShutdown(), "Shared executor should not be shut down");
+
+        } finally {
+            testExecutor.shutdown();
+            testExecutor.awaitTermination(5, SECONDS);
+            sharedExecutor.shutdown();
+            sharedExecutor.awaitTermination(5, SECONDS);
+        }
+    }
 }


### PR DESCRIPTION
Backport  #4479 to 7.4.x

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-node cluster pipelining to optionally reuse a caller-provided `ExecutorService`, affecting concurrency and thread lifecycle; mistakes could cause deadlocks or thread leaks, though coverage is added.
> 
> **Overview**
> Adds support for **shared executors in cluster pipelining** so multi-node `sync()` can reuse a caller-provided `ExecutorService` instead of creating/shutting down a thread pool per sync.
> 
> `JedisCluster` and `RedisClusterClient` now expose `pipelined(ExecutorService)` and route `pipelined()` through it; `ClusterPipeline`/`MultiNodePipelineBase` are updated to accept and retain an optional shared executor and only shut down *dedicated* executors.
> 
> Extends `ClusterPipeliningTest` with integration tests verifying the shared executor isn’t shut down, works for single-node-slot pipelines, and avoids deadlock under concurrent pipelines sharing a small thread pool.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf1711b5762622a32a773c73767115f8196cb243. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->