### PR TITLE
fix: test fail with Redis Search v8.7.90+

### DIFF
--- a/src/test/java/redis/clients/jedis/commands/unified/search/SearchCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/search/SearchCommandsTestBase.java
@@ -1,38 +1,29 @@
 package redis.clients.jedis.commands.unified.search;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.emptyOrNullString;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.util.*;
-import java.util.stream.Collectors;
-
-import io.redis.test.annotations.SinceRedisVersion;
-import io.redis.test.utils.RedisVersion;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
 
 import redis.clients.jedis.Endpoints;
 import redis.clients.jedis.RedisProtocol;
-import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.commands.unified.UnifiedJedisCommandsTestBase;
 import redis.clients.jedis.exceptions.JedisDataException;
-import redis.clients.jedis.json.Path;
 import redis.clients.jedis.search.*;
 import redis.clients.jedis.search.Schema.*;
-import redis.clients.jedis.util.RedisVersionUtil;
 import redis.clients.jedis.util.SafeEncoder;
 
 /**
@@ -336,7 +327,10 @@ public abstract class SearchCommandsTestBase extends UnifiedJedisCommandsTestBas
       jedis.ftSearch(INDEX, new Query("hello world"));
       fail("Index should not exist.");
     } catch (JedisDataException de) {
-      assertTrue(de.getMessage().toLowerCase().contains("no such index"));
+      assertThat(de.getMessage(), anyOf(containsStringIgnoringCase("no such index"), // Redis Search
+                                                                                     // <v8.7.90
+        containsString("SEARCH_INDEX_NOT_FOUND") // Redis Search v8.7.90+
+      ));
     }
     assertEquals(100, jedis.dbSize());
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates a RediSearch test assertion to tolerate a changed server error string, with minor import cleanup and no production code impact.
> 
> **Overview**
> Makes the `dropIndex` test resilient to Redis Search v8.7.90+ by accepting either the legacy "no such index" message (case-insensitive) or the newer `SEARCH_INDEX_NOT_FOUND` error code when querying a dropped index.
> 
> Also removes unused test imports related to prior assertions/compat helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a355a5b62df82f79ca62e77cdc2c6147531eea91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->