### PR TITLE
Fix flaky `MultiDbClient` failback test

### DIFF
--- a/src/test/java/redis/clients/jedis/mcf/FailbackMechanismIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/FailbackMechanismIntegrationTest.java
@@ -27,6 +27,7 @@ class FailbackMechanismIntegrationTest {
   private HostAndPort endpoint3;
   private JedisClientConfig clientConfig;
   private static Duration FIFTY_MILLISECONDS = Duration.ofMillis(50);
+  private static Duration TEN_MILLISECONDS = Duration.ofMillis(10);
 
   @BeforeEach
   void setUp() {
@@ -202,7 +203,7 @@ class FailbackMechanismIntegrationTest {
         // Wait for failback check
         // Should have failed back to database1 immediately (higher weight, no stability period
         // required)
-        await().atMost(Durations.TWO_HUNDRED_MILLISECONDS).pollInterval(FIFTY_MILLISECONDS)
+        await().atMost(Durations.TWO_HUNDRED_MILLISECONDS).pollInterval(TEN_MILLISECONDS)
             .until(() -> provider.getDatabase(endpoint1) == provider.getDatabase());
       }
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts test timing (Awaitility poll interval) without changing production code or behavior.
> 
> **Overview**
> Improves reliability of `FailbackMechanismIntegrationTest` by tightening the Awaitility `pollInterval` for the “immediate failback” assertion (from 50ms to 10ms) and introducing a `TEN_MILLISECONDS` constant to support that change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3fa3c545c18dddcf4e477a90aef3058b80b254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->