### PR TITLE
ci: add Spring Data Redis integration test workflow

### DIFF
--- a/.github/workflows/spring-data-redis-integration.yml
+++ b/.github/workflows/spring-data-redis-integration.yml
@@ -1,0 +1,97 @@
+---
+
+name: Spring Data Redis Integration Test
+
+on:
+  pull_request:
+    branches:
+      - master
+      - '[0-9].*'
+  workflow_dispatch:
+    inputs:
+      spring_data_redis_branch:
+        description: 'Spring Data Redis branch to test against'
+        required: false
+        default: 'main'
+      redis_version:
+        description: 'Redis version (6, 7, 8)'
+        required: false
+        default: '8'
+
+jobs:
+  integration-test:
+    name: SDR Integration Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Jedis
+        uses: actions/checkout@v4
+        with:
+          path: jedis
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build Jedis (skip tests)
+        working-directory: jedis
+        run: |
+          mvn -B clean install -DskipTests -Dgpg.skip=true
+          JEDIS_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "JEDIS_VERSION=$JEDIS_VERSION" >> $GITHUB_ENV
+          echo "Built Jedis version: $JEDIS_VERSION"
+
+      - name: Checkout Spring Data Redis
+        uses: actions/checkout@v4
+        with:
+          repository: spring-projects/spring-data-redis
+          ref: ${{ github.event.inputs.spring_data_redis_branch || 'main' }}
+          path: spring-data-redis
+
+      - name: Patch Spring Data Redis to use local Jedis
+        working-directory: spring-data-redis
+        run: |
+          echo "Patching Spring Data Redis to use Jedis version: $JEDIS_VERSION"
+          mvn versions:set-property -Dproperty=jedis -DnewVersion=$JEDIS_VERSION -DgenerateBackupPoms=false
+
+      - name: Setup Redis using SDR infrastructure
+        working-directory: spring-data-redis
+        run: |
+          mkdir -p work
+          make start
+        env:
+          IMAGE: redis:${{ github.event.inputs.redis_version || '8' }}
+
+      - name: Run Spring Data Redis tests
+        working-directory: spring-data-redis
+        run: |
+          # Run only Jedis-related tests to keep the workflow focused
+          ./mvnw -B clean test \
+            -Dtest="**/jedis/**/*Test,**/jedis/**/*Tests" \
+            -DfailIfNoTests=false \
+            -Dmaven.javadoc.skip=true \
+            -Pci
+
+      - name: Cleanup Redis
+        if: always()
+        working-directory: spring-data-redis
+        run: make clean || true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdr-test-results
+          path: |
+            spring-data-redis/target/surefire-reports/
+          retention-days: 7

--- a/.github/workflows/spring-data-redis-integration.yml
+++ b/.github/workflows/spring-data-redis-integration.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build Jedis (skip tests)
         working-directory: jedis
         run: |
-          mvn -B clean install -DskipTests -Dgpg.skip=true
+          mvn -B clean install -DskipTests -DskipUnitTests=true -Dgpg.skip=true
           JEDIS_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "JEDIS_VERSION=$JEDIS_VERSION" >> $GITHUB_ENV
           echo "Built Jedis version: $JEDIS_VERSION"
@@ -64,6 +64,24 @@ jobs:
           echo "Patching Spring Data Redis to use Jedis version: $JEDIS_VERSION"
           mvn versions:set-property -Dproperty=jedis -DnewVersion=$JEDIS_VERSION -DgenerateBackupPoms=false
 
+      - name: Build Spring Data Redis
+        working-directory: spring-data-redis
+        run: |
+          # Verify Jedis changes do not cause compile-time issues in SDR
+          ./mvnw -B clean test-compile \
+            -Dmaven.javadoc.skip=true \
+            -Pci
+
+      - name: Run Spring Data Redis unit tests
+        working-directory: spring-data-redis
+        run: |
+          # Verify Jedis changes do not break SDR unit tests (no Redis required)
+          ./mvnw -B test \
+            -Dtest="**/jedis/**/*UnitTests,**/jedis/**/*UnitTest" \
+            -DfailIfNoTests=false \
+            -Dmaven.javadoc.skip=true \
+            -Pci
+
       - name: Setup Redis using SDR infrastructure
         working-directory: spring-data-redis
         run: |
@@ -72,12 +90,12 @@ jobs:
         env:
           IMAGE: redis:${{ github.event.inputs.redis_version || '8' }}
 
-      - name: Run Spring Data Redis tests
+      - name: Run Spring Data Redis integration tests
         working-directory: spring-data-redis
         run: |
-          # Run only Jedis-related tests to keep the workflow focused
-          ./mvnw -B clean test \
-            -Dtest="**/jedis/**/*Test,**/jedis/**/*Tests" \
+          # Verify Jedis changes do not break SDR integration tests (Redis required)
+          ./mvnw -B test \
+            -Dtest="**/jedis/**/*Tests,**/jedis/**/*Test,!**/jedis/**/*UnitTests,!**/jedis/**/*UnitTest" \
             -DfailIfNoTests=false \
             -Dmaven.javadoc.skip=true \
             -Pci


### PR DESCRIPTION
Adds a GitHub Actions workflow that verifies Jedis changes do not break Spring Data Redis (SDR).

### The workflow:

* Builds the current Jedis source and installs it to the local Maven repo
* Clones Spring Data Redis and patches it to consume the locally built Jedis
* Provisions the required Redis topologies via SDR's make start (standalone, auth, cluster, sentinel)
* Runs SDR's Jedis-scoped test suite (`**/jedis/**/*Test`, `**/jedis/**/*Tests`)
* Tears down the Redis infrastructure and uploads surefire reports as an artifact

Verified on run [24897960792](https://github.com/redis/jedis/actions/runs/24897960792): 
> 3568 tests executed, 0 failures, 0 errors, 258 skipped — completed in ~4m30s.

Similar to https://github.com/redis/lettuce/pull/3732


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that adds additional test coverage; main risk is longer CI time or occasional workflow flakiness due to external checkout/Redis startup.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`spring-data-redis-integration.yml`) to validate Jedis changes against Spring Data Redis on PRs (and via manual dispatch).
> 
> The job builds Jedis into the local Maven repo, checks out Spring Data Redis and patches its `jedis` dependency to the locally built version, then runs SDR compile checks plus Jedis-scoped unit and Redis-backed integration tests (bringing Redis up via `make start` with a selectable Redis image version) and uploads surefire reports as an artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 551a65decf3ae6e64e8b7759c82c422ccd9f21a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->