### PR TITLE
add 8.8 to test matrix

### DIFF
--- a/.github/workflows/test-on-docker.yml
+++ b/.github/workflows/test-on-docker.yml
@@ -13,7 +13,6 @@ on:
       - master
       - '[0-9].*'
       - 'feature/**'
-      - 'topic/**'
   pull_request:
     branches:
       - master
@@ -41,6 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         redis_version:
+          - "8.8"
           - "8.6"
           - "8.4"
           - "8.2"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PATH := ./redis-git/src:${PATH}
 
 # Supported test env versions
-SUPPORTED_TEST_ENV_VERSIONS := 8.6 8.4 8.2 8.0 7.4 7.2 6.2
+SUPPORTED_TEST_ENV_VERSIONS := 8.8 8.6 8.4 8.2 8.0 7.4 7.2 6.2
 DEFAULT_TEST_ENV_VERSION := 8.6
 REDIS_ENV_WORK_DIR := $(or ${REDIS_ENV_WORK_DIR},/tmp/redis-env-work)
 TOXIPROXY_IMAGE := ghcr.io/shopify/toxiproxy:2.8.0

--- a/src/test/resources/env/.env.v8.8
+++ b/src/test/resources/env/.env.v8.8
@@ -1,0 +1,8 @@
+REDIS_VERSION=8.8-m02
+REDIS_STACK_VERSION=8.8-m02
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test
+REDIS_ENV_CONF_DIR=./
+REDIS_MODULES_DIR=/tmp
+REDIS_ENV_WORK_DIR=/tmp/redis-env-work
+
+ENABLE_MODULE_COMMAND_DIRECTIVE=--enable-module-command yes


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change that expands the Redis versions tested; main risk is increased build time or failures due to new version/environment drift.
> 
> **Overview**
> Adds Redis `8.8` to the GitHub Actions docker test matrix and to `SUPPORTED_TEST_ENV_VERSIONS` in the `Makefile` so local/CI env validation accepts it.
> 
> Introduces a version-specific env file `src/test/resources/env/.env.v8.8` pointing tests at `8.8-m02` images and enabling the module command directive for that environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a77a6b1ba7b7921048b3619bae74430b37e6c14c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->