### PR TITLE
Ignore CONFIG GET failure in SDR integration tests until we bump Jedi…

### DIFF
--- a/.github/workflows/spring-data-redis-integration.yml
+++ b/.github/workflows/spring-data-redis-integration.yml
@@ -94,8 +94,9 @@ jobs:
         working-directory: spring-data-redis
         run: |
           # Verify Jedis changes do not break SDR integration tests (Redis required)
+          # TODO: re-enable UnifiedJedisConnectionIntegrationTests#testGetConfig once Jedis 8.0 is released and SDR is bumped to use it
           ./mvnw -B test \
-            -Dtest="**/jedis/**/*Tests,**/jedis/**/*Test,!**/jedis/**/*UnitTests,!**/jedis/**/*UnitTest" \
+            -Dtest="**/jedis/**/*Tests,**/jedis/**/*Test,!**/jedis/**/*UnitTests,!**/jedis/**/*UnitTest,!UnifiedJedisConnectionIntegrationTests#testGetConfig" \
             -DfailIfNoTests=false \
             -Dmaven.javadoc.skip=true \
             -Pci


### PR DESCRIPTION
…s there

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts CI test selection by skipping a single known-failing integration test, without affecting production code paths.
> 
> **Overview**
> Updates the `Spring Data Redis Integration Test` GitHub Actions workflow to **exclude** `UnifiedJedisConnectionIntegrationTests#testGetConfig` from the Jedis-focused integration test run, with a TODO to re-enable it once Jedis 8.0 is released and Spring Data Redis is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1de954ea5e55e9781f22c79bad82634d8316ed6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->