### PR TITLE
bump snapshot version to 7.4.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>jar</packaging>
 	<groupId>redis.clients</groupId>
 	<artifactId>jedis</artifactId>
-	<version>7.4.0-SNAPSHOT</version>
+	<version>7.4.1-SNAPSHOT</version>
 	<name>Jedis</name>
 	<description>Jedis is a blazingly small and sane Redis java client.</description>
 	<url>https://github.com/redis/jedis</url>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates the Maven project version, with no code or dependency changes.
> 
> **Overview**
> Updates `pom.xml` to bump the Jedis artifact snapshot version from `7.4.0-SNAPSHOT` to `7.4.1-SNAPSHOT`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cc2aa4c37134f520854006d467d7220af3ed7f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->