### PR TITLE
test: fix flaky testPolicy_AllSuccess_StopsOnFirstFailure test

### DIFF
--- a/src/test/java/redis/clients/jedis/mcf/HealthCheckTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/HealthCheckTest.java
@@ -737,10 +737,8 @@ public class HealthCheckTest {
     AtomicInteger callCount = new AtomicInteger(0);
     CountDownLatch unhealthyLatch = new CountDownLatch(1);
 
-    TestHealthCheckStrategy strategy = new TestHealthCheckStrategy(
-        HealthCheckStrategy.Config.builder().interval(5).timeout(200).numProbes(3)
-            .policy(BuiltIn.ALL_SUCCESS).delayInBetweenProbes(5).build(),
-        e -> {
+    TestHealthCheckStrategy strategy = new TestHealthCheckStrategy(HealthCheckStrategy.Config
+        .builder().numProbes(3).policy(BuiltIn.ALL_SUCCESS).delayInBetweenProbes(5).build(), e -> {
           int c = callCount.incrementAndGet();
           return c == 1 ? HealthStatus.UNHEALTHY : HealthStatus.HEALTHY;
         });


### PR DESCRIPTION
Test uses `interval(5`), causing a new health check to be scheduled before probes for the existing one complete.

fix: use default healthcheck interval 1s, giving time for probes to be performed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adjusts health check config to avoid overlapping scheduled runs and reduce timing-related flakiness.
> 
> **Overview**
> Updates `HealthCheckTest.testPolicy_AllSuccess_StopsOnFirstFailure` to stop overriding `interval`/`timeout` in the strategy config, relying on defaults so the probe sequence completes before a new scheduled health check can start.
> 
> This stabilizes the assertion that `BuiltIn.ALL_SUCCESS` stops after the first failed probe by removing timing-sensitive scheduling behavior from the test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1784c7b3a3202f86d672058d888058d3288d5994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->