### PR TITLE
docs:  Improve mget javadocs

### DIFF
--- a/src/main/java/redis/clients/jedis/commands/StringBinaryCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/StringBinaryCommands.java
@@ -56,6 +56,14 @@ public interface StringBinaryCommands extends BitBinaryCommands {
   @Deprecated
   String psetex(byte[] key, long milliseconds, byte[] value);
 
+  /**
+   * Gets the values of all the specified keys.
+   * <p>
+   * At least one key must be supplied because Redis MGET requires one or more keys.
+   *
+   * @param keys the keys to get; must not be empty
+   * @return Multi bulk reply
+   */
   List<byte[]> mget(byte[]... keys);
 
   String mset(byte[]... keysvalues);

--- a/src/main/java/redis/clients/jedis/commands/StringBinaryCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/StringBinaryCommands.java
@@ -57,12 +57,14 @@ public interface StringBinaryCommands extends BitBinaryCommands {
   String psetex(byte[] key, long milliseconds, byte[] value);
 
   /**
-   * Gets the values of all the specified keys.
+   * Get the values of all the specified keys.
    * <p>
-   * At least one key must be supplied because Redis MGET requires one or more keys.
+   * At least one key must be supplied; otherwise the server returns an error.
    *
-   * @param keys the keys to get; must not be empty
-   * @return Multi bulk reply
+   * @param keys the keys to get
+   * @return a list of values in the same order as {@code keys};
+   *         entries are {@code null} for keys that do not exist or do not hold a string value
+   * @see StringCommands#mget(String...)
    */
   List<byte[]> mget(byte[]... keys);
 

--- a/src/main/java/redis/clients/jedis/commands/StringCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/StringCommands.java
@@ -166,7 +166,7 @@ public interface StringCommands extends BitCommands {
    * @param value
    * @return OK
    * @deprecated Use {@link StringCommands#set(String, String, SetParams)} with {@link SetParams#px(long)}.
-   * Deprecated in Jedis 7.3.0. Mirrors Redis deprecation since 2.6.12.
+   * Deprecated in Jedis 7.3.0. Mirrors Redis deprecation since 2.0.0.
    */
   @Deprecated
   String psetex(String key, long milliseconds, String value);
@@ -177,8 +177,10 @@ public interface StringCommands extends BitCommands {
    * String, a 'nil' value is returned instead of the value of the specified key, but the operation
    * never fails.
    * <p>
+   * At least one key must be supplied because Redis MGET requires one or more keys.
+   * <p>
    * Time complexity: O(1) for every key
-   * @param keys
+   * @param keys the keys to get; must not be empty
    * @return Multi bulk reply
    */
   List<String> mget(String... keys);

--- a/src/main/java/redis/clients/jedis/commands/StringCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/StringCommands.java
@@ -166,22 +166,22 @@ public interface StringCommands extends BitCommands {
    * @param value
    * @return OK
    * @deprecated Use {@link StringCommands#set(String, String, SetParams)} with {@link SetParams#px(long)}.
-   * Deprecated in Jedis 7.3.0. Mirrors Redis deprecation since 2.0.0.
+   * Deprecated in Jedis 7.3.0. Mirrors Redis deprecation since 2.6.12.
    */
   @Deprecated
   String psetex(String key, long milliseconds, String value);
 
   /**
    * <b><a href="http://redis.io/commands/mget">MGet Command</a></b>
-   * Get the values of all the specified keys. If one or more keys don't exist or is not of type
-   * String, a 'nil' value is returned instead of the value of the specified key, but the operation
-   * never fails.
+   * Get the values of all the specified keys.
    * <p>
-   * At least one key must be supplied because Redis MGET requires one or more keys.
+   * At least one key must be supplied; otherwise the server returns an error.
    * <p>
    * Time complexity: O(1) for every key
-   * @param keys the keys to get; must not be empty
-   * @return Multi bulk reply
+   *
+   * @param keys the keys to get
+   * @return a list of values in the same order as {@code keys};
+   *         entries are {@code null} for keys that do not exist or do not hold a string value
    */
   List<String> mget(String... keys);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes clarifying `mget` requires at least one key and returns `null` entries for missing/non-string keys; no runtime logic is modified.
> 
> **Overview**
> Updates Javadoc for `StringCommands#mget` and `StringBinaryCommands#mget` to clarify Redis behavior when called with no keys (server error) and to better specify the return list semantics/order, including `null` entries for missing/non-string keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0580df0239beefce4dafdb93a61982cf9e61160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->