### PR TITLE
test added for SslOptions.defaults()

### DIFF
--- a/src/test/java/redis/clients/jedis/tls/RedisClusterClientIT.java
+++ b/src/test/java/redis/clients/jedis/tls/RedisClusterClientIT.java
@@ -73,13 +73,10 @@ public class RedisClusterClientIT extends RedisClusterTestBase {
   @ParameterizedTest(name = "connectToNodesSucceedsWithSSLParametersAndHostMapping_{0}")
   @MethodSource("sslOptionsProvider")
   void connectToNodesSucceedsWithSSLParametersAndHostMapping(String testName, SslOptions ssl) {
-    final SSLParameters sslParameters = new SSLParameters();
-    sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
-
     try (RedisClusterClient jc = RedisClusterClient.builder()
         .nodes(Collections.singleton(tlsEndpoint.getHostAndPort()))
         .clientConfig(DefaultJedisClientConfig.builder().password(tlsEndpoint.getPassword())
-            .sslOptions(ssl).sslParameters(sslParameters).build())
+            .sslOptions(ssl).build())
         .maxAttempts(DEFAULT_REDIRECTIONS).poolConfig(DEFAULT_POOL_CONFIG).build()) {
       assertEquals("PONG", jc.ping());
     }

--- a/src/test/java/redis/clients/jedis/tls/SSLOptionsRedisClientIT.java
+++ b/src/test/java/redis/clients/jedis/tls/SSLOptionsRedisClientIT.java
@@ -1,13 +1,16 @@
 package redis.clients.jedis.tls;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.RedisClient;
 import redis.clients.jedis.SslOptions;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 
 /**
  * SSL/TLS tests for {@link RedisClient} using SslOptions builder pattern.
@@ -42,4 +45,46 @@ public class SSLOptionsRedisClientIT extends RedisClientTlsTestBase {
       assertEquals("PONG", client.ping());
     }
   }
+
+  @Test
+  public void connectWithSslOptionsDefaults() {
+    SslOptions sslOptions = SslOptions.defaults();
+
+    DefaultJedisClientConfig clientConfig = DefaultJedisClientConfig.builder()
+        .sslOptions(sslOptions).password(endpoint.getPassword()).build();
+
+    try (RedisClient client = RedisClient.builder()
+        .hostAndPort(endpoint.getHost(), endpoint.getPort()).clientConfig(clientConfig).build()) {
+      assertEquals("PONG", client.ping());
+    }
+  }
+
+  @Test
+  public void connectWithSslOptionsDefaultsWrongHost() {
+    SslOptions sslOptions = SslOptions.defaults();
+
+    DefaultJedisClientConfig clientConfig = DefaultJedisClientConfig.builder()
+        .sslOptions(sslOptions).password(wrongHostEndpoint.getPassword()).build();
+
+    try (RedisClient client = RedisClient.builder()
+        .hostAndPort(wrongHostEndpoint.getHost(), wrongHostEndpoint.getPort())
+        .clientConfig(clientConfig).build()) {
+      assertThrows(JedisConnectionException.class, client::ping);
+    }
+  }
+
+  @Test
+  public void connectWithSslOptionsCustomTrustStore() {
+    SslOptions sslOptions = SslOptions.builder().truststore(trustStorePath.toFile())
+        .trustStoreType("jceks").build();
+
+    DefaultJedisClientConfig clientConfig = DefaultJedisClientConfig.builder()
+        .sslOptions(sslOptions).password(endpoint.getPassword()).build();
+
+    try (RedisClient client = RedisClient.builder()
+        .hostAndPort(endpoint.getHost(), endpoint.getPort()).clientConfig(clientConfig).build()) {
+      assertEquals("PONG", client.ping());
+    }
+  }
+
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes that validate TLS defaults and expected connection failures; low risk aside from potential CI flakiness due to environment-dependent TLS/hostname behavior.
> 
> **Overview**
> Adds new TLS integration tests for `RedisClient` that exercise `SslOptions.defaults()` (successful connect, failure on hostname mismatch) and a custom truststore configuration.
> 
> Updates the cluster TLS integration test to stop explicitly supplying `SSLParameters` with `HTTPS` endpoint identification, relying on `SslOptions`/client defaults instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c587922e46eb9d9ef42b43a10e39b7ec1a48d48a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->