### PR TITLE
CommandObjects refactoring Part 3: Enforce protocol value and use RESP2 instead of the null value 

### DIFF
--- a/src/main/java/redis/clients/jedis/ClusterPipeline.java
+++ b/src/main/java/redis/clients/jedis/ClusterPipeline.java
@@ -123,7 +123,7 @@ public class ClusterPipeline extends MultiNodePipelineBase {
           // Protocol negotiation failed; fall back to RESP2 below.
         }
       }
-      return new ClusterCommandObjects(effective != null ? effective : RedisProtocol.RESP2);
+      return new ClusterCommandObjects(RedisProtocol.orServerDefault(effective));
     };
   }
 

--- a/src/main/java/redis/clients/jedis/ClusterPipeline.java
+++ b/src/main/java/redis/clients/jedis/ClusterPipeline.java
@@ -120,10 +120,10 @@ public class ClusterPipeline extends MultiNodePipelineBase {
             effective = resolved;
           }
         } catch (JedisException je) {
-          // Protocol negotiation failed, leave protocol=null on the command objects.
+          // Protocol negotiation failed; fall back to RESP2 below.
         }
       }
-      return new ClusterCommandObjects(effective);
+      return new ClusterCommandObjects(effective != null ? effective : RedisProtocol.RESP2);
     };
   }
 

