### PR TITLE
[7.5] Backport #4495: Enforce hostname verification by default for TLS connections

### DIFF
--- a/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
@@ -192,7 +192,9 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
     }
 
     if (JedisURIHelper.isRedisSSLScheme(redisUri)) {
-      builder.sslOptions(SslOptions.builder().build());
+      builder.ssl(true);
+    } else if (JedisURIHelper.isRedisScheme(redisUri)) {
+      builder.ssl(false);
     }
 
     return builder;

--- a/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
@@ -192,9 +192,7 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
     }
 
     if (JedisURIHelper.isRedisSSLScheme(redisUri)) {
-      builder.ssl(true);
-    } else if (JedisURIHelper.isRedisScheme(redisUri)) {
-      builder.ssl(false);
+      builder.sslOptions(SslOptions.builder().build());
     }
 
     return builder;

--- a/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
@@ -111,11 +111,19 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
     return ssl;
   }
 
+  /**
+   * @deprecated since 7.4.2, use {@link #getSslOptions()} instead.
+   */
+  @Deprecated
   @Override
   public SSLSocketFactory getSslSocketFactory() {
     return sslSocketFactory;
   }
 
+  /**
+   * @deprecated since 7.4.2, use {@link #getSslOptions()} instead.
+   */
+  @Deprecated
   @Override
   public SSLParameters getSslParameters() {
     return sslParameters;
@@ -306,21 +314,50 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
       return this;
     }
 
+    /**
+     * Enable TLS/SSL for connections.
+     * <p>
+     * TLS is enabled when either {@code ssl(true)} or {@link #sslOptions(SslOptions)} is set.
+     * {@link #sslOptions(SslOptions)} takes precedence; otherwise TLS uses
+     * {@link #sslSocketFactory(SSLSocketFactory)} and {@link #sslParameters(SSLParameters)}.
+     * @param ssl {@code true} to enable TLS/SSL
+     * @return {@code this}
+     * @deprecated since 7.4.2, use {@link #sslOptions(SslOptions)} instead. For TLS with JVM
+     *             defaults use {@code sslOptions(SslOptions.defaults())}.
+     */
+    @Deprecated
     public Builder ssl(boolean ssl) {
       this.ssl = ssl;
       return this;
     }
 
+    /**
+     * @deprecated since 7.4.2, use {@link #sslOptions(SslOptions)} instead.
+     */
+    @Deprecated
     public Builder sslSocketFactory(SSLSocketFactory sslSocketFactory) {
       this.sslSocketFactory = sslSocketFactory;
       return this;
     }
 
+    /**
+     * @deprecated since 7.4.2, use {@link #sslOptions(SslOptions)} instead.
+     */
+    @Deprecated
     public Builder sslParameters(SSLParameters sslParameters) {
       this.sslParameters = sslParameters;
       return this;
     }
 
