### PR TITLE
Add subkeyspace notifications integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -574,6 +574,8 @@
 						<include>**/*MapMatcher.java</include>
 						<include>**/JsonSetParamsTest.java</include>
                         <include>**/XNack*.java</include>
+						<include>**/*SubkeyNotifications*.java</include>
+						<include>**/PubSubHelpers.java</include>
 
                         <include>src/test/java/redis/clients/jedis/commands/unified/**bloom/*.java</include>
                         <include>src/test/java/redis/clients/jedis/commands/unified/**json/*.java</include>

--- a/src/test/java/redis/clients/jedis/commands/jedis/JedisCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/JedisCommandsTestBase.java
@@ -50,7 +50,7 @@ public abstract class JedisCommandsTestBase {
   @BeforeEach
   public void setUp() throws Exception {
     jedis = new Jedis(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder()
-        .protocol(protocol).timeoutMillis(500).build());
+        .protocol(protocol).autoNegotiateProtocol(false).timeoutMillis(500).build());
     jedis.flushAll();
   }
 
@@ -61,6 +61,6 @@ public abstract class JedisCommandsTestBase {
 
   protected Jedis createJedis() {
     return new Jedis(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder()
-        .protocol(protocol).build());
+        .protocol(protocol).autoNegotiateProtocol(false).build());
   }
 }

--- a/src/test/java/redis/clients/jedis/commands/jedis/SubkeyNotificationsBinaryIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/SubkeyNotificationsBinaryIntegrationTest.java
@@ -1,0 +1,187 @@
+package redis.clients.jedis.commands.jedis;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static redis.clients.jedis.util.PubSubHelpers.concat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.util.PubSubHelpers;
+import redis.clients.jedis.util.PubSubHelpers.CapturingBinaryPubSub;
+
+/** Binary integration tests for the Redis 8.8 Subkey Notifications feature. */
+@ParameterizedClass
+@MethodSource("redis.clients.jedis.commands.CommandsTestsParameters#respVersions")
+@Tag("integration")
+public class SubkeyNotificationsBinaryIntegrationTest extends JedisCommandsTestBase {
+
+  private String originalNotifyConfig;
+  private Jedis subscriber;
+  private CapturingBinaryPubSub pubSub;
+  private Thread subscriberThread;
+
+  public SubkeyNotificationsBinaryIntegrationTest(RedisProtocol protocol) {
+    super(protocol);
+  }
+
+  @BeforeEach
+  public void enableSubkeyNotifications() {
+    Map<String, String> current = jedis.configGet("notify-keyspace-events");
+    originalNotifyConfig = current.getOrDefault("notify-keyspace-events", "");
+    try {
+      jedis.configSet("notify-keyspace-events", "AKEhSTIV");
+    } catch (JedisDataException e) {
+      Assumptions
+          .abort("Server does not support subkey notification flags (STIV): " + e.getMessage());
+    }
+  }
+
+  @AfterEach
+  public void closeSubscriber() {
+    if (pubSub != null) {
+      try {
+        pubSub.unsubscribe();
+      } catch (Exception ignore) {
+        /* best-effort */ }
+      try {
+        pubSub.punsubscribe();
+      } catch (Exception ignore) {
+        /* best-effort */ }
+    }
+    if (subscriberThread != null) {
+      try {
+        subscriberThread.join(2_000L);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+    if (subscriber != null) {
+      try {
+        subscriber.close();
+      } catch (Exception ignore) {
+        /* best-effort */ }
+    }
+    if (jedis != null && originalNotifyConfig != null) {
+      try {
+        jedis.configSet("notify-keyspace-events", originalNotifyConfig);
+      } catch (Exception ignore) {
+        /* best-effort */ }
+    }
+  }
+
+  @Test
+  public void subkeyspace_subkeyContainingPipeAndNonUtf8() throws InterruptedException {
+    byte[] hashKey = ("bin-subkeyspace-" + System.nanoTime()).getBytes(StandardCharsets.UTF_8);
+    byte[] field = new byte[] { 'a', '|', 'b', (byte) 0xFE, 'c' };
+    byte[] channel = concat(prefix("__subkeyspace@0__:"), hashKey);
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+    byte[] payload = pubSub.expectMessageOn(channel);
+    byte[] expected = concat("hset|".getBytes(StandardCharsets.UTF_8),
+      (field.length + ":").getBytes(StandardCharsets.UTF_8), field);
+    assertThat(payload, equalTo(expected));
+  }
+
+  @Test
+  public void subkeyevent_keyAndSubkeyContainingPipe() throws InterruptedException {
+    byte[] hashKey = new byte[] { 'h', '|', 'k', (byte) 0x80 };
+    byte[] field = new byte[] { 'f', '|', 'd' };
+    byte[] channel = "__subkeyevent@0__:hset".getBytes(StandardCharsets.UTF_8);
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+    byte[] payload = pubSub.expectMessageOn(channel);
+    byte[] expected = concat((hashKey.length + ":").getBytes(StandardCharsets.UTF_8), hashKey,
+      "|".getBytes(StandardCharsets.UTF_8), (field.length + ":").getBytes(StandardCharsets.UTF_8),
+      field);
+    assertThat(payload, equalTo(expected));
+  }
+
+  @Test
+  public void subkeyspaceitem_channelContainsBinaryBytes() throws InterruptedException {
+    byte[] hashKey = new byte[] { 'i', (byte) 0xC3, (byte) 0xA9 };
+    byte[] field = new byte[] { 'f', (byte) 0x80, 'd' };
+    byte[] pattern = concat(prefix("__subkeyspaceitem@0__:"), hashKey,
+      "\n*".getBytes(StandardCharsets.UTF_8));
+    byte[] expectedChannel = concat(prefix("__subkeyspaceitem@0__:"), hashKey,
+      "\n".getBytes(StandardCharsets.UTF_8), field);
+    subscribePatterns(pattern);
+
+    jedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+    byte[] payload = pubSub.expectMessageOn(expectedChannel);
+    assertThat(payload, equalTo("hset".getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  public void subkeyspaceevent_keyContainingPipeInChannel() throws InterruptedException {
+    byte[] hashKey = new byte[] { 'k', '|', 'k', (byte) 0xFF };
+    byte[] field = new byte[] { 'f', 'l', 'd' };
+    byte[] channel = concat("__subkeyspaceevent@0__:hset|".getBytes(StandardCharsets.UTF_8),
+      hashKey);
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+    byte[] payload = pubSub.expectMessageOn(channel);
+    byte[] expected = concat((field.length + ":").getBytes(StandardCharsets.UTF_8), field);
+    assertThat(payload, equalTo(expected));
+  }
+
+  @Test
+  public void subkeyevent_keyAndSubkeyContainingNewline() throws InterruptedException {
+    byte[] hashKey = new byte[] { 'h', '\n', 'k' };
+    byte[] field = new byte[] { 'f', '\n', 'd' };
+    byte[] channel = "__subkeyevent@0__:hset".getBytes(StandardCharsets.UTF_8);
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+    byte[] payload = pubSub.expectMessageOn(channel);
+    byte[] expected = concat((hashKey.length + ":").getBytes(StandardCharsets.UTF_8), hashKey,
+      "|".getBytes(StandardCharsets.UTF_8), (field.length + ":").getBytes(StandardCharsets.UTF_8),
+      field);
+    assertThat(payload, equalTo(expected));
+  }
+
+  // -------------------------------------------------------------------- helpers
+
+  private void subscribeChannels(byte[]... channels) throws InterruptedException {
+    pubSub = new CapturingBinaryPubSub();
+    subscriber = createJedis();
+    subscriberThread = new Thread(() -> subscriber.subscribe(pubSub, channels),
+        "subkey-bin-sub-" + System.nanoTime());
+    subscriberThread.setDaemon(true);
+    subscriberThread.start();
+    PubSubHelpers.awaitSubscribed(pubSub.subscribed);
+  }
+
+  private void subscribePatterns(byte[]... patterns) throws InterruptedException {
+    pubSub = new CapturingBinaryPubSub();
+    subscriber = createJedis();
+    subscriberThread = new Thread(() -> subscriber.psubscribe(pubSub, patterns),
+        "subkey-bin-psub-" + System.nanoTime());
+    subscriberThread.setDaemon(true);
+    subscriberThread.start();
+    PubSubHelpers.awaitSubscribed(pubSub.subscribed);
+  }
+
+  private static byte[] prefix(String s) {
+    return s.getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/src/test/java/redis/clients/jedis/commands/jedis/SubkeyNotificationsIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/SubkeyNotificationsIntegrationTest.java
@@ -1,0 +1,280 @@
+package redis.clients.jedis.commands.jedis;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.util.PubSubHelpers;
+import redis.clients.jedis.util.PubSubHelpers.CapturingPubSub;
+import redis.clients.jedis.util.PubSubHelpers.Notification;
+
+/** Integration tests for the Redis 8.8 Subkey Notifications feature. */
+@ParameterizedClass
+@MethodSource("redis.clients.jedis.commands.CommandsTestsParameters#respVersions")
+@Tag("integration")
+public class SubkeyNotificationsIntegrationTest extends JedisCommandsTestBase {
+
+  static final String CHANNEL_PREFIX_SUBKEYSPACE = "__subkeyspace@0__:";
+  static final String CHANNEL_PREFIX_SUBKEYEVENT = "__subkeyevent@0__:";
+  static final String CHANNEL_PREFIX_SUBKEYSPACEITEM = "__subkeyspaceitem@0__:";
+  static final String CHANNEL_PREFIX_SUBKEYSPACEEVENT = "__subkeyspaceevent@0__:";
+
+  private String originalNotifyConfig;
+  protected Jedis subscriber;
+  private CapturingPubSub pubSub;
+  private Thread subscriberThread;
+
+  public SubkeyNotificationsIntegrationTest(RedisProtocol protocol) {
+    super(protocol);
+  }
+
+  @BeforeEach
+  public void enableSubkeyNotifications() {
+    Map<String, String> current = jedis.configGet("notify-keyspace-events");
+    originalNotifyConfig = current.getOrDefault("notify-keyspace-events", "");
+    try {
+      jedis.configSet("notify-keyspace-events", "AKEhSTIV");
+    } catch (JedisDataException e) {
+      Assumptions
+          .abort("Server does not support subkey notification flags (STIV): " + e.getMessage());
+    }
+  }
+
+  @AfterEach
+  public void closeSubscriber() {
+    if (pubSub != null) {
+      try {
+        pubSub.unsubscribe();
+      } catch (Exception ignore) {
+        /* best-effort */ }
+      try {
+        pubSub.punsubscribe();
+      } catch (Exception ignore) {
+        /* best-effort */ }
+    }
+    if (subscriberThread != null) {
+      try {
+        subscriberThread.join(2_000L);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+    if (subscriber != null) {
+      try {
+        subscriber.close();
+      } catch (Exception ignore) {
+        /* best-effort */ }
+    }
+    if (jedis != null && originalNotifyConfig != null) {
+      try {
+        jedis.configSet("notify-keyspace-events", originalNotifyConfig);
+      } catch (Exception ignore) {
+        /* best-effort */ }
+    }
+  }
+
+  // -------------------------------------------------------------------- subkeyspace (flag S)
+
+  @Test
+  public void subkeyspace_singleHashField() throws InterruptedException {
+    String hashKey = "subkeyspace-basic-" + System.nanoTime();
+    String channel = CHANNEL_PREFIX_SUBKEYSPACE + hashKey;
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, "fld", "v1");
+
+    Notification n = pubSub.expectMessageOn(channel);
+    assertThat(n.pattern, nullValue());
+    assertThat(n.message, equalTo("hset|3:fld"));
+  }
+
+  @Test
+  public void subkeyspace_multipleFields() throws InterruptedException {
+    String hashKey = "subkeyspace-multi-" + System.nanoTime();
+    String channel = CHANNEL_PREFIX_SUBKEYSPACE + hashKey;
+    subscribeChannels(channel);
+
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("f1", "v1");
+    fields.put("f22", "v2");
+    jedis.hset(hashKey, fields);
+
+    Notification n = pubSub.expectMessageOn(channel);
+    assertThat(n.pattern, nullValue());
+    assertThat(n.message, anyOf(equalTo("hset|2:f1,3:f22"), equalTo("hset|3:f22,2:f1")));
+  }
+
+  @Test
+  public void subkeyspace_psubscribePrefix() throws InterruptedException {
+    String prefix = "subkeyspace-pattern-" + System.nanoTime() + "-";
+    String hashKey1 = prefix + "a";
+    String hashKey2 = prefix + "b";
+    String pattern = CHANNEL_PREFIX_SUBKEYSPACE + prefix + "*";
+    subscribePatterns(pattern);
+
+    jedis.hset(hashKey1, "fld", "v1");
+    jedis.hset(hashKey2, "fld", "v2");
+
+    Notification n1 = pubSub.expectMessageOn(CHANNEL_PREFIX_SUBKEYSPACE + hashKey1);
+    Notification n2 = pubSub.expectMessageOn(CHANNEL_PREFIX_SUBKEYSPACE + hashKey2);
+    assertThat(n1.pattern, equalTo(pattern));
+    assertThat(n2.pattern, equalTo(pattern));
+    assertThat(n1.message, equalTo("hset|3:fld"));
+    assertThat(n2.message, equalTo("hset|3:fld"));
+  }
+
+  // -------------------------------------------------------------------- subkeyevent (flag T)
+
+  @Test
+  public void subkeyevent_singleHashField() throws InterruptedException {
+    String hashKey = "subkeyevent-basic-" + System.nanoTime();
+    String channel = CHANNEL_PREFIX_SUBKEYEVENT + "hset";
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, "fld", "v1");
+
+    Notification n = pubSub.expectMessageOn(channel);
+    assertThat(n.pattern, nullValue());
+    assertThat(n.message, equalTo(hashKey.length() + ":" + hashKey + "|3:fld"));
+  }
+
+  @Test
+  public void subkeyevent_multipleFields() throws InterruptedException {
+    String hashKey = "subkeyevent-multi-" + System.nanoTime();
+    String channel = CHANNEL_PREFIX_SUBKEYEVENT + "hset";
+    subscribeChannels(channel);
+
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("f1", "v1");
+    fields.put("f22", "v2");
+    jedis.hset(hashKey, fields);
+
+    Notification n = pubSub.expectMessageOn(channel);
+    assertThat(n.pattern, nullValue());
+    String prefix = hashKey.length() + ":" + hashKey + "|";
+    assertThat(n.message, anyOf(equalTo(prefix + "2:f1,3:f22"), equalTo(prefix + "3:f22,2:f1")));
+  }
+
+  // -------------------------------------------------------------------- subkeyspaceitem (flag I)
+
+  @Test
+  public void subkeyspaceitem_singleHashField() throws InterruptedException {
+    String hashKey = "subkeyspaceitem-basic-" + System.nanoTime();
+    String field = "fld";
+    String channel = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\n" + field;
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, field, "v1");
+
+    Notification n = pubSub.expectMessageOn(channel);
+    assertThat(n.pattern, nullValue());
+    assertThat(n.message, equalTo("hset"));
+  }
+
+  @Test
+  public void subkeyspaceitem_filtersToTargetFieldOnly() throws InterruptedException {
+    String hashKey = "subkeyspaceitem-filter-" + System.nanoTime();
+    String targetChannel = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\nf2";
+    subscribeChannels(targetChannel);
+
+    jedis.hset(hashKey, "f1", "v1");
+    jedis.hset(hashKey, "f2", "v2");
+    jedis.hset(hashKey, "f3", "v3");
+
+    Notification n = pubSub.expectMessageOn(targetChannel);
+    assertThat(n.message, equalTo("hset"));
+    assertThat(n.pattern, nullValue());
+
+    pubSub.expectNoMessageOn(targetChannel, 250, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  public void subkeyspaceitem_multipleFieldsEmitOneEventPerField() throws InterruptedException {
+    String hashKey = "subkeyspaceitem-multi-" + System.nanoTime();
+    String pattern = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\n*";
+    String channelF1 = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\nf1";
+    String channelF22 = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\nf22";
+    subscribePatterns(pattern);
+
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("f1", "v1");
+    fields.put("f22", "v2");
+    jedis.hset(hashKey, fields);
+
+    Notification n1 = pubSub.expectMessageOn(channelF1);
+    Notification n2 = pubSub.expectMessageOn(channelF22);
+    assertThat(n1.message, equalTo("hset"));
+    assertThat(n2.message, equalTo("hset"));
+    assertThat(n1.pattern, equalTo(pattern));
+    assertThat(n2.pattern, equalTo(pattern));
+  }
+
+  // -------------------------------------------------------------------- subkeyspaceevent (flag V)
+
+  @Test
+  public void subkeyspaceevent_singleHashField() throws InterruptedException {
+    String hashKey = "subkeyspaceevent-basic-" + System.nanoTime();
+    String channel = CHANNEL_PREFIX_SUBKEYSPACEEVENT + "hset|" + hashKey;
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, "fld", "v1");
+
+    Notification n = pubSub.expectMessageOn(channel);
+    assertThat(n.pattern, nullValue());
+    assertThat(n.message, equalTo("3:fld"));
+  }
+
+  @Test
+  public void subkeyspaceevent_multipleFields() throws InterruptedException {
+    String hashKey = "subkeyspaceevent-multi-" + System.nanoTime();
+    String channel = CHANNEL_PREFIX_SUBKEYSPACEEVENT + "hset|" + hashKey;
+    subscribeChannels(channel);
+
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("f1", "v1");
+    fields.put("f22", "v2");
+    jedis.hset(hashKey, fields);
+
+    Notification n = pubSub.expectMessageOn(channel);
+    assertThat(n.pattern, nullValue());
+    assertThat(n.message, anyOf(equalTo("2:f1,3:f22"), equalTo("3:f22,2:f1")));
+  }
+
+  // -------------------------------------------------------------------- helpers
+
+  private void subscribeChannels(String... channels) throws InterruptedException {
+    pubSub = new CapturingPubSub();
+    subscriber = createJedis();
+    subscriberThread = new Thread(() -> subscriber.subscribe(pubSub, channels),
+        "subkey-sub-" + System.nanoTime());
+    subscriberThread.setDaemon(true);
+    subscriberThread.start();
+    PubSubHelpers.awaitSubscribed(pubSub.subscribed);
+  }
+
+  private void subscribePatterns(String... patterns) throws InterruptedException {
+    pubSub = new CapturingPubSub();
+    subscriber = createJedis();
+    subscriberThread = new Thread(() -> subscriber.psubscribe(pubSub, patterns),
+        "subkey-psub-" + System.nanoTime());
+    subscriberThread.setDaemon(true);
+    subscriberThread.start();
+    PubSubHelpers.awaitSubscribed(pubSub.subscribed);
+  }
+}

--- a/src/test/java/redis/clients/jedis/commands/unified/SubkeyNotificationsBinaryTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/SubkeyNotificationsBinaryTestBase.java
@@ -1,0 +1,190 @@
+package redis.clients.jedis.commands.unified;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static redis.clients.jedis.util.PubSubHelpers.concat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.util.PubSubHelpers;
+import redis.clients.jedis.util.PubSubHelpers.CapturingBinaryPubSub;
+
+/**
+ * Binary integration tests for the Redis 8.8 Subkey Notifications feature against
+ * {@link UnifiedJedis}.
+ */
+@Tag("integration")
+public abstract class SubkeyNotificationsBinaryTestBase extends UnifiedJedisCommandsTestBase {
+
+  private String originalNotifyConfig;
+  private UnifiedJedis subscriber;
+  private CapturingBinaryPubSub pubSub;
+  private Thread subscriberThread;
+
+  public SubkeyNotificationsBinaryTestBase(RedisProtocol protocol) {
+    super(protocol);
+  }
+
+  @BeforeEach
+  public void enableSubkeyNotifications() {
+    try (Jedis control = new Jedis(endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().build())) {
+      Map<String, String> current = control.configGet("notify-keyspace-events");
+      originalNotifyConfig = current.getOrDefault("notify-keyspace-events", "");
+    }
+    try {
+      jedis.configSet("notify-keyspace-events", "AKEhSTIV");
+    } catch (JedisDataException e) {
+      Assumptions
+          .abort("Server does not support subkey notification flags (STIV): " + e.getMessage());
+    }
+  }
+
+  @AfterEach
+  public void closeSubscriber() {
+    if (pubSub != null) {
+      try {
+        pubSub.unsubscribe();
+      } catch (Exception ignore) {
+        /* best-effort */ }
+      try {
+        pubSub.punsubscribe();
+      } catch (Exception ignore) {
+        /* best-effort */ }
+    }
+    if (subscriberThread != null) {
+      try {
+        subscriberThread.join(2_000L);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+    if (subscriber != null) {
+      try {
+        subscriber.close();
+      } catch (Exception ignore) {
+        /* best-effort */ }
+    }
+    if (jedis != null && originalNotifyConfig != null) {
+      try {
+        jedis.configSet("notify-keyspace-events", originalNotifyConfig);
+      } catch (Exception ignore) {
+        /* best-effort */ }
+    }
+  }
+
+  @Test
+  public void subkeyspace_subkeyContainingPipeAndNonUtf8() throws InterruptedException {
+    byte[] hashKey = ("bin-subkeyspace-" + System.nanoTime()).getBytes(StandardCharsets.UTF_8);
+    byte[] field = new byte[] { 'a', '|', 'b', (byte) 0xFE, 'c' };
+    byte[] channel = concat(prefix("__subkeyspace@0__:"), hashKey);
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+    byte[] payload = pubSub.expectMessageOn(channel);
+    byte[] expected = concat("hset|".getBytes(StandardCharsets.UTF_8),
+      (field.length + ":").getBytes(StandardCharsets.UTF_8), field);
+    assertThat(payload, equalTo(expected));
+  }
+
+  @Test
+  public void subkeyevent_keyAndSubkeyContainingPipe() throws InterruptedException {
+    byte[] hashKey = new byte[] { 'h', '|', 'k', (byte) 0x80 };
+    byte[] field = new byte[] { 'f', '|', 'd' };
+    byte[] channel = "__subkeyevent@0__:hset".getBytes(StandardCharsets.UTF_8);
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+    byte[] payload = pubSub.expectMessageOn(channel);
+    byte[] expected = concat((hashKey.length + ":").getBytes(StandardCharsets.UTF_8), hashKey,
+      "|".getBytes(StandardCharsets.UTF_8), (field.length + ":").getBytes(StandardCharsets.UTF_8),
+      field);
+    assertThat(payload, equalTo(expected));
+  }
+
+  @Test
+  public void subkeyspaceitem_channelContainsBinaryBytes() throws InterruptedException {
+    byte[] hashKey = new byte[] { 'i', (byte) 0xC3, (byte) 0xA9 };
+    byte[] field = new byte[] { 'f', (byte) 0x80, 'd' };
+    byte[] pattern = concat(prefix("__subkeyspaceitem@0__:"), hashKey,
+      "\n*".getBytes(StandardCharsets.UTF_8));
+    byte[] expectedChannel = concat(prefix("__subkeyspaceitem@0__:"), hashKey,
+      "\n".getBytes(StandardCharsets.UTF_8), field);
+    subscribePatterns(pattern);
+
+    jedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+    byte[] payload = pubSub.expectMessageOn(expectedChannel);
+    assertThat(payload, equalTo("hset".getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  public void subkeyspaceevent_keyContainingPipeInChannel() throws InterruptedException {
+    byte[] hashKey = new byte[] { 'k', '|', 'k', (byte) 0xFF };
+    byte[] field = new byte[] { 'f', 'l', 'd' };
+    byte[] channel = concat("__subkeyspaceevent@0__:hset|".getBytes(StandardCharsets.UTF_8),
+      hashKey);
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+    byte[] payload = pubSub.expectMessageOn(channel);
+    byte[] expected = concat((field.length + ":").getBytes(StandardCharsets.UTF_8), field);
+    assertThat(payload, equalTo(expected));
+  }
+
+  @Test
+  public void subkeyevent_keyAndSubkeyContainingNewline() throws InterruptedException {
+    byte[] hashKey = new byte[] { 'h', '\n', 'k' };
+    byte[] field = new byte[] { 'f', '\n', 'd' };
+    byte[] channel = "__subkeyevent@0__:hset".getBytes(StandardCharsets.UTF_8);
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, field, "v1".getBytes(StandardCharsets.UTF_8));
+
+    byte[] payload = pubSub.expectMessageOn(channel);
+    byte[] expected = concat((hashKey.length + ":").getBytes(StandardCharsets.UTF_8), hashKey,
+      "|".getBytes(StandardCharsets.UTF_8), (field.length + ":").getBytes(StandardCharsets.UTF_8),
+      field);
+    assertThat(payload, equalTo(expected));
+  }
+
+  // -------------------------------------------------------------------- helpers
+
+  private void subscribeChannels(byte[]... channels) throws InterruptedException {
+    pubSub = new CapturingBinaryPubSub();
+    subscriber = createTestClient();
+    subscriberThread = new Thread(() -> subscriber.subscribe(pubSub, channels),
+        "subkey-uj-bin-sub-" + System.nanoTime());
+    subscriberThread.setDaemon(true);
+    subscriberThread.start();
+    PubSubHelpers.awaitSubscribed(pubSub.subscribed);
+  }
+
+  private void subscribePatterns(byte[]... patterns) throws InterruptedException {
+    pubSub = new CapturingBinaryPubSub();
+    subscriber = createTestClient();
+    subscriberThread = new Thread(() -> subscriber.psubscribe(pubSub, patterns),
+        "subkey-uj-bin-psub-" + System.nanoTime());
+    subscriberThread.setDaemon(true);
+    subscriberThread.start();
+    PubSubHelpers.awaitSubscribed(pubSub.subscribed);
+  }
+
+  private static byte[] prefix(String s) {
+    return s.getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/src/test/java/redis/clients/jedis/commands/unified/SubkeyNotificationsBinaryTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/SubkeyNotificationsBinaryTestBase.java
@@ -39,7 +39,7 @@ public abstract class SubkeyNotificationsBinaryTestBase extends UnifiedJedisComm
   @BeforeEach
   public void enableSubkeyNotifications() {
     try (Jedis control = new Jedis(endpoint.getHostAndPort(),
-        endpoint.getClientConfigBuilder().build())) {
+        endpoint.getClientConfigBuilder().autoNegotiateProtocol(false).build())) {
       Map<String, String> current = control.configGet("notify-keyspace-events");
       originalNotifyConfig = current.getOrDefault("notify-keyspace-events", "");
     }

--- a/src/test/java/redis/clients/jedis/commands/unified/SubkeyNotificationsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/SubkeyNotificationsTestBase.java
@@ -1,0 +1,282 @@
+package redis.clients.jedis.commands.unified;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.util.PubSubHelpers;
+import redis.clients.jedis.util.PubSubHelpers.CapturingPubSub;
+import redis.clients.jedis.util.PubSubHelpers.Notification;
+
+/**
+ * Integration tests for the Redis 8.8 Subkey Notifications feature against {@link UnifiedJedis}.
+ */
+@Tag("integration")
+public abstract class SubkeyNotificationsTestBase extends UnifiedJedisCommandsTestBase {
+
+  static final String CHANNEL_PREFIX_SUBKEYSPACE = "__subkeyspace@0__:";
+  static final String CHANNEL_PREFIX_SUBKEYEVENT = "__subkeyevent@0__:";
+  static final String CHANNEL_PREFIX_SUBKEYSPACEITEM = "__subkeyspaceitem@0__:";
+  static final String CHANNEL_PREFIX_SUBKEYSPACEEVENT = "__subkeyspaceevent@0__:";
+
+  private String originalNotifyConfig;
+  private UnifiedJedis subscriber;
+  private CapturingPubSub pubSub;
+  private Thread subscriberThread;
+
+  public SubkeyNotificationsTestBase(RedisProtocol protocol) {
+    super(protocol);
+  }
+
+  @BeforeEach
+  public void enableSubkeyNotifications() {
+    try (Jedis control = new Jedis(endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().build())) {
+      Map<String, String> current = control.configGet("notify-keyspace-events");
+      originalNotifyConfig = current.getOrDefault("notify-keyspace-events", "");
+    }
+    try {
+      jedis.configSet("notify-keyspace-events", "AKEhSTIV");
+    } catch (JedisDataException e) {
+      Assumptions
+          .abort("Server does not support subkey notification flags (STIV): " + e.getMessage());
+    }
+  }
+
+  @AfterEach
+  public void closeSubscriber() {
+    if (pubSub != null) {
+      try {
+        pubSub.unsubscribe();
+      } catch (Exception ignore) {
+        /* best-effort */ }
+      try {
+        pubSub.punsubscribe();
+      } catch (Exception ignore) {
+        /* best-effort */ }
+    }
+    if (subscriberThread != null) {
+      try {
+        subscriberThread.join(2_000L);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+    if (subscriber != null) {
+      try {
+        subscriber.close();
+      } catch (Exception ignore) {
+        /* best-effort */ }
+    }
+    if (jedis != null && originalNotifyConfig != null) {
+      try {
+        jedis.configSet("notify-keyspace-events", originalNotifyConfig);
+      } catch (Exception ignore) {
+        /* best-effort */ }
+    }
+  }
+
+  // -------------------------------------------------------------------- subkeyspace (flag S)
+
+  @Test
+  public void subkeyspace_singleHashField() throws InterruptedException {
+    String hashKey = "subkeyspace-basic-" + System.nanoTime();
+    String channel = CHANNEL_PREFIX_SUBKEYSPACE + hashKey;
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, "fld", "v1");
+
+    Notification n = pubSub.expectMessageOn(channel);
+    assertThat(n.pattern, nullValue());
+    assertThat(n.message, equalTo("hset|3:fld"));
+  }
+
+  @Test
+  public void subkeyspace_multipleFields() throws InterruptedException {
+    String hashKey = "subkeyspace-multi-" + System.nanoTime();
+    String channel = CHANNEL_PREFIX_SUBKEYSPACE + hashKey;
+    subscribeChannels(channel);
+
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("f1", "v1");
+    fields.put("f22", "v2");
+    jedis.hset(hashKey, fields);
+
+    Notification n = pubSub.expectMessageOn(channel);
+    assertThat(n.pattern, nullValue());
+    assertThat(n.message, anyOf(equalTo("hset|2:f1,3:f22"), equalTo("hset|3:f22,2:f1")));
+  }
+
+  @Test
+  public void subkeyspace_psubscribePrefix() throws InterruptedException {
+    String prefix = "subkeyspace-pattern-" + System.nanoTime() + "-";
+    String hashKey1 = prefix + "a";
+    String hashKey2 = prefix + "b";
+    String pattern = CHANNEL_PREFIX_SUBKEYSPACE + prefix + "*";
+    subscribePatterns(pattern);
+
+    jedis.hset(hashKey1, "fld", "v1");
+    jedis.hset(hashKey2, "fld", "v2");
+
+    Notification n1 = pubSub.expectMessageOn(CHANNEL_PREFIX_SUBKEYSPACE + hashKey1);
+    Notification n2 = pubSub.expectMessageOn(CHANNEL_PREFIX_SUBKEYSPACE + hashKey2);
+    assertThat(n1.pattern, equalTo(pattern));
+    assertThat(n2.pattern, equalTo(pattern));
+    assertThat(n1.message, equalTo("hset|3:fld"));
+    assertThat(n2.message, equalTo("hset|3:fld"));
+  }
+
+  // -------------------------------------------------------------------- subkeyevent (flag T)
+
+  @Test
+  public void subkeyevent_singleHashField() throws InterruptedException {
+    String hashKey = "subkeyevent-basic-" + System.nanoTime();
+    String channel = CHANNEL_PREFIX_SUBKEYEVENT + "hset";
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, "fld", "v1");
+
+    Notification n = pubSub.expectMessageOn(channel);
+    assertThat(n.pattern, nullValue());
+    assertThat(n.message, equalTo(hashKey.length() + ":" + hashKey + "|3:fld"));
+  }
+
+  @Test
+  public void subkeyevent_multipleFields() throws InterruptedException {
+    String hashKey = "subkeyevent-multi-" + System.nanoTime();
+    String channel = CHANNEL_PREFIX_SUBKEYEVENT + "hset";
+    subscribeChannels(channel);
+
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("f1", "v1");
+    fields.put("f22", "v2");
+    jedis.hset(hashKey, fields);
+
+    Notification n = pubSub.expectMessageOn(channel);
+    assertThat(n.pattern, nullValue());
+    String prefix = hashKey.length() + ":" + hashKey + "|";
+    assertThat(n.message, anyOf(equalTo(prefix + "2:f1,3:f22"), equalTo(prefix + "3:f22,2:f1")));
+  }
+
+  // -------------------------------------------------------------------- subkeyspaceitem (flag I)
+
+  @Test
+  public void subkeyspaceitem_singleHashField() throws InterruptedException {
+    String hashKey = "subkeyspaceitem-basic-" + System.nanoTime();
+    String field = "fld";
+    String channel = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\n" + field;
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, field, "v1");
+
+    Notification n = pubSub.expectMessageOn(channel);
+    assertThat(n.pattern, nullValue());
+    assertThat(n.message, equalTo("hset"));
+  }
+
+  @Test
+  public void subkeyspaceitem_filtersToTargetFieldOnly() throws InterruptedException {
+    String hashKey = "subkeyspaceitem-filter-" + System.nanoTime();
+    String targetChannel = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\nf2";
+    subscribeChannels(targetChannel);
+
+    jedis.hset(hashKey, "f1", "v1");
+    jedis.hset(hashKey, "f2", "v2");
+    jedis.hset(hashKey, "f3", "v3");
+
+    Notification n = pubSub.expectMessageOn(targetChannel);
+    assertThat(n.message, equalTo("hset"));
+    assertThat(n.pattern, nullValue());
+
+    pubSub.expectNoMessageOn(targetChannel, 250, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  public void subkeyspaceitem_multipleFieldsEmitOneEventPerField() throws InterruptedException {
+    String hashKey = "subkeyspaceitem-multi-" + System.nanoTime();
+    String pattern = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\n*";
+    String channelF1 = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\nf1";
+    String channelF22 = CHANNEL_PREFIX_SUBKEYSPACEITEM + hashKey + "\nf22";
+    subscribePatterns(pattern);
+
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("f1", "v1");
+    fields.put("f22", "v2");
+    jedis.hset(hashKey, fields);
+
+    Notification n1 = pubSub.expectMessageOn(channelF1);
+    Notification n2 = pubSub.expectMessageOn(channelF22);
+    assertThat(n1.message, equalTo("hset"));
+    assertThat(n2.message, equalTo("hset"));
+    assertThat(n1.pattern, equalTo(pattern));
+    assertThat(n2.pattern, equalTo(pattern));
+  }
+
+  // -------------------------------------------------------------------- subkeyspaceevent (flag V)
+
+  @Test
+  public void subkeyspaceevent_singleHashField() throws InterruptedException {
+    String hashKey = "subkeyspaceevent-basic-" + System.nanoTime();
+    String channel = CHANNEL_PREFIX_SUBKEYSPACEEVENT + "hset|" + hashKey;
+    subscribeChannels(channel);
+
+    jedis.hset(hashKey, "fld", "v1");
+
+    Notification n = pubSub.expectMessageOn(channel);
+    assertThat(n.pattern, nullValue());
+    assertThat(n.message, equalTo("3:fld"));
+  }
+
+  @Test
+  public void subkeyspaceevent_multipleFields() throws InterruptedException {
+    String hashKey = "subkeyspaceevent-multi-" + System.nanoTime();
+    String channel = CHANNEL_PREFIX_SUBKEYSPACEEVENT + "hset|" + hashKey;
+    subscribeChannels(channel);
+
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("f1", "v1");
+    fields.put("f22", "v2");
+    jedis.hset(hashKey, fields);
+
+    Notification n = pubSub.expectMessageOn(channel);
+    assertThat(n.pattern, nullValue());
+    assertThat(n.message, anyOf(equalTo("2:f1,3:f22"), equalTo("3:f22,2:f1")));
+  }
+
+  // -------------------------------------------------------------------- helpers
+
+  private void subscribeChannels(String... channels) throws InterruptedException {
+    pubSub = new CapturingPubSub();
+    subscriber = createTestClient();
+    subscriberThread = new Thread(() -> subscriber.subscribe(pubSub, channels),
+        "subkey-uj-sub-" + System.nanoTime());
+    subscriberThread.setDaemon(true);
+    subscriberThread.start();
+    PubSubHelpers.awaitSubscribed(pubSub.subscribed);
+  }
+
+  private void subscribePatterns(String... patterns) throws InterruptedException {
+    pubSub = new CapturingPubSub();
+    subscriber = createTestClient();
+    subscriberThread = new Thread(() -> subscriber.psubscribe(pubSub, patterns),
+        "subkey-uj-psub-" + System.nanoTime());
+    subscriberThread.setDaemon(true);
+    subscriberThread.start();
+    PubSubHelpers.awaitSubscribed(pubSub.subscribed);
+  }
+}

--- a/src/test/java/redis/clients/jedis/commands/unified/SubkeyNotificationsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/SubkeyNotificationsTestBase.java
@@ -46,7 +46,7 @@ public abstract class SubkeyNotificationsTestBase extends UnifiedJedisCommandsTe
   @BeforeEach
   public void enableSubkeyNotifications() {
     try (Jedis control = new Jedis(endpoint.getHostAndPort(),
-        endpoint.getClientConfigBuilder().build())) {
+        endpoint.getClientConfigBuilder().autoNegotiateProtocol(false).build())) {
       Map<String, String> current = control.configGet("notify-keyspace-events");
       originalNotifyConfig = current.getOrDefault("notify-keyspace-events", "");
     }

--- a/src/test/java/redis/clients/jedis/commands/unified/client/RedisClientSubkeyNotificationsBinaryIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/client/RedisClientSubkeyNotificationsBinaryIntegrationTest.java
@@ -1,0 +1,29 @@
+package redis.clients.jedis.commands.unified.client;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.commands.unified.SubkeyNotificationsBinaryTestBase;
+
+@ParameterizedClass
+@MethodSource("redis.clients.jedis.commands.CommandsTestsParameters#respVersions")
+public class RedisClientSubkeyNotificationsBinaryIntegrationTest
+    extends SubkeyNotificationsBinaryTestBase {
+
+  public RedisClientSubkeyNotificationsBinaryIntegrationTest(RedisProtocol protocol) {
+    super(protocol);
+  }
+
+  @Override
+  protected UnifiedJedis createTestClient() {
+    return RedisClientCommandsTestHelper.getClient(protocol);
+  }
+
+  @BeforeEach
+  public void setUp() {
+    RedisClientCommandsTestHelper.clearData();
+  }
+}

--- a/src/test/java/redis/clients/jedis/commands/unified/client/RedisClientSubkeyNotificationsIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/client/RedisClientSubkeyNotificationsIntegrationTest.java
@@ -1,0 +1,28 @@
+package redis.clients.jedis.commands.unified.client;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.commands.unified.SubkeyNotificationsTestBase;
+
+@ParameterizedClass
+@MethodSource("redis.clients.jedis.commands.CommandsTestsParameters#respVersions")
+public class RedisClientSubkeyNotificationsIntegrationTest extends SubkeyNotificationsTestBase {
+
+  public RedisClientSubkeyNotificationsIntegrationTest(RedisProtocol protocol) {
+    super(protocol);
+  }
+
+  @Override
+  protected UnifiedJedis createTestClient() {
+    return RedisClientCommandsTestHelper.getClient(protocol);
+  }
+
+  @BeforeEach
+  public void setUp() {
+    RedisClientCommandsTestHelper.clearData();
+  }
+}

--- a/src/test/java/redis/clients/jedis/util/PubSubHelpers.java
+++ b/src/test/java/redis/clients/jedis/util/PubSubHelpers.java
@@ -1,0 +1,159 @@
+package redis.clients.jedis.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import redis.clients.jedis.BinaryJedisPubSub;
+import redis.clients.jedis.JedisPubSub;
+
+/** Test utilities for asserting on Pub/Sub notifications. */
+public final class PubSubHelpers {
+
+  public static final long DEFAULT_AWAIT_MILLIS = 5_000L;
+
+  private static final long SUBSCRIBED_AWAIT_SECONDS = 5L;
+
+  private PubSubHelpers() {
+  }
+
+  /** Asserts that the subscriber became active within 5 seconds. */
+  public static void awaitSubscribed(CountDownLatch subscribed) throws InterruptedException {
+    assertThat("subscriber did not become active",
+      subscribed.await(SUBSCRIBED_AWAIT_SECONDS, TimeUnit.SECONDS), equalTo(true));
+  }
+
+  public static byte[] concat(byte[]... parts) {
+    int total = 0;
+    for (byte[] p : parts)
+      total += p.length;
+    byte[] out = new byte[total];
+    int off = 0;
+    for (byte[] p : parts) {
+      System.arraycopy(p, 0, out, off, p.length);
+      off += p.length;
+    }
+    return out;
+  }
+
+  public static final class Notification {
+    public final String pattern;
+    public final String channel;
+    public final String message;
+
+    public Notification(String pattern, String channel, String message) {
+      this.pattern = pattern;
+      this.channel = channel;
+      this.message = message;
+    }
+  }
+
+  /** Routes each received message into a per-channel queue. */
+  public static final class CapturingPubSub extends JedisPubSub {
+
+    private final ConcurrentMap<String, BlockingQueue<Notification>> byChannel = new ConcurrentHashMap<>();
+    public final CountDownLatch subscribed = new CountDownLatch(1);
+
+    @Override
+    public void onSubscribe(String channel, int subscribedChannels) {
+      subscribed.countDown();
+    }
+
+    @Override
+    public void onPSubscribe(String pattern, int subscribedChannels) {
+      subscribed.countDown();
+    }
+
+    @Override
+    public void onMessage(String channel, String message) {
+      queueFor(channel).add(new Notification(null, channel, message));
+    }
+
+    @Override
+    public void onPMessage(String pattern, String channel, String message) {
+      queueFor(channel).add(new Notification(pattern, channel, message));
+    }
+
+    private BlockingQueue<Notification> queueFor(String channel) {
+      return byChannel.computeIfAbsent(channel, k -> new LinkedBlockingQueue<>());
+    }
+
+    public Notification expectMessageOn(String channel) throws InterruptedException {
+      return expectMessageOn(channel, DEFAULT_AWAIT_MILLIS);
+    }
+
+    public Notification expectMessageOn(String channel, long timeoutMillis)
+        throws InterruptedException {
+      Notification n = queueFor(channel).poll(timeoutMillis, TimeUnit.MILLISECONDS);
+      if (n == null)
+        throw new AssertionError("did not receive notification on channel: " + channel);
+      return n;
+    }
+
+    public void expectNoMessageOn(String channel, long timeout, TimeUnit unit)
+        throws InterruptedException {
+      Notification n = queueFor(channel).poll(timeout, unit);
+      if (n != null) {
+        throw new AssertionError(
+            "expected no message on channel '" + channel + "' but received: " + n.message);
+      }
+    }
+  }
+
+  /** Routes each received message into a per-channel queue (binary overload). */
+  public static final class CapturingBinaryPubSub extends BinaryJedisPubSub {
+
+    private final ConcurrentMap<ByteBuffer, BlockingQueue<byte[]>> byChannel = new ConcurrentHashMap<>();
+    public final CountDownLatch subscribed = new CountDownLatch(1);
+
+    @Override
+    public void onSubscribe(byte[] channel, int subscribedChannels) {
+      subscribed.countDown();
+    }
+
+    @Override
+    public void onPSubscribe(byte[] pattern, int subscribedChannels) {
+      subscribed.countDown();
+    }
+
+    @Override
+    public void onMessage(byte[] channel, byte[] message) {
+      queueFor(channel).add(message);
+    }
+
+    @Override
+    public void onPMessage(byte[] pattern, byte[] channel, byte[] message) {
+      queueFor(channel).add(message);
+    }
+
+    private BlockingQueue<byte[]> queueFor(byte[] channel) {
+      return byChannel.computeIfAbsent(ByteBuffer.wrap(channel), k -> new LinkedBlockingQueue<>());
+    }
+
+    public byte[] expectMessageOn(byte[] channel) throws InterruptedException {
+      return expectMessageOn(channel, DEFAULT_AWAIT_MILLIS);
+    }
+
+    public byte[] expectMessageOn(byte[] channel, long timeoutMillis) throws InterruptedException {
+      byte[] msg = queueFor(channel).poll(timeoutMillis, TimeUnit.MILLISECONDS);
+      if (msg == null) throw new AssertionError("did not receive notification on expected channel");
+      return msg;
+    }
+
+    public void expectNoMessageOn(byte[] channel, long timeout, TimeUnit unit)
+        throws InterruptedException {
+      byte[] msg = queueFor(channel).poll(timeout, unit);
+      if (msg != null) {
+        throw new AssertionError(
+            "expected no message on the given channel but received " + msg.length + " bytes");
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds integration coverage for the new `S`, `T`, `I`, `V` `notify-keyspace-events`
flags introduced in Redis 8.8. No production code changes.

## What's covered

Four new channel families, exercised against `Jedis` and `UnifiedJedis`
(`RedisClient`), in both string and binary modes, across RESP2 and RESP3:

| Flag | Channel family             | Payload format          |
|------|----------------------------|-------------------------|
| `S`  | `__subkeyspace@0__:<key>`         | `<cmd>\|<len>:<field>`        |
| `T`  | `__subkeyevent@0__:<cmd>`         | `<klen>:<key>\|<flen>:<field>` |
| `I`  | `__subkeyspaceitem@0__:<key>\n<field>` | `<cmd>`                  |
| `V`  | `__subkeyspaceevent@0__:<cmd>\|<key>` | `<len>:<field>`            |

Each family is tested for: single field, multi-field (order-tolerant via
`anyOf`), `psubscribe` patterns, and exact-match channel routing. The binary
suite asserts byte-perfect round-trips with `|`, `\n` and non-UTF-8 bytes in
keys/fields/channels.

Tests skip cleanly via `Assumptions.abort` when the server rejects the `STIV`
flags, keeping the suite green on pre-8.8 servers.

## Files

- `src/test/java/redis/clients/jedis/util/PubSubHelpers.java` — capturing
  `JedisPubSub` / `BinaryJedisPubSub` with per-channel `BlockingQueue`s and
  `expectMessageOn` / `expectNoMessageOn` assertions.
- `commands/jedis/SubkeyNotifications{,Binary}IntegrationTest.java` —
  parameterized over RESP2/RESP3.
- `commands/unified/SubkeyNotifications{,Binary}TestBase.java` +
  `commands/unified/client/RedisClient*` concretes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are isolated to test code and build formatting config, with the main risk being increased integration-test flakiness due to added Pub/Sub timing/threading and explicit protocol negotiation settings.
> 
> **Overview**
> Adds new integration coverage for Redis 8.8 *subkey notification* Pub/Sub channels (flags `S`, `T`, `I`, `V`) for both `Jedis` and `UnifiedJedis` (`RedisClient`) clients, including binary byte-perfect assertions for tricky keys/fields (pipes, newlines, non-UTF8 bytes).
> 
> Introduces `PubSubHelpers` test utility to capture per-channel notifications (string and binary) with `expectMessageOn`/`expectNoMessageOn`, and updates `JedisCommandsTestBase` to set `autoNegotiateProtocol(false)` so tests run deterministically against the parameterized RESP version. Also updates `pom.xml` formatter includes to cover the new `*SubkeyNotifications*` tests and `PubSubHelpers`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 435198fe763a8dfa49ad9be39a3f9137c2bcfd78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->