### PR TITLE
fix Maven argument parsing on Windows, add OS matrix

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,7 +22,11 @@ on:
 jobs:
   unit-tests:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -50,11 +54,11 @@ jobs:
 
       - name: Run Unit Tests
         run: |
-          mvn -B -Dwith-param-names=true clean test jacoco:report -Djacoco.dataFile=target/jacoco-ut.exec
+           mvn -B "-Dwith-param-names=true" clean test jacoco:report "-Djacoco.dataFile=target/jacoco-ut.exec"
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always() && github.actor != 'dependabot[bot]'
+        if: always() && github.actor != 'dependabot[bot]' && runner.os == 'Linux'
         with:
           files: |
             target/surefire-reports/**/*.xml


### PR DESCRIPTION
## What is the purpose of this PR

Add Windows to the CI build matrix. Currently the workflow only runs on Ubuntu.

## Expected results

- Ubuntu: passes 
- Windows: Maven build and all unit tests pass.

## Actual results

Running the workflow on Windows without fixes produces two errors:

**Maven argument parsing:** PowerShell splits unquoted `-D` arguments at the `=` sign, causing Maven to receive `.dataFile=target/jacoco-ut.exec` as an unknown lifecycle phase instead of a property definition.

**Docker action:** `EnricoMi/publish-unit-test-result-action@v2` is a Docker container action, which GitHub Actions only supports on Linux runners.

**Note on macOS:** macOS was not included in this PR because the workflow uses Java 8 with the Temurin distribution, and GitHub's macOS-latest runners (Apple Silicon/ARM) do not have Temurin Java 8 builds available. The `setup-java` step fails with "Could not find satisfied version for SemVer '8'". This is a GitHub Actions infrastructure limitation, not a jedis issue.

## Description of fix

1. Added `windows-latest` to the OS build matrix.
2. Wrapped Maven `-D` arguments in double quotes so PowerShell treats them as single strings.
3. Added `runner.os == 'Linux'` condition to the Publish Test Results step to skip it on Windows.