+    /**
+     * Recommended way to configure TLS/SSL connections.
+     * <p>
+     * When set, TLS is enabled and {@link #sslSocketFactory(SSLSocketFactory)} /
+     * {@link #sslParameters(SSLParameters)} are ignored.
+     * @param sslOptions TLS configuration
+     * @return {@code this}
+     * @see SslOptions
+     */
     public Builder sslOptions(SslOptions sslOptions) {
       this.sslOptions = sslOptions;
       return this;

--- a/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
@@ -140,9 +140,14 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
     SSLSocket sslSocket = (SSLSocket) _sslSocketFactory.createSocket(socket,
         _hostAndPort.getHost(), _hostAndPort.getPort(), true);
 
-    if (_sslParameters != null) {
-      sslSocket.setSSLParameters(_sslParameters);
+    // Enable hostname verification by default (HTTPS algorithm).
+    // Users can override by providing custom SSLParameters via JedisClientConfig.
+    if (_sslParameters == null) {
+      _sslParameters = new SSLParameters();
+      _sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
     }
+
+    sslSocket.setSSLParameters(_sslParameters);
 
     // allowing HostnameVerifier for both SslOptions and legacy ssl config
     if (hostnameVerifier != null && !hostnameVerifier.verify(_hostAndPort.getHost(), sslSocket.getSession())) {

--- a/src/main/java/redis/clients/jedis/JedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/JedisClientConfig.java
@@ -65,25 +65,54 @@ public interface JedisClientConfig {
   }
 
   /**
+   * Enable TLS/SSL for connections.
+   * <p>
+   * <b>Prefer {@link #getSslOptions()}</b> for simpler configuration with built-in hostname
+   * verification and certificate validation modes.
+   * <p>
+   * When {@code true} without custom {@link #getSslParameters()}, hostname verification is enabled
+   * by default. Custom {@link SSLParameters} can override this behavior.
    * @return {@code true} - to create TLS connection(s). {@code false} - otherwise.
+   * @see #getSslOptions()
    */
   default boolean isSsl() {
     return false;
   }
 
+  /**
+   * Custom {@link SSLSocketFactory} for TLS connections.
+   * <p>
+   * <b>Prefer {@link #getSslOptions()}</b> for simpler configuration.
+   * @return Custom SSL socket factory, or {@code null} to use default
+   * @see #getSslOptions()
+   */
   default SSLSocketFactory getSslSocketFactory() {
     return null;
   }
 
+  /**
+   * Custom {@link SSLParameters} for TLS connections.
+   * <p>
+   * <b>Prefer {@link #getSslOptions()}</b> for simpler configuration with built-in hostname
+   * verification modes.
+   * @return Custom SSL parameters, or {@code null} to use defaults with hostname verification
+   * @see #getSslOptions()
+   */
   default SSLParameters getSslParameters() {
     return null;
   }
 
   /**
-   * {@link JedisClientConfig#isSsl()}, {@link JedisClientConfig#getSslSocketFactory()} and
-   * {@link JedisClientConfig#getSslParameters()} will be ignored if
-   * {@link JedisClientConfig#getSslOptions() this} is set.
-   * @return ssl options
+   * Recommended way to configure TLS/SSL connections.
+   * <p>
+   * Provides simple builder API with built-in support for certificate validation modes, hostname
+   * verification, and truststore/keystore configuration.
+   * <p>
+   * When set, {@link #isSsl()}, {@link #getSslSocketFactory()} and {@link #getSslParameters()} are
+   * ignored.
+   * @return SSL options, or {@code null} to use {@link #isSsl()} configuration
+   * @see SslOptions
+   * @see SslVerifyMode
    */
   default SslOptions getSslOptions() {
     return null;

--- a/src/main/java/redis/clients/jedis/JedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/JedisClientConfig.java
@@ -65,14 +65,12 @@ public interface JedisClientConfig {
   }
 
   /**
-   * Enable TLS/SSL for connections.
+   * Whether TLS/SSL should be used for connections.
    * <p>
-   * <b>Prefer {@link #getSslOptions()}</b> for simpler configuration with built-in hostname
-   * verification and certificate validation modes.
-   * <p>
-   * When {@code true} without custom {@link #getSslParameters()}, hostname verification is enabled
-   * by default. Custom {@link SSLParameters} can override this behavior.
-   * @return {@code true} - to create TLS connection(s). {@code false} - otherwise.
+   * A TLS connection is established when this returns {@code true} or when {@link #getSslOptions()}
+   * returns a non-{@code null} value. If both are provided, {@link #getSslOptions()} takes
+   * precedence.
+   * @return {@code true} if TLS/SSL is enabled, {@code false} otherwise
    * @see #getSslOptions()
    */
   default boolean isSsl() {
@@ -80,37 +78,42 @@ public interface JedisClientConfig {
   }
 
   /**
-   * Custom {@link SSLSocketFactory} for TLS connections.
+   * Custom {@link SSLSocketFactory} to use for TLS connections.
    * <p>
-   * <b>Prefer {@link #getSslOptions()}</b> for simpler configuration.
-   * @return Custom SSL socket factory, or {@code null} to use default
+   * Consulted only when {@link #getSslOptions()} returns {@code null}. Implementations should
+   * return {@code null} to use the JVM default.
+   * @return custom SSL socket factory, or {@code null} to use the default
    * @see #getSslOptions()
+   * @deprecated since 7.4.2, use {@link #getSslOptions()} instead.
    */
+  @Deprecated
   default SSLSocketFactory getSslSocketFactory() {
     return null;
   }
 
   /**
-   * Custom {@link SSLParameters} for TLS connections.
+   * Custom {@link SSLParameters} to apply to TLS sockets.
    * <p>
-   * <b>Prefer {@link #getSslOptions()}</b> for simpler configuration with built-in hostname
-   * verification modes.
-   * @return Custom SSL parameters, or {@code null} to use defaults with hostname verification
+   * Consulted only when {@link #getSslOptions()} returns {@code null}. Implementations should
+   * return {@code null} to let the client apply defaults (which enable HTTPS hostname
+   * verification).
+   * @return custom SSL parameters, or {@code null} for defaults
    * @see #getSslOptions()
+   * @deprecated since 7.4.2, use {@link #getSslOptions()} instead.
    */
+  @Deprecated
   default SSLParameters getSslParameters() {
     return null;
   }
 
   /**
-   * Recommended way to configure TLS/SSL connections.
+   * TLS/SSL configuration. Recommended way to configure TLS connections.
    * <p>
-   * Provides simple builder API with built-in support for certificate validation modes, hostname
-   * verification, and truststore/keystore configuration.
-   * <p>
-   * When set, {@link #isSsl()}, {@link #getSslSocketFactory()} and {@link #getSslParameters()} are
-   * ignored.
-   * @return SSL options, or {@code null} to use {@link #isSsl()} configuration
+   * When non-{@code null}, TLS is enabled and this takes precedence over
+   * {@link #getSslSocketFactory()} and {@link #getSslParameters()}. Implementations should return
+   * {@code null} to fall back to {@link #isSsl()} / {@link #getSslSocketFactory()} /
+   * {@link #getSslParameters()}.
+   * @return TLS configuration, or {@code null} if not configured
    * @see SslOptions
    * @see SslVerifyMode
    */

--- a/src/main/java/redis/clients/jedis/SslOptions.java
+++ b/src/main/java/redis/clients/jedis/SslOptions.java
@@ -27,8 +27,65 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Options to configure SSL options for the connections kept to Redis servers.
+ * TLS/SSL configuration for connections to Redis.
+ * <p>
+ * Recommended entry point for enabling TLS.
  *
+ * <h2>Verification modes</h2>
+ *
+ * Controlled via {@link SslVerifyMode}:
+ * <ul>
+ * <li>{@link SslVerifyMode#FULL} (default) - verifies the certificate chain against the truststore
+ * <b>and</b> verifies that the server hostname matches the certificate (HTTPS endpoint
+ * identification). Recommended for production.</li>
+ * <li>{@link SslVerifyMode#CA} - verifies the certificate chain against the truststore but
+ * <b>skips</b> hostname verification. Useful when connecting via IP or a name not listed in the
+ * certificate's SAN/CN.</li>
+ * <li>{@link SslVerifyMode#INSECURE} - disables all certificate and hostname verification. Do NOT
+ * use in production.</li>
+ * </ul>
+ *
+ * <h2>Truststore and keystore</h2>
+ *
+ * If no truststore is configured, the default JVM truststore ({@code cacerts}) is used. Custom
+ * truststores can be provided .
+ *
+ * <h2>Examples</h2>
+ *
+ * Default (uses JVM truststore, full verification):
+ * <pre>{@code
+ * SslOptions sslOptions = SslOptions.builder().build();
+ * }</pre>
+ *
+ * Custom truststore:
+ * <pre>{@code
+ * SslOptions sslOptions = SslOptions.builder()
+ *     .truststore(new File("/path/to/truststore.p12"), "changeit".toCharArray())
+ *     .build();
+ * }</pre>
+ *
+ * Mutual TLS (client certificate):
+ * <pre>{@code
+ * SslOptions sslOptions = SslOptions.builder()
+ *     .keystore(new File("/path/to/keystore.p12"), "changeit".toCharArray())
+ *     .truststore(new File("/path/to/truststore.p12"), "changeit".toCharArray())
+ *     .build();
+ * }</pre>
+ *
+ * Use with a client:
+ * <pre>{@code
+ * JedisClientConfig config = DefaultJedisClientConfig.builder()
+ *     .sslOptions(sslOptions)
+ *     .build();
+ *
+ * RedisClient client = RedisClient.builder()
+ *     .hostAndPort("redis.example.com", 6379)
+ *     .clientConfig(config)
+ *     .build();
+ * }</pre>
+ *
+ * @see SslVerifyMode
+ * @see JedisClientConfig#getSslOptions()
  * @author Mark Paluch
  */
 public class SslOptions {
@@ -116,9 +173,9 @@ public class SslOptions {
         }
 
         /**
-         * Sets the KeyStore type. Defaults to {@link KeyStore#getDefaultType()} if not set.
+         * Sets the TrustStore type. Defaults to {@link KeyStore#getDefaultType()} if not set.
          *
-         * @param trustStoreType the keystore type to use, must not be {@code null}.
+         * @param trustStoreType the truststore type to use, must not be {@code null}.
          * @return {@code this}
          */
         public Builder trustStoreType(String trustStoreType) {
@@ -173,7 +230,7 @@ public class SslOptions {
          * each connection attempt that allows to replace certificates during runtime.
          *
          * @param keystore the keystore file, must not be {@code null}.
-         * @param keystorePassword
+         * @param keystorePassword the keystore password. May be empty to omit password and the keystore integrity check.
          * @return {@code this}
          */
         public Builder keystore(URL keystore, char[] keystorePassword) {
@@ -277,7 +334,10 @@ public class SslOptions {
         }
 
         /**
-         * Sets a configured {@link SSLParameters}.
+         * Sets custom {@link SSLParameters}.
+         * <p>
+         * The endpoint identification algorithm is managed by {@link #sslVerifyMode(SslVerifyMode)}:
+         * {@link SslVerifyMode#FULL} sets it to {@code "HTTPS"}, {@link SslVerifyMode#CA} clears it.
          *
          * @param sslParameters a {@link SSLParameters} object.
          * @return {@code this}
@@ -288,7 +348,7 @@ public class SslOptions {
         }
 
         /**
-         * Sets the {@link SslVerifyMode}.
+         * Sets the {@link SslVerifyMode}. Defaults to {@link SslVerifyMode#FULL}.
          *
          * @param sslVerifyMode the {@link SslVerifyMode}.
          * @return {@code this}
@@ -299,8 +359,8 @@ public class SslOptions {
         }
 
         /**
-         * The SSL/TLS protocol to be used to initialize {@link SSLContext}.
-         * @param protocol the ssl/tls protocol
+         * The SSL/TLS protocol to use when initializing {@link SSLContext}. Defaults to {@code "TLS"}.
+         * @param protocol the ssl/tls protocol (e.g. {@code "TLS"}, {@code "TLSv1.3"})
          * @return {@code this}
          */
         public Builder sslProtocol(String protocol) {

--- a/src/main/java/redis/clients/jedis/SslOptions.java
+++ b/src/main/java/redis/clients/jedis/SslOptions.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  *
  * Default (uses JVM truststore, full verification):
  * <pre>{@code
- * SslOptions sslOptions = SslOptions.builder().build();
+ * SslOptions sslOptions = SslOptions.defaults();
  * }</pre>
  *
  * Custom truststore:
@@ -133,6 +133,17 @@ public class SslOptions {
      */
     public static SslOptions.Builder builder() {
         return new SslOptions.Builder();
+    }
+
+    /**
+     * Returns {@link SslOptions} with default settings: JVM truststore, TLS protocol and full
+     * certificate and hostname verification ({@link SslVerifyMode#FULL}). Equivalent to
+     * {@code SslOptions.builder().build()}.
+     *
+     * @return a new {@link SslOptions} instance with default settings.
+     */
+    public static SslOptions defaults() {
+        return builder().build();
     }
 
     /**

--- a/src/test/java/redis/clients/jedis/tls/JedisIT.java
+++ b/src/test/java/redis/clients/jedis/tls/JedisIT.java
@@ -1,12 +1,16 @@
 package redis.clients.jedis.tls;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisClientConfig;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+import javax.net.ssl.SSLParameters;
 
 /**
  * SSL/TLS tests for {@link Jedis} with basic authentication (password-only, no ACL).
@@ -65,6 +69,36 @@ public class JedisIT extends JedisTlsTestBase {
     // The "rediss" scheme instructs jedis to open a SSL/TLS connection.
     try (Jedis jedis = new Jedis(endpoint.getURI())) {
       jedis.auth(endpoint.getPassword());
+      assertEquals("PONG", jedis.ping());
+    }
+  }
+
+  /**
+   * Verifies that hostname verification fails when hostname doesn't match certificate CN/SAN.
+   */
+  @Test
+  public void connectWrongHost() {
+    // Connection with hostname mismatch should fail
+    assertThrows(JedisConnectionException.class,
+      () -> new Jedis(wrongHostEndpoint.getHost(), wrongHostEndpoint.getPort(), true));
+
+    // Same test using URI
+    assertThrows(JedisConnectionException.class, () -> new Jedis(wrongHostEndpoint.getURI()));
+  }
+
+  /**
+   * Verifies that hostname verification can be disabled by providing custom SSLParameters without
+   * endpoint identification algorithm set.
+   */
+  @Test
+  public void connectWrongHostWithSslParameters() {
+    // Custom SSLParameters without endpoint identification allows connection despite hostname
+    // mismatch
+    JedisClientConfig config = DefaultJedisClientConfig.builder().ssl(true)
+        .sslParameters(new SSLParameters()).user(wrongHostEndpoint.getUsername())
+        .password(wrongHostEndpoint.getPassword()).build();
+    try (
+        Jedis jedis = new Jedis(wrongHostEndpoint.getHost(), wrongHostEndpoint.getPort(), config)) {
       assertEquals("PONG", jedis.ping());
     }
   }

--- a/src/test/java/redis/clients/jedis/tls/JedisTlsTestBase.java
+++ b/src/test/java/redis/clients/jedis/tls/JedisTlsTestBase.java
@@ -24,6 +24,7 @@ public abstract class JedisTlsTestBase {
 
   protected static EndpointConfig endpoint;
   protected static EndpointConfig aclEndpoint;
+  protected static EndpointConfig wrongHostEndpoint;
   protected static Path trustStorePath;
   protected static SslOptions sslOptions;
 
@@ -31,6 +32,7 @@ public abstract class JedisTlsTestBase {
   public static void setUpTrustStore() {
     endpoint = Endpoints.getRedisEndpoint("standalone0-tls");
     aclEndpoint = Endpoints.getRedisEndpoint("standalone0-acl-tls");
+    wrongHostEndpoint = Endpoints.getRedisEndpoint("standalone0-tls-wronghost");
 
     List<Path> trustedCertLocation = Arrays.asList(endpoint.getCertificatesLocation(),
       aclEndpoint.getCertificatesLocation());

--- a/src/test/java/redis/clients/jedis/tls/RedisClientIT.java
+++ b/src/test/java/redis/clients/jedis/tls/RedisClientIT.java
@@ -1,11 +1,16 @@
 package redis.clients.jedis.tls;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+import javax.net.ssl.SSLParameters;
 
 /**
  * SSL/TLS tests for {@link RedisClient} with basic authentication (password-only, no ACL).
@@ -57,6 +62,46 @@ public class RedisClientIT extends RedisClientTlsTestBase {
     // URI includes credentials via defaultCredentials()
     try (RedisClient client = RedisClient
         .create(endpoint.getURIBuilder().defaultCredentials().build())) {
+      assertEquals("PONG", client.ping());
+    }
+  }
+
+  /**
+   * Verifies that hostname verification is enabled by default when using ssl(true). Connection
+   * should fail when hostname doesn't match the certificate CN/SAN.
+   */
+  @Test
+  public void connectWithWrongHost() {
+    // Connection with hostname mismatch should fail with default hostname verification
+    DefaultJedisClientConfig config = DefaultJedisClientConfig.builder().ssl(true)
+        .password(wrongHostEndpoint.getPassword()).build();
+    try (RedisClient client = RedisClient.builder()
+        .hostAndPort(wrongHostEndpoint.getHost(), wrongHostEndpoint.getPort()).clientConfig(config)
+        .build()) {
+      assertThrows(JedisConnectionException.class, client::ping);
+    }
+
+    // Same test using URI
+    try (RedisClient client = RedisClient
+        .create(wrongHostEndpoint.getURIBuilder().defaultCredentials().build())) {
+      assertThrows(JedisConnectionException.class, client::ping);
+    }
+  }
+
+  /**
+   * Verifies that hostname verification can be disabled by providing custom SSLParameters without
+   * endpoint identification algorithm set.
+   */
+  @Test
+  public void connectWrongHostWithSslParameters() {
+    // Custom SSLParameters without endpoint identification allows connection despite hostname
+    // mismatch
+    JedisClientConfig config = DefaultJedisClientConfig.builder().ssl(true)
+        .sslParameters(new SSLParameters()).user(wrongHostEndpoint.getUsername())
+        .password(wrongHostEndpoint.getPassword()).build();
+    try (RedisClient client = RedisClient.builder()
+        .hostAndPort(wrongHostEndpoint.getHost(), wrongHostEndpoint.getPort()).clientConfig(config)
+        .build()) {
       assertEquals("PONG", client.ping());
     }
   }

--- a/src/test/java/redis/clients/jedis/tls/RedisClientTlsTestBase.java
+++ b/src/test/java/redis/clients/jedis/tls/RedisClientTlsTestBase.java
@@ -24,6 +24,7 @@ public abstract class RedisClientTlsTestBase {
 
   protected static EndpointConfig endpoint;
   protected static EndpointConfig aclEndpoint;
+  protected static EndpointConfig wrongHostEndpoint;
   protected static Path trustStorePath;
   protected static SslOptions sslOptions;
 
@@ -31,6 +32,7 @@ public abstract class RedisClientTlsTestBase {
   public static void setUpTrustStore() {
     endpoint = Endpoints.getRedisEndpoint("standalone0-tls");
     aclEndpoint = Endpoints.getRedisEndpoint("standalone0-acl-tls");
+    wrongHostEndpoint = Endpoints.getRedisEndpoint("standalone0-tls-wronghost");
 
     List<Path> trustedCertLocation = Arrays.asList(endpoint.getCertificatesLocation(),
       aclEndpoint.getCertificatesLocation());

--- a/src/test/java/redis/clients/jedis/tls/RedisClusterClientIT.java
+++ b/src/test/java/redis/clients/jedis/tls/RedisClusterClientIT.java
@@ -138,4 +138,35 @@ public class RedisClusterClientIT extends RedisClusterTestBase {
     }
   }
 
+  /**
+   * Verifies that hostname verification is enabled by default for cluster connections. Cluster
+   * initialization should fail when hostname doesn't match certificate CN/SAN.
+   */
+  @Test
+  public void connectWrongHost() {
+    // Cluster init with hostname mismatch should fail
+    RedisClusterClient.Builder builder = RedisClusterClient.builder();
+    builder.nodes(Collections.singleton(tlsEndpointWrongHost.getHostAndPort()))
+        .clientConfig(DefaultJedisClientConfig.builder()
+            .password(tlsEndpointWrongHost.getPassword()).ssl(true).build());
+    assertThrows(JedisClusterOperationException.class, builder::build);
+  }
+
+  /**
+   * Verifies that hostname verification can be disabled for cluster connections by providing custom
+   * SSLParameters without endpoint identification algorithm.
+   */
+  @Test
+  public void connectWrongHostWithSslParameters() {
+    // Custom SSLParameters without endpoint identification allows cluster connection despite
+    // hostname mismatch
+    JedisClientConfig config = DefaultJedisClientConfig.builder().ssl(true)
+        .sslParameters(new SSLParameters()).password(tlsEndpointWrongHost.getPassword()).build();
+    RedisClusterClient.Builder builder = RedisClusterClient.builder();
+    builder.nodes(Collections.singleton(tlsEndpointWrongHost.getHostAndPort()))
+        .clientConfig(config);
+    try (RedisClusterClient client = builder.build()) {
+      assertEquals("PONG", client.ping());
+    }
+  }
 }

--- a/src/test/java/redis/clients/jedis/tls/RedisClusterTestBase.java
+++ b/src/test/java/redis/clients/jedis/tls/RedisClusterTestBase.java
@@ -31,6 +31,7 @@ import redis.clients.jedis.util.*;
 public abstract class RedisClusterTestBase {
 
   private static final String ENDPOINT_NAME = "cluster-stable-tls";
+  private static final String ENDPOINT_NAME_WRONG_HOST = "cluster-stable-tls-wronghost";
   /**
    * Non-TLS endpoint used for version and command checks. Extensions run before @BeforeAll, so we
    * can't use TLS endpoints for these checks since the truststore isn't configured yet.
@@ -46,6 +47,7 @@ public abstract class RedisClusterTestBase {
       () -> Endpoints.getRedisEndpoint(VERSION_CHECK_ENDPOINT_NAME));
 
   protected static EndpointConfig tlsEndpoint;
+  protected static EndpointConfig tlsEndpointWrongHost;
   protected static Path trustStorePath;
 
   protected RedisClusterClient cluster;
@@ -64,6 +66,7 @@ public abstract class RedisClusterTestBase {
   @BeforeAll
   public static void prepareEndpointAndTrustStore() {
     tlsEndpoint = Endpoints.getRedisEndpoint(ENDPOINT_NAME);
+    tlsEndpointWrongHost = Endpoints.getRedisEndpoint(ENDPOINT_NAME_WRONG_HOST);
     List<Path> trustedCertLocation = Collections
         .singletonList(tlsEndpoint.getCertificatesLocation());
     trustStorePath = TlsUtil.createAndSaveTestTruststore(RedisClusterTestBase.class.getSimpleName(),

--- a/src/test/java/redis/clients/jedis/tls/RedisSentinelClientIT.java
+++ b/src/test/java/redis/clients/jedis/tls/RedisSentinelClientIT.java
@@ -1,16 +1,22 @@
 package redis.clients.jedis.tls;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import javax.net.ssl.SSLParameters;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.EndpointConfig;
 import redis.clients.jedis.Endpoints;
+import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.RedisSentinelClient;
 import redis.clients.jedis.SslOptions;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 
 /**
  * SSL/TLS tests for {@link RedisSentinelClient} with basic authentication (password-only, no ACL).
@@ -48,6 +54,48 @@ public class RedisSentinelClientIT extends RedisSentinelTlsTestBase {
     try (RedisSentinelClient client = RedisSentinelClient.builder().masterName(MASTER_NAME)
         .sentinels(sentinels).clientConfig(masterConfig).sentinelClientConfig(sentinelConfig)
         .build()) {
+      assertEquals("PONG", client.ping());
+    }
+  }
+
+  /**
+   * Verifies that hostname verification is enabled by default for sentinel connections. Connection
+   * should fail when hostname doesn't match the certificate CN/SAN.
+   */
+  @Test
+  public void connectWithWrongHost() {
+    // Sentinel config with hostname mismatch should fail with default hostname verification
+    DefaultJedisClientConfig sentinelConfig = DefaultJedisClientConfig.builder()
+        .user(sentinelWrongHost.getUsername()).password(sentinelWrongHost.getPassword()).ssl(true)
+        .build();
+    assertThrows(JedisConnectionException.class, () -> {
+      try (RedisSentinelClient client = RedisSentinelClient.builder().masterName(MASTER_NAME)
+          .sentinels(sentinelsWrongHost).sentinelClientConfig(sentinelConfig).build()) {
+        client.ping();
+      }
+    });
+  }
+
+  /**
+   * Verifies that hostname verification can be disabled for sentinel connections by providing
+   * custom SSLParameters without endpoint identification algorithm.
+   */
+  @Test
+  public void connectWrongHostWithSslParameters() {
+    // Custom SSLParameters without endpoint identification allows connection despite hostname
+    // mismatch
+    JedisClientConfig sentinelConfig = DefaultJedisClientConfig.builder()
+        .user(sentinelWrongHost.getUsername()).password(sentinelWrongHost.getPassword()).ssl(true)
+        .sslParameters(new SSLParameters()).build();
+
+    // Master uses correct hostname and SSL
+    DefaultJedisClientConfig masterConfig = DefaultJedisClientConfig.builder()
+        .clientName("master-client").ssl(true).password(masterEndpoint.getPassword())
+        .hostAndPortMapper(PRIMARY_SSL_PORT_MAPPER).build();
+
+    try (RedisSentinelClient client = RedisSentinelClient.builder().masterName(MASTER_NAME)
+        .sentinels(sentinelsWrongHost).clientConfig(masterConfig)
+        .sentinelClientConfig(sentinelConfig).build()) {
       assertEquals("PONG", client.ping());
     }
   }

--- a/src/test/java/redis/clients/jedis/tls/RedisSentinelTlsTestBase.java
+++ b/src/test/java/redis/clients/jedis/tls/RedisSentinelTlsTestBase.java
@@ -31,7 +31,9 @@ public abstract class RedisSentinelTlsTestBase {
   private static final String TRUSTSTORE_TYPE = "jceks";
 
   protected static EndpointConfig sentinel;
+  protected static EndpointConfig sentinelWrongHost;
   protected static Set<HostAndPort> sentinels = new HashSet<>();
+  protected static Set<HostAndPort> sentinelsWrongHost = new HashSet<>();
   protected static Path trustStorePath;
   protected static SslOptions sslOptions;
 
@@ -44,7 +46,9 @@ public abstract class RedisSentinelTlsTestBase {
   @BeforeAll
   public static void setupSentinelTls() {
     sentinel = Endpoints.getRedisEndpoint("sentinel-standalone0");
+    sentinelWrongHost = Endpoints.getRedisEndpoint("sentinel-standalone0-tls-wronghost");
     sentinels.add(sentinel.getHostAndPort());
+    sentinelsWrongHost.add(sentinelWrongHost.getHostAndPort());
 
     List<Path> trustedCertLocation = Collections
         .singletonList(Paths.get("redis1-2-5-8-sentinel/work/tls"));

--- a/src/test/resources/endpoints.json
+++ b/src/test/resources/endpoints.json
@@ -4,10 +4,18 @@
     "username": "sentinel",
     "password": "foobared",
     "endpoints": [
-      "redis://127.0.0.1:26379"
+      "redis://localhost:26379"
     ]
   },
   "sentinel-standalone0-tls": {
+    "tls": true,
+    "username": "sentinel",
+    "password": "foobared",
+    "endpoints": [
+      "redis://localhost:36379"
+    ]
+  },
+  "sentinel-standalone0-tls-wronghost": {
     "tls": true,
     "username": "sentinel",
     "password": "foobared",
@@ -18,19 +26,19 @@
   "sentinel-standalone2-1": {
     "tls": false,
     "endpoints": [
-      "redis://127.0.0.1:26380"
+      "redis://localhost:26380"
     ]
   },
   "sentinel-failover": {
     "tls": false,
     "endpoints": [
-      "redis://127.0.0.1:26381"
+      "redis://localhost:26381"
     ]
   },
   "sentinel-standalone2-3": {
     "tls": false,
     "endpoints": [
-      "redis://127.0.0.1:26382"
+      "redis://localhost:26382"
     ]
   },
   "redis-failover-1": {
@@ -59,6 +67,15 @@
     "tls_cert_path": "redis1-2-5-8-sentinel/work/tls",
     "endpoints": [
       "rediss://localhost:6390"
+    ]
+  },
+  "standalone0-tls-wronghost": {
+    "username": "default",
+    "password": "foobared",
+    "tls": true,
+    "tls_cert_path": "redis1-2-5-8-sentinel/work/tls",
+    "endpoints": [
+      "rediss://127.0.0.1:6390"
     ]
   },
   "standalone0-acl": {
@@ -165,6 +182,16 @@
       "rediss://localhost:8479",
       "rediss://localhost:8480",
       "rediss://localhost:8481"
+    ]
+  },
+  "cluster-stable-tls-wronghost": {
+    "password": "cluster",
+    "tls": true,
+    "tls_cert_path": "cluster-stable/work/tls",
+    "endpoints": [
+      "rediss://127.0.0.1:8479",
+      "rediss://127.0.0.1:8480",
+      "rediss://127.0.0.1:8481"
     ]
   },
   "cluster-stack": {

--- a/src/test/resources/env/redis1-2-5-8-sentinel/config/node-sentinel-26379-36379/redis.conf
+++ b/src/test/resources/env/redis1-2-5-8-sentinel/config/node-sentinel-26379-36379/redis.conf
@@ -4,9 +4,12 @@ tls-auth-clients no
 user default off
 user deploy on allcommands allkeys >verify
 user sentinel on allcommands allkeys allchannels >foobared
-sentinel monitor aclmaster 127.0.0.1 6379 1
+sentinel monitor aclmaster localhost 6379 1
 sentinel auth-user aclmaster acljedis
 sentinel auth-pass aclmaster fizzbuzz
 sentinel down-after-milliseconds aclmaster 2000
 sentinel failover-timeout aclmaster 120000
 sentinel parallel-syncs aclmaster 1
+sentinel resolve-hostnames yes
+sentinel announce-hostnames yes
+sentinel announce-ip localhost


### PR DESCRIPTION
Backport of #4495 to 7.5.

Enables HTTPS endpoint identification by default in `DefaultJedisSocketFactory`
when `ssl(true)` is used without custom `SSLParameters`, closing the hostname
verification bypass. Deprecates the low-level SSL config methods
(`getSslSocketFactory`, `getSslParameters`, and the corresponding builder
setters) in favor of `SslOptions`, and adds `SslOptions.defaults()` as a
one-line migration from `ssl(true)`.

See #4495 for behavior change and fallback options.

Fixes: CAE-2794

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Behavior changes in TLS socket creation now enforce HTTPS endpoint identification by default, which can break existing deployments that relied on connecting via IP/incorrect hostnames. Changes touch connection security defaults and related config APIs.
> 
> **Overview**
> **TLS connections created via legacy `ssl(true)` now enable hostname verification by default** by applying `SSLParameters` with HTTPS endpoint identification in `DefaultJedisSocketFactory` when callers don’t supply custom parameters.
> 
> Legacy low-level SSL configuration (`getSslSocketFactory`, `getSslParameters`, and the corresponding `DefaultJedisClientConfig.Builder` setters including `ssl(boolean)`) is **deprecated** in favor of `SslOptions`, and `SslOptions.defaults()` is added as a one-line migration path.
> 
> Integration tests and test fixtures are updated to cover hostname-mismatch failures across standalone, `RedisClient`, cluster, and sentinel TLS setups, including explicit opt-out via custom `SSLParameters`, plus new `*-wronghost` endpoints and sentinel config tweaks to use hostnames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d91535d43ec351bde2def1d0f29245fe6c006c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->