### PR TITLE
CommandObjects refactoring Part 2: remove protocol setter and make protocol ummutable

### DIFF
--- a/src/main/java/redis/clients/jedis/AbstractTransaction.java
+++ b/src/main/java/redis/clients/jedis/AbstractTransaction.java
@@ -5,11 +5,6 @@ import java.util.List;
 
 public abstract class AbstractTransaction extends PipeliningBase implements Closeable {
 
-  @Deprecated
-  protected AbstractTransaction() {
-    super(new CommandObjects());
-  }
-
   protected AbstractTransaction(CommandObjects commandObjects) {
     super(commandObjects);
   }

--- a/src/main/java/redis/clients/jedis/ClusterCommandObjects.java
+++ b/src/main/java/redis/clients/jedis/ClusterCommandObjects.java
@@ -22,10 +22,6 @@ public class ClusterCommandObjects extends CommandObjects {
 
   private static final String CLUSTER_UNSUPPORTED_MESSAGE = "Not supported in cluster mode.";
 
- // TODO: Remove together with setProtocol
-  public ClusterCommandObjects() {
-  }
-
   public ClusterCommandObjects(RedisProtocol protocol) {
     super(protocol);
   }

--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -38,19 +38,10 @@ import redis.clients.jedis.util.CompareCondition;
 
 public class CommandObjects {
 
-  private RedisProtocol protocol;
-
-  // TODO: Remove together with setProtocol
-  public CommandObjects() {
-  }
+  private final RedisProtocol protocol;
 
   public CommandObjects(RedisProtocol protocol) {
     this.protocol = protocol;
-  }
-
-  // TODO: restrict?
-  public final void setProtocol(RedisProtocol proto) {
-    this.protocol = proto;
   }
 
   // TODO: remove?

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -98,6 +98,8 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   private static final Logger logger = LoggerFactory.getLogger(Jedis.class);
 
+  private static final RedisProtocol REDIS_SERVER_DEFAULT_PROTO = RedisProtocol.RESP2;
+
   protected final Connection connection;
   private final CommandObjects commandObjects;
   private int db = 0;
@@ -130,7 +132,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   public Jedis() {
     connection = new Connection();
-    commandObjects = new CommandObjects(RedisProtocol.RESP2);
+    commandObjects = new CommandObjects(REDIS_SERVER_DEFAULT_PROTO);
   }
 
   /**
@@ -144,12 +146,12 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   public Jedis(final HostAndPort hp) {
     connection = new Connection(hp);
-    commandObjects = new CommandObjects(RedisProtocol.RESP2);
+    commandObjects = new CommandObjects(REDIS_SERVER_DEFAULT_PROTO);
   }
 
   public Jedis(final String host, final int port) {
     connection = new Connection(host, port);
-    commandObjects = new CommandObjects(RedisProtocol.RESP2);
+    commandObjects = new CommandObjects(REDIS_SERVER_DEFAULT_PROTO);
   }
 
   public Jedis(final String host, final int port, final JedisClientConfig config) {
@@ -160,7 +162,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
     JedisClientConfig effective = sanitize(config);
     connection = new Connection(hostPort, effective);
     RedisProtocol proto = effective.getRedisProtocol();
-    commandObjects = new CommandObjects(proto != null ? proto : RedisProtocol.RESP2);
+    commandObjects = new CommandObjects(proto != null ? proto : REDIS_SERVER_DEFAULT_PROTO);
   }
 
   public Jedis(final String host, final int port, final boolean ssl) {
@@ -240,7 +242,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
             .password(JedisURIHelper.getPassword(uri)).database(JedisURIHelper.getDBIndex(uri))
             .protocol(JedisURIHelper.getRedisProtocol(uri))
             .ssl(JedisURIHelper.isRedisSSLScheme(uri)).build());
-    commandObjects = new CommandObjects(RedisProtocol.RESP2);
+    commandObjects = new CommandObjects(REDIS_SERVER_DEFAULT_PROTO);
   }
 
   public Jedis(URI uri, final SSLSocketFactory sslSocketFactory,
@@ -310,24 +312,24 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
             .sslParameters(effective.getSslParameters()).hostnameVerifier(effective.getHostnameVerifier())
             .build());
     RedisProtocol proto = effective.getRedisProtocol();
-    commandObjects = new CommandObjects(proto != null ? proto : RedisProtocol.RESP2);
+    commandObjects = new CommandObjects(proto != null ? proto : REDIS_SERVER_DEFAULT_PROTO);
   }
 
   public Jedis(final JedisSocketFactory jedisSocketFactory) {
     connection = new Connection(jedisSocketFactory);
-    commandObjects = new CommandObjects(RedisProtocol.RESP2);
+    commandObjects = new CommandObjects(REDIS_SERVER_DEFAULT_PROTO);
   }
 
   public Jedis(final JedisSocketFactory jedisSocketFactory, final JedisClientConfig clientConfig) {
     JedisClientConfig effective = sanitize(clientConfig);
     connection = new Connection(jedisSocketFactory, effective);
     RedisProtocol proto = effective.getRedisProtocol();
-    commandObjects = new CommandObjects(proto != null ? proto : RedisProtocol.RESP2);
+    commandObjects = new CommandObjects(proto != null ? proto : REDIS_SERVER_DEFAULT_PROTO);
   }
 
   public Jedis(final Connection connection) {
     this.connection = connection;
-    this.commandObjects = new CommandObjects(RedisProtocol.RESP2);
+    this.commandObjects = new CommandObjects(REDIS_SERVER_DEFAULT_PROTO);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -99,7 +99,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   private static final Logger logger = LoggerFactory.getLogger(Jedis.class);
 
   protected final Connection connection;
-  private final CommandObjects commandObjects = new CommandObjects();
+  private final CommandObjects commandObjects;
   private int db = 0;
   private Transaction transaction = null;
   private boolean isInMulti = false;
@@ -130,6 +130,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   public Jedis() {
     connection = new Connection();
+    commandObjects = new CommandObjects(RedisProtocol.RESP2);
   }
 
   /**
@@ -143,10 +144,12 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   public Jedis(final HostAndPort hp) {
     connection = new Connection(hp);
+    commandObjects = new CommandObjects(RedisProtocol.RESP2);
   }
 
   public Jedis(final String host, final int port) {
     connection = new Connection(host, port);
+    commandObjects = new CommandObjects(RedisProtocol.RESP2);
   }
 
   public Jedis(final String host, final int port, final JedisClientConfig config) {
@@ -157,7 +160,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
     JedisClientConfig effective = sanitize(config);
     connection = new Connection(hostPort, effective);
     RedisProtocol proto = effective.getRedisProtocol();
-    if (proto != null) commandObjects.setProtocol(proto);
+    commandObjects = new CommandObjects(proto != null ? proto : RedisProtocol.RESP2);
   }
 
   public Jedis(final String host, final int port, final boolean ssl) {
@@ -237,6 +240,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
             .password(JedisURIHelper.getPassword(uri)).database(JedisURIHelper.getDBIndex(uri))
             .protocol(JedisURIHelper.getRedisProtocol(uri))
             .ssl(JedisURIHelper.isRedisSSLScheme(uri)).build());
+    commandObjects = new CommandObjects(RedisProtocol.RESP2);
   }
 
   public Jedis(URI uri, final SSLSocketFactory sslSocketFactory,
@@ -306,22 +310,24 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
             .sslParameters(effective.getSslParameters()).hostnameVerifier(effective.getHostnameVerifier())
             .build());
     RedisProtocol proto = effective.getRedisProtocol();
-    if (proto != null) commandObjects.setProtocol(proto);
+    commandObjects = new CommandObjects(proto != null ? proto : RedisProtocol.RESP2);
   }
 
   public Jedis(final JedisSocketFactory jedisSocketFactory) {
     connection = new Connection(jedisSocketFactory);
+    commandObjects = new CommandObjects(RedisProtocol.RESP2);
   }
 
   public Jedis(final JedisSocketFactory jedisSocketFactory, final JedisClientConfig clientConfig) {
     JedisClientConfig effective = sanitize(clientConfig);
     connection = new Connection(jedisSocketFactory, effective);
     RedisProtocol proto = effective.getRedisProtocol();
-    if (proto != null) commandObjects.setProtocol(proto);
+    commandObjects = new CommandObjects(proto != null ? proto : RedisProtocol.RESP2);
   }
 
   public Jedis(final Connection connection) {
     this.connection = connection;
+    this.commandObjects = new CommandObjects(RedisProtocol.RESP2);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -7,7 +7,6 @@ import java.util.Set;
 import org.json.JSONArray;
 
 import redis.clients.jedis.annots.Experimental;
-import redis.clients.jedis.annots.VisibleForTesting;
 import redis.clients.jedis.args.*;
 import redis.clients.jedis.bloom.*;
 import redis.clients.jedis.commands.JedisCommands;
@@ -91,31 +90,6 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   public UnifiedJedis(ConnectionProvider provider, int maxAttempts, Duration maxTotalRetriesDuration) {
     this(new RetryableCommandExecutor(provider, maxAttempts, maxTotalRetriesDuration), provider,
         (RedisProtocol) null, null);
-  }
-
-  /**
-   * Test-only ctor that accepts a pre-built {@link CommandObjects}. The protocol stored on the
-   * supplied object is overridden by probing the provider.
-   * @deprecated
-   */
-  @VisibleForTesting
-  @Deprecated
-  protected UnifiedJedis(CommandExecutor executor, ConnectionProvider provider, CommandObjects commandObjects) {
-    this.provider = provider;
-    this.executor = executor;
-    this.commandObjects = commandObjects;
-    this.cache = null;
-    if (this.provider != null) {
-      try (Connection conn = this.provider.getConnection()) {
-        if (conn != null) {
-          RedisProtocol resolved = conn.getRedisProtocol();
-          if (resolved != null) {
-            this.commandObjects.setProtocol(resolved);
-          }
-        }
-      } catch (JedisException je) {
-      }
-    }
   }
 
   /**

--- a/src/main/java/redis/clients/jedis/mcf/MultiDbPipeline.java
+++ b/src/main/java/redis/clients/jedis/mcf/MultiDbPipeline.java
@@ -19,18 +19,6 @@ public class MultiDbPipeline extends AbstractPipeline implements Closeable {
   private final MultiDbConnectionSupplier failoverProvider;
   private final Queue<KeyValue<CommandArguments, Response<?>>> commands = new LinkedList<>();
 
-  @Deprecated
-  public MultiDbPipeline(MultiDbConnectionProvider pooledProvider) {
-    super(new CommandObjects());
-
-    this.failoverProvider = new MultiDbConnectionSupplier(pooledProvider);
-
-    try (Connection connection = failoverProvider.getConnection()) {
-      RedisProtocol proto = connection.getRedisProtocol();
-      if (proto != null) this.commandObjects.setProtocol(proto);
-    }
-  }
-
   public MultiDbPipeline(MultiDbConnectionProvider pooledProvider, CommandObjects commandObjects) {
     super(commandObjects);
     this.failoverProvider = new MultiDbConnectionSupplier(pooledProvider);

--- a/src/main/java/redis/clients/jedis/mcf/MultiDbTransaction.java
+++ b/src/main/java/redis/clients/jedis/mcf/MultiDbTransaction.java
@@ -32,34 +32,6 @@ public class MultiDbTransaction extends AbstractTransaction {
   private boolean inMulti = false;
 
   /**
-   * A MULTI command will be added to be sent to server. WATCH/UNWATCH/MULTI commands must not be
-   * called with this object.
-   * @param provider
-   */
-  @Deprecated
-  public MultiDbTransaction(MultiDbConnectionProvider provider) {
-    this(provider, true);
-  }
-
-  /**
-   * A user wanting to WATCH/UNWATCH keys followed by a call to MULTI ({@link #multi()}) it should
-   * be {@code doMulti=false}.
-   * @param provider
-   * @param doMulti {@code false} should be set to enable manual WATCH, UNWATCH and MULTI
-   */
-  @Deprecated
-  public MultiDbTransaction(MultiDbConnectionProvider provider, boolean doMulti) {
-    this.failoverProvider = new MultiDbConnectionSupplier(provider);
-
-    try (Connection connection = failoverProvider.getConnection()) {
-      RedisProtocol proto = connection.getRedisProtocol();
-      if (proto != null) this.commandObjects.setProtocol(proto);
-    }
-
-    if (doMulti) multi();
-  }
-
-  /**
    * A user wanting to WATCH/UNWATCH keys followed by a call to MULTI ({@link #multi()}) it should
    * be {@code doMulti=false}.
    * @param provider

--- a/src/test/java/redis/clients/jedis/ClusterCommandObjectsTest.java
+++ b/src/test/java/redis/clients/jedis/ClusterCommandObjectsTest.java
@@ -27,7 +27,7 @@ public class ClusterCommandObjectsTest {
 
   @BeforeEach
   public void setUp() {
-    clusterCommandObjects = new ClusterCommandObjects();
+    clusterCommandObjects = new ClusterCommandObjects(RedisProtocol.RESP2);
   }
 
   @Test
@@ -472,7 +472,7 @@ public class ClusterCommandObjectsTest {
   @Test
   public void testGroupArgumentsByKeyHashSlot_withKeyPreProcessor_usesPreprocessedSlot() {
     // Create ClusterCommandObjects with a key preprocessor that adds a hash tag prefix
-    ClusterCommandObjects clusterCmdObjects = new ClusterCommandObjects();
+    ClusterCommandObjects clusterCmdObjects = new ClusterCommandObjects(RedisProtocol.RESP2);
     // The prefix "{sameSlot}:" ensures all keys hash to the same slot
     clusterCmdObjects.setKeyArgumentPreProcessor(
       new redis.clients.jedis.util.PrefixedKeyArgumentPreProcessor("{sameSlot}:"));
@@ -519,7 +519,7 @@ public class ClusterCommandObjectsTest {
    */
   @Test
   public void testGroupArgumentsByKeyValueHashSlot_withKeyPreProcessor_usesPreprocessedSlot() {
-    ClusterCommandObjects clusterCmdObjects = new ClusterCommandObjects();
+    ClusterCommandObjects clusterCmdObjects = new ClusterCommandObjects(RedisProtocol.RESP2);
     clusterCmdObjects.setKeyArgumentPreProcessor(
       new redis.clients.jedis.util.PrefixedKeyArgumentPreProcessor("{sameSlot}:"));
 
@@ -557,7 +557,7 @@ public class ClusterCommandObjectsTest {
    */
   @Test
   public void testGroupArgumentsByKeyHashSlot_withKeyPreProcessor_differentSlotsAfterPreprocess() {
-    ClusterCommandObjects clusterCmdObjects = new ClusterCommandObjects();
+    ClusterCommandObjects clusterCmdObjects = new ClusterCommandObjects(RedisProtocol.RESP2);
     // This preprocessor changes the hash tag, causing keys to hash to different slots
     clusterCmdObjects.setKeyArgumentPreProcessor(key -> {
       String keyStr = (String) key;
@@ -594,7 +594,7 @@ public class ClusterCommandObjectsTest {
    */
   @Test
   public void testGroupArgumentsByKeyHashSlot_withKeyPreProcessor_binaryKeys() {
-    ClusterCommandObjects clusterCmdObjects = new ClusterCommandObjects();
+    ClusterCommandObjects clusterCmdObjects = new ClusterCommandObjects(RedisProtocol.RESP2);
     clusterCmdObjects.setKeyArgumentPreProcessor(
       new redis.clients.jedis.util.PrefixedKeyArgumentPreProcessor("{sameSlot}:"));
 

--- a/src/test/java/redis/clients/jedis/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/PipeliningTest.java
@@ -700,7 +700,7 @@ public class PipeliningTest extends JedisCommandsTestBase {
   @Test
   public void errorInTheMiddle() {
     CommandObject<String> invalidCommand =
-        new CommandObject<>(new CommandObjects().commandArguments(Foo.FOO), BuilderFactory.STRING);
+        new CommandObject<>(new CommandObjects(RedisProtocol.RESP2).commandArguments(Foo.FOO), BuilderFactory.STRING);
 
     Pipeline p = jedis.pipelined();
 

--- a/src/test/java/redis/clients/jedis/TransactionV2Test.java
+++ b/src/test/java/redis/clients/jedis/TransactionV2Test.java
@@ -246,7 +246,7 @@ public class TransactionV2Test {
     // A command may fail to be queued, so there may be an error before EXEC is called.
     // For instance the command may be syntactically wrong (wrong number of arguments, wrong command name, ...)
     CommandObject<String> invalidCommand =
-        new CommandObject<>(new CommandObjects().commandArguments(SET), BuilderFactory.STRING);
+        new CommandObject<>(new CommandObjects(RedisProtocol.RESP2).commandArguments(SET), BuilderFactory.STRING);
 
     Transaction t = new Transaction(conn);
     t.appendCommand(invalidCommand);

--- a/src/test/java/redis/clients/jedis/UnboundRedisClusterClientTest.java
+++ b/src/test/java/redis/clients/jedis/UnboundRedisClusterClientTest.java
@@ -256,7 +256,7 @@ public class UnboundRedisClusterClientTest extends UnboundRedisClusterClientTest
 
     DefaultJedisClientConfig READ_REPLICAS_CLIENT_CONFIG = DefaultJedisClientConfig.builder()
         .password(endpoint.getPassword()).readOnlyForRedisClusterReplicas().build();
-    ClusterCommandObjects commandObjects = new ClusterCommandObjects();
+    ClusterCommandObjects commandObjects = new ClusterCommandObjects(RedisProtocol.RESP2);
     try (RedisClusterClient jedisCluster = RedisClusterClient.builder()
         .nodes(Collections.singleton(nodeInfo1))
         .clientConfig(READ_REPLICAS_CLIENT_CONFIG)

--- a/src/test/java/redis/clients/jedis/csc/ClientSideCacheFunctionalityTest.java
+++ b/src/test/java/redis/clients/jedis/csc/ClientSideCacheFunctionalityTest.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import redis.clients.jedis.CommandObjects;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.util.TestEnvUtil;
 
@@ -423,7 +424,7 @@ public class ClientSideCacheFunctionalityTest extends ClientSideCacheTestBase {
       Set<String> members1 = jedis.smembers("foo");
       Set<String> members2 = jedis.smembers("foo");
 
-      Set<String> fromMap = (Set<String>) cache.get(new CacheKey<>(new CommandObjects().smembers("foo"))).getValue();
+      Set<String> fromMap = (Set<String>) cache.get(new CacheKey<>(new CommandObjects(RedisProtocol.RESP3).smembers("foo"))).getValue();
       assertEquals(expected, members1);
       assertEquals(expected, members2);
       assertEquals(expected, fromMap);
@@ -602,17 +603,17 @@ public class ClientSideCacheFunctionalityTest extends ClientSideCacheTestBase {
 
       // check touched keys not evicted
       for (int i = touchOffset; i < touchOffset + expectedEvictions; i++) {
-        assertTrue(cache.hasCacheKey(new CacheKey(new CommandObjects().get("foo" + i))));
+        assertTrue(cache.hasCacheKey(new CacheKey(new CommandObjects(RedisProtocol.RESP3).get("foo" + i))));
       }
 
       // check expected evictions are done till the offset
       for (int i = 0; i < touchOffset; i++) {
-        assertTrue(!cache.hasCacheKey(new CacheKey(new CommandObjects().get("foo" + i))));
+        assertTrue(!cache.hasCacheKey(new CacheKey(new CommandObjects(RedisProtocol.RESP3).get("foo" + i))));
       }
 
       // check expected evictions are done after the touched keys
       for (int i = touchOffset + expectedEvictions; i < (2 * expectedEvictions); i++) {
-        assertFalse(cache.hasCacheKey(new CacheKey(new CommandObjects().get("foo" + i))));
+        assertFalse(cache.hasCacheKey(new CacheKey(new CommandObjects(RedisProtocol.RESP3).get("foo" + i))));
       }
 
       assertEquals(maxSize, cache.getSize());

--- a/src/test/java/redis/clients/jedis/executors/ClusterCommandExecutorTest.java
+++ b/src/test/java/redis/clients/jedis/executors/ClusterCommandExecutorTest.java
@@ -1241,7 +1241,7 @@ public class ClusterCommandExecutorTest {
     when(connectionHandler.getConnection(ArgumentMatchers.any(CommandArguments.class)))
         .thenReturn(connection);
 
-    ClusterCommandObjects commandObjects = new ClusterCommandObjects();
+    ClusterCommandObjects commandObjects = new ClusterCommandObjects(RedisProtocol.RESP2);
 
     // Try many different key combinations including ones where keys hash to different slots
     for (int i = 0; i < 100; i++) {
@@ -1336,7 +1336,7 @@ public class ClusterCommandExecutorTest {
       mockedStatic.when(() -> JedisClusterCRC16.getSlot(key2)).thenReturn(200);
       mockedStatic.when(() -> JedisClusterCRC16.getSlot(key3)).thenReturn(100);
 
-      ClusterCommandObjects commandObjects = new ClusterCommandObjects();
+      ClusterCommandObjects commandObjects = new ClusterCommandObjects(RedisProtocol.RESP2);
 
       // The fix should create 3 separate commands (not 2) to preserve order
       List<CommandObject<List<String>>> mgetCommands = commandObjects.mgetMultiShard(key1, key2,
@@ -1410,7 +1410,7 @@ public class ClusterCommandExecutorTest {
       mockedStatic.when(() -> JedisClusterCRC16.getSlot(key3)).thenReturn(200);
       mockedStatic.when(() -> JedisClusterCRC16.getSlot(key4)).thenReturn(200);
 
-      ClusterCommandObjects commandObjects = new ClusterCommandObjects();
+      ClusterCommandObjects commandObjects = new ClusterCommandObjects(RedisProtocol.RESP2);
 
       // Consecutive keys with the same slot should be combined into one command
       List<CommandObject<List<String>>> mgetCommands = commandObjects.mgetMultiShard(key1, key2,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core client command construction by making `RedisProtocol` immutable and changing how `CommandObjects` is instantiated across `Jedis`/cluster/multi-db flows, which could affect protocol selection at runtime. Risk is moderated by mostly-constructor-level refactoring plus updated tests, but mis-defaulting to RESP2/RESP3 could cause subtle behavior differences.
> 
> **Overview**
> Refactors `CommandObjects` to require a `RedisProtocol` at construction time (**protocol is now `final` and `setProtocol`/no-arg ctor are removed**), and deletes several deprecated constructors that previously created a protocol-less instance and later mutated it.
> 
> Updates `Jedis` and related cluster/multi-db transaction/pipeline entry points to always build `CommandObjects` with an explicit protocol (defaulting to `RESP2` when unspecified), removes a test-only `UnifiedJedis` constructor that probed connections to override protocol, and adjusts unit tests to pass explicit `RedisProtocol` values (including RESP3 where cache keys require it).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf34e06352346a47689935e61c7a5be8636b534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->