### PR TITLE
CommandObjects refactoring Part 4: Backport deprecations to 7.5.x

### DIFF
--- a/src/main/java/redis/clients/jedis/ClusterCommandObjects.java
+++ b/src/main/java/redis/clients/jedis/ClusterCommandObjects.java
@@ -16,6 +16,25 @@ import redis.clients.jedis.util.KeyValue;
 
 public class ClusterCommandObjects extends CommandObjects {
 
+  /**
+   * @deprecated Use {@link #ClusterCommandObjects(RedisProtocol)} so the protocol is supplied via
+   *             the constructor. The no-arg constructor will be removed in the next major
+   *             release.
+   */
+  @Deprecated
+  public ClusterCommandObjects() {
+  }
+
+  /**
+   * Constructs a {@code ClusterCommandObjects} bound to the given Redis protocol. This
+   * constructor will become the only supported entry point in the next major release.
+   * @param protocol the negotiated Redis protocol; passing {@code null} is allowed for backward
+   *                 compatibility but will be rejected in the next major release.
+   */
+  public ClusterCommandObjects(RedisProtocol protocol) {
+    super(protocol);
+  }
+
   @Override
   protected ClusterCommandArguments commandArguments(ProtocolCommand command) {
     ClusterCommandArguments comArgs = new ClusterCommandArguments(command);

--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -40,7 +40,30 @@ public class CommandObjects {
 
   private RedisProtocol protocol;
 
-  // TODO: restrict?
+  /**
+   * @deprecated Use {@link #CommandObjects(RedisProtocol)} so the protocol is supplied via the
+   *             constructor. The no-arg constructor will be removed in the next major release.
+   */
+  @Deprecated
+  public CommandObjects() {
+  }
+
+  /**
+   * Constructs a {@code CommandObjects} bound to the given Redis protocol. This constructor will
+   * become the only supported entry point in the next major release; prefer it over the
+   * combination of the no-arg constructor and {@link #setProtocol(RedisProtocol)}.
+   * @param protocol the negotiated Redis protocol; passing {@code null} is allowed for backward
+   *                 compatibility but will be rejected in the next major release.
+   */
+  public CommandObjects(RedisProtocol protocol) {
+    this.protocol = protocol;
+  }
+
+  /**
+   * @deprecated Pass the protocol via {@link #CommandObjects(RedisProtocol)} instead. This setter
+   *             will be removed in the next major release.
+   */
+  @Deprecated
   public final void setProtocol(RedisProtocol proto) {
     this.protocol = proto;
   }

--- a/src/main/java/redis/clients/jedis/builders/AbstractClientBuilder.java
+++ b/src/main/java/redis/clients/jedis/builders/AbstractClientBuilder.java
@@ -301,7 +301,11 @@ public abstract class AbstractClientBuilder<T extends AbstractClientBuilder<T, C
    * This method is called by concrete builders to configure the CommandObjects with the common
    * settings like key preprocessor, JSON mapper, and search dialect.
    * @param commandObjects the CommandObjects instance to configure
+   * @deprecated Will be removed in the next major release. The client constructor will own
+   *             {@link CommandObjects} construction and apply this configuration internally;
+   *             callers should rely on {@code build()} alone.
    */
+  @Deprecated
   public void applyCommandObjectsConfiguration(CommandObjects commandObjects) {
     if (keyPreProcessor != null) {
       commandObjects.setKeyArgumentPreProcessor(keyPreProcessor);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Enables HTTPS-style hostname verification by default for TLS sockets and changes cluster pipelining execution semantics, which can break existing deployments relying on permissive TLS or implicit executor lifecycle.
> 
> **Overview**
> Bumps project version to `7.5.0-SNAPSHOT` and continues the `CommandObjects` refactor by deprecating the no-arg constructors and `setProtocol`, steering callers to constructor-injected `RedisProtocol` (also deprecating `AbstractClientBuilder.applyCommandObjectsConfiguration`).
> 
> Adds opt-in support for *shared* `ExecutorService` usage in cluster pipelining: `JedisCluster`/`RedisClusterClient` gain `pipelined(ExecutorService)` and `MultiNodePipelineBase` now reuses a provided executor instead of always creating/shutting down its own; new tests cover shared-executor concurrency and lifecycle.
> 
> Hardens TLS behavior by defaulting `DefaultJedisSocketFactory` to enable hostname verification (`SSLParameters` endpoint identification `HTTPS`) when no custom parameters are provided, and expands TLS integration tests/endpoints to validate failure on wrong-host certificates and the ability to disable verification via custom `SSLParameters`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffb19174231ad17bdb8a19bcd56319e2832bc6fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->