--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -41,6 +41,13 @@ public class CommandObjects {
   private final RedisProtocol protocol;
 
   public CommandObjects(RedisProtocol protocol) {
+    this(protocol, null);
+  }
+
+  public CommandObjects(RedisProtocol protocol, CommandObjectsConfig config) {
+    if (protocol == null) {
+      throw new IllegalArgumentException("protocol must not be null");
+    }
     this.protocol = protocol;
   }
 
@@ -1203,7 +1210,7 @@ public class CommandObjects {
 
   public final CommandObject<List<Map.Entry<String, String>>> hrandfieldWithValues(String key, long count) {
     return new CommandObject<>(commandArguments(HRANDFIELD).key(key).add(count).add(WITHVALUES),
-        protocol != RedisProtocol.RESP3 ? BuilderFactory.STRING_PAIR_LIST : BuilderFactory.STRING_PAIR_LIST_FROM_PAIRS);
+        protocol == RedisProtocol.RESP2 ? BuilderFactory.STRING_PAIR_LIST : BuilderFactory.STRING_PAIR_LIST_FROM_PAIRS);
   }
 
   public final CommandObject<Map<byte[], byte[]>> hgetAll(byte[] key) {
@@ -1220,7 +1227,7 @@ public class CommandObjects {
 
   public final CommandObject<List<Map.Entry<byte[], byte[]>>> hrandfieldWithValues(byte[] key, long count) {
     return new CommandObject<>(commandArguments(HRANDFIELD).key(key).add(count).add(WITHVALUES),
-        protocol != RedisProtocol.RESP3 ? BuilderFactory.BINARY_PAIR_LIST : BuilderFactory.BINARY_PAIR_LIST_FROM_PAIRS);
+        protocol == RedisProtocol.RESP2 ? BuilderFactory.BINARY_PAIR_LIST : BuilderFactory.BINARY_PAIR_LIST_FROM_PAIRS);
   }
 
   public final CommandObject<ScanResult<Map.Entry<String, String>>> hscan(String key, String cursor, ScanParams params) {
@@ -3989,7 +3996,7 @@ public class CommandObjects {
 
   public final CommandObject<List<Class<?>>> jsonType(String key, Path2 path) {
     return new CommandObject<>(commandArguments(JsonCommand.TYPE).key(key).add(path),
-        protocol != RedisProtocol.RESP3 ? JsonBuilderFactory.JSON_TYPE_LIST : JsonBuilderFactory.JSON_TYPE_RESPONSE_RESP3_COMPATIBLE);
+        protocol == RedisProtocol.RESP2 ? JsonBuilderFactory.JSON_TYPE_LIST : JsonBuilderFactory.JSON_TYPE_RESPONSE_RESP3_COMPATIBLE);
   }
 
   @Deprecated

--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -41,10 +41,6 @@ public class CommandObjects {
   private final RedisProtocol protocol;
 
   public CommandObjects(RedisProtocol protocol) {
-    this(protocol, null);
-  }
-
-  public CommandObjects(RedisProtocol protocol, CommandObjectsConfig config) {
     if (protocol == null) {
       throw new IllegalArgumentException("protocol must not be null");
     }

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -98,8 +98,6 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   private static final Logger logger = LoggerFactory.getLogger(Jedis.class);
 
-  private static final RedisProtocol REDIS_SERVER_DEFAULT_PROTO = RedisProtocol.RESP2;
-
   protected final Connection connection;
   private final CommandObjects commandObjects;
   private int db = 0;
@@ -132,7 +130,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   public Jedis() {
     connection = new Connection();
-    commandObjects = new CommandObjects(REDIS_SERVER_DEFAULT_PROTO);
+    commandObjects = new CommandObjects(RedisProtocol.REDIS_SERVER_DEFAULT_PROTO);
   }
 
   /**
@@ -146,12 +144,12 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
 
   public Jedis(final HostAndPort hp) {
     connection = new Connection(hp);
-    commandObjects = new CommandObjects(REDIS_SERVER_DEFAULT_PROTO);
+    commandObjects = new CommandObjects(RedisProtocol.REDIS_SERVER_DEFAULT_PROTO);
   }
 
   public Jedis(final String host, final int port) {
     connection = new Connection(host, port);
-    commandObjects = new CommandObjects(REDIS_SERVER_DEFAULT_PROTO);
+    commandObjects = new CommandObjects(RedisProtocol.REDIS_SERVER_DEFAULT_PROTO);
   }
 
   public Jedis(final String host, final int port, final JedisClientConfig config) {
@@ -161,8 +159,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   public Jedis(final HostAndPort hostPort, final JedisClientConfig config) {
     JedisClientConfig effective = sanitize(config);
     connection = new Connection(hostPort, effective);
-    RedisProtocol proto = effective.getRedisProtocol();
-    commandObjects = new CommandObjects(proto != null ? proto : REDIS_SERVER_DEFAULT_PROTO);
+    commandObjects = new CommandObjects(RedisProtocol.orServerDefault(effective.getRedisProtocol()));
   }
 
   public Jedis(final String host, final int port, final boolean ssl) {
@@ -242,7 +239,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
             .password(JedisURIHelper.getPassword(uri)).database(JedisURIHelper.getDBIndex(uri))
             .protocol(JedisURIHelper.getRedisProtocol(uri))
             .ssl(JedisURIHelper.isRedisSSLScheme(uri)).build());
-    commandObjects = new CommandObjects(REDIS_SERVER_DEFAULT_PROTO);
+    commandObjects = new CommandObjects(RedisProtocol.REDIS_SERVER_DEFAULT_PROTO);
   }
 
   public Jedis(URI uri, final SSLSocketFactory sslSocketFactory,
@@ -311,25 +308,23 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
             .ssl(JedisURIHelper.isRedisSSLScheme(uri)).sslSocketFactory(effective.getSslSocketFactory())
             .sslParameters(effective.getSslParameters()).hostnameVerifier(effective.getHostnameVerifier())
             .build());
-    RedisProtocol proto = effective.getRedisProtocol();
-    commandObjects = new CommandObjects(proto != null ? proto : REDIS_SERVER_DEFAULT_PROTO);
+    commandObjects = new CommandObjects(RedisProtocol.orServerDefault(effective.getRedisProtocol()));
   }
 
   public Jedis(final JedisSocketFactory jedisSocketFactory) {
     connection = new Connection(jedisSocketFactory);
-    commandObjects = new CommandObjects(REDIS_SERVER_DEFAULT_PROTO);
+    commandObjects = new CommandObjects(RedisProtocol.REDIS_SERVER_DEFAULT_PROTO);
   }
 
   public Jedis(final JedisSocketFactory jedisSocketFactory, final JedisClientConfig clientConfig) {
     JedisClientConfig effective = sanitize(clientConfig);
     connection = new Connection(jedisSocketFactory, effective);
-    RedisProtocol proto = effective.getRedisProtocol();
-    commandObjects = new CommandObjects(proto != null ? proto : REDIS_SERVER_DEFAULT_PROTO);
+    commandObjects = new CommandObjects(RedisProtocol.orServerDefault(effective.getRedisProtocol()));
   }
 
   public Jedis(final Connection connection) {
     this.connection = connection;
-    this.commandObjects = new CommandObjects(REDIS_SERVER_DEFAULT_PROTO);
+    this.commandObjects = new CommandObjects(RedisProtocol.REDIS_SERVER_DEFAULT_PROTO);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/Pipeline.java
+++ b/src/main/java/redis/clients/jedis/Pipeline.java
@@ -32,8 +32,7 @@ public class Pipeline extends AbstractPipeline implements DatabasePipelineComman
   }
 
   private static CommandObjects createCommandObjects(Connection connection) {
-    RedisProtocol proto = connection.getRedisProtocol();
-    return new CommandObjects(proto != null ? proto : RedisProtocol.RESP2);
+    return new CommandObjects(RedisProtocol.orServerDefault(connection.getRedisProtocol()));
   }
 
   Pipeline(Connection connection, boolean closeConnection, CommandObjects commandObjects) {

--- a/src/main/java/redis/clients/jedis/Pipeline.java
+++ b/src/main/java/redis/clients/jedis/Pipeline.java
@@ -32,7 +32,8 @@ public class Pipeline extends AbstractPipeline implements DatabasePipelineComman
   }
 
   private static CommandObjects createCommandObjects(Connection connection) {
-    return new CommandObjects(connection.getRedisProtocol());
+    RedisProtocol proto = connection.getRedisProtocol();
+    return new CommandObjects(proto != null ? proto : RedisProtocol.RESP2);
   }
 
   Pipeline(Connection connection, boolean closeConnection, CommandObjects commandObjects) {

--- a/src/main/java/redis/clients/jedis/RedisProtocol.java
+++ b/src/main/java/redis/clients/jedis/RedisProtocol.java
@@ -23,6 +23,8 @@ public enum RedisProtocol {
   RESP2("2"),
   RESP3("3");
 
+  public static final RedisProtocol REDIS_SERVER_DEFAULT_PROTO = RESP2;
+
   private final String version;
 
   private RedisProtocol(String ver) {
@@ -44,5 +46,9 @@ public enum RedisProtocol {
     if (proto == 2) return RESP2;
     if (proto == 3) return RESP3;
     throw new IllegalArgumentException("Unknown protocol version: " + proto);
+  }
+
+  public static RedisProtocol orServerDefault(RedisProtocol proto) {
+    return (proto == null) ? REDIS_SERVER_DEFAULT_PROTO : proto;
   }
 }

--- a/src/main/java/redis/clients/jedis/ReliableTransaction.java
+++ b/src/main/java/redis/clients/jedis/ReliableTransaction.java
@@ -85,8 +85,7 @@ public class ReliableTransaction extends AbstractTransaction {
   }
 
   private static CommandObjects createCommandObjects(Connection connection) {
-    RedisProtocol proto = connection.getRedisProtocol();
-    return new CommandObjects(proto != null ? proto : RedisProtocol.RESP2);
+    return new CommandObjects(RedisProtocol.orServerDefault(connection.getRedisProtocol()));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/ReliableTransaction.java
+++ b/src/main/java/redis/clients/jedis/ReliableTransaction.java
@@ -85,7 +85,8 @@ public class ReliableTransaction extends AbstractTransaction {
   }
 
   private static CommandObjects createCommandObjects(Connection connection) {
-    return new CommandObjects(connection.getRedisProtocol());
+    RedisProtocol proto = connection.getRedisProtocol();
+    return new CommandObjects(proto != null ? proto : RedisProtocol.RESP2);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/Transaction.java
+++ b/src/main/java/redis/clients/jedis/Transaction.java
@@ -84,7 +84,8 @@ public class Transaction extends AbstractTransaction {
   }
 
   private static CommandObjects createCommandObjects(Connection connection) {
-    return new CommandObjects(connection.getRedisProtocol());
+    RedisProtocol proto = connection.getRedisProtocol();
+    return new CommandObjects(proto != null ? proto : RedisProtocol.RESP2);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/Transaction.java
+++ b/src/main/java/redis/clients/jedis/Transaction.java
@@ -84,8 +84,7 @@ public class Transaction extends AbstractTransaction {
   }
 
   private static CommandObjects createCommandObjects(Connection connection) {
-    RedisProtocol proto = connection.getRedisProtocol();
-    return new CommandObjects(proto != null ? proto : RedisProtocol.RESP2);
+    return new CommandObjects(RedisProtocol.orServerDefault(connection.getRedisProtocol()));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -74,7 +74,8 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   protected UnifiedJedis(Connection connection) {
     this.provider = null;
     this.executor = new SimpleCommandExecutor(connection);
-    this.commandObjects = newCommandObjects(connection.getRedisProtocol());
+    RedisProtocol proto = connection.getRedisProtocol();
+    this.commandObjects = newCommandObjects(proto != null ? proto : RedisProtocol.RESP2);
 
     if (connection instanceof CacheConnection) {
       this.cache = ((CacheConnection) connection).getCache();
@@ -124,7 +125,9 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
     // When the protocol is left unspecified, auto-negotiation may have resolved it to either
     // RESP2 or RESP3 on the wire. Probe a connection to learn the actual value so the command
-    // objects parse replies with the correct decoder.
+    // objects parse replies with the correct decoder. If the probe fails or the connection has
+    // not yet negotiated, fall back to RESP2 — matching the wire default and preserving lazy
+    // construction semantics.
     RedisProtocol resolvedProtocol = protocol;
     if (resolvedProtocol == null && provider != null) {
       try (Connection conn = provider.getConnection()) {
@@ -133,6 +136,9 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
         }
       } catch (JedisException ignored) {
       }
+    }
+    if (resolvedProtocol == null) {
+      resolvedProtocol = RedisProtocol.RESP2;
     }
 
     if (cache != null && resolvedProtocol != RedisProtocol.RESP3) {

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -74,8 +74,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   protected UnifiedJedis(Connection connection) {
     this.provider = null;
     this.executor = new SimpleCommandExecutor(connection);
-    RedisProtocol proto = connection.getRedisProtocol();
-    this.commandObjects = newCommandObjects(proto != null ? proto : RedisProtocol.RESP2);
+    this.commandObjects = newCommandObjects(RedisProtocol.orServerDefault(connection.getRedisProtocol()));
 
     if (connection instanceof CacheConnection) {
       this.cache = ((CacheConnection) connection).getCache();

--- a/src/test/java/redis/clients/jedis/commands/CommandsTestsParameters.java
+++ b/src/test/java/redis/clients/jedis/commands/CommandsTestsParameters.java
@@ -36,4 +36,14 @@ public class CommandsTestsParameters {
         new Object[] { RedisProtocol.RESP2 }, new Object[] { RedisProtocol.RESP3 });
   }
 
+  /**
+   * RESP protocol versions for {@link redis.clients.jedis.CommandObjects} tests. Only the strict
+   * (non-{@code null}) protocols are valid here — {@code CommandObjects} requires a concrete
+   * protocol at construction time, as it is meant to be used after auto-negotiation has already
+   * resolved a specific version.
+   */
+  public static Collection<Object[]> commandObjectsRespVersions() {
+    return Arrays.asList(new Object[] { RedisProtocol.RESP2 }, new Object[] { RedisProtocol.RESP3 });
+  }
+
 }

--- a/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsTestBase.java
@@ -27,13 +27,13 @@ import redis.clients.jedis.providers.PooledConnectionProvider;
  * on if a Redis Stack server is needed, or a standalone suffices.
  * <p>
  * In principle all subclasses of this class should be parameterized tests,
- * to run with several versions of RESP. {@link CommandsTestsParameters#jedisRespVersions}
- * The strict (non-{@code null}) RESP versions are the right fit here: CommandObjects receive a
- * specific protocol after auto-negotiation has already happened.
+ * to run with several versions of RESP. {@link CommandsTestsParameters#commandObjectsRespVersions}
+ * provides the strict (non-{@code null}) RESP versions, which are the right fit here:
+ * CommandObjects receive a specific protocol after auto-negotiation has already happened.
  */
 @Tag("integration")
 @ParameterizedClass
-@MethodSource("redis.clients.jedis.commands.CommandsTestsParameters#jedisRespVersions")
+@MethodSource("redis.clients.jedis.commands.CommandsTestsParameters#commandObjectsRespVersions")
 public abstract class CommandObjectsTestBase {
 
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches protocol selection/negotiation paths across `Jedis`, pipelines, transactions, and cluster pipeline, which can affect reply decoding and compatibility when protocol is unspecified or negotiation fails. Changes are small but impact core client behavior and are best validated against both RESP2/RESP3 servers.
> 
> **Overview**
> **Enforces a concrete RESP protocol for `CommandObjects` and removes reliance on `null` as a protocol sentinel.** `CommandObjects` now throws if constructed with `null`, and callers (`Jedis`, `Pipeline`, `Transaction`, `ReliableTransaction`, `UnifiedJedis`, `ClusterPipeline`) consistently use `RedisProtocol.orServerDefault(...)` to fall back to the server default (RESP2) when no protocol is resolved.
> 
> Updates a few command reply parsers (`hrandfieldWithValues`, `jsonType`) to branch explicitly on *RESP2 vs non-RESP2* rather than *non-RESP3*, and adjusts tests to stop parameterizing `CommandObjects` tests with a `null` protocol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9006db1d0e4aa09850f7a7432943a193a78780ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->