### PR TITLE
Codex/otel 1.49 jedis 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<packaging>jar</packaging>
-	<groupId>redis.clients</groupId>
+	<groupId>io.github.stellhub</groupId>
 	<artifactId>jedis</artifactId>
 	<version>6.0.0-SNAPSHOT</version>
 	<name>Jedis</name>
 	<description>Jedis is a blazingly small and sane Redis java client.</description>
-	<url>https://github.com/redis/jedis</url>
+	<url>https://github.com/stellhub/jedis</url>
 
 	<mailingLists>
 		<mailingList>
@@ -38,10 +38,9 @@
 	</issueManagement>
 
 	<scm>
-		<connection>scm:git:git@github.com:redis/jedis.git</connection>
-		<url>scm:git:git@github.com:redis/jedis.git</url>
-		<developerConnection>scm:git:git@github.com:redis/jedis.git</developerConnection>
-		<tag>jedis-3.4.1</tag>
+		<connection>scm:git:https://github.com/stellhub/jedis.git</connection>
+		<url>https://github.com/stellhub/jedis</url>
+		<developerConnection>scm:git:git@github.com:stellhub/jedis.git</developerConnection>
 	</scm>
 
 	<properties>
@@ -49,6 +48,7 @@
 		<jedis.module.name>redis.clients.jedis</jedis.module.name>
 		<slf4j.version>1.7.36</slf4j.version>
 		<resilience4j.version>1.7.1</resilience4j.version>
+		<opentelemetry.version>1.49.0</opentelemetry.version>
 		<jackson.version>2.18.3</jackson.version>
 		<maven.surefire.version>3.5.3</maven.surefire.version>
 		<junit.version>5.13.0-M1</junit.version>
@@ -92,6 +92,11 @@
 			<groupId>redis.clients.authentication</groupId>
 			<artifactId>redis-authx-core</artifactId>
 			<version>0.1.1-beta2</version>
+		</dependency>
+		<dependency>
+			<groupId>io.opentelemetry</groupId>
+			<artifactId>opentelemetry-api</artifactId>
+			<version>${opentelemetry.version}</version>
 		</dependency>
 
 		<!-- Optional dependencies -->
@@ -190,6 +195,12 @@
 			<version>0.1.1-beta2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.opentelemetry</groupId>
+			<artifactId>opentelemetry-sdk-testing</artifactId>
+			<version>${opentelemetry.version}</version>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- circuit breaker / failover -->
 		<dependency>
@@ -214,12 +225,12 @@
 
 	<distributionManagement>
 		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<id>stellhubmaven</id>
+			<url>https://maven.pkg.github.com/stellhub/stellhubmaven</url>
 		</snapshotRepository>
 		<repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+			<id>stellhubmaven</id>
+			<url>https://maven.pkg.github.com/stellhub/stellhubmaven</url>
 		</repository>
 	</distributionManagement>
 
@@ -308,17 +319,6 @@
 			<plugin>
 				<artifactId>maven-release-plugin</artifactId>
 				<version>3.1.1</version>
-			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.7.0</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>ossrh</serverId>
-					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-					<autoReleaseAfterClose>true</autoReleaseAfterClose>
-				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>net.revelc.code.formatter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>jar</packaging>
 	<groupId>io.github.stellhub</groupId>
 	<artifactId>jedis</artifactId>
-	<version>6.0.0-SNAPSHOT</version>
+	<version>6.0.0</version>
 	<name>Jedis</name>
 	<description>Jedis is a blazingly small and sane Redis java client.</description>
 	<url>https://github.com/stellhub/jedis</url>

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -48,6 +48,7 @@ public class Connection implements Closeable {
   protected String version;
   private AtomicReference<RedisCredentials> currentCredentials = new AtomicReference<>(null);
   private AuthXManager authXManager;
+  private JedisTelemetry telemetry = JedisTelemetry.noop();
 
   public Connection() {
     this(Protocol.DEFAULT_HOST, Protocol.DEFAULT_PORT);
@@ -74,6 +75,8 @@ public class Connection implements Closeable {
     this.socketFactory = socketFactory;
     this.soTimeout = clientConfig.getSocketTimeoutMillis();
     this.infiniteSoTimeout = clientConfig.getBlockingSocketTimeoutMillis();
+    this.telemetry = JedisTelemetry.create(clientConfig.getTelemetryConfig(), getTelemetryHostAndPort(),
+      clientConfig.getRedisProtocol());
     initializeFromClientConfig(clientConfig);
   }
 
@@ -164,22 +167,39 @@ public class Connection implements Closeable {
   }
 
   public Object executeCommand(final CommandArguments args) {
-    sendCommand(args);
-    return getOne();
+    long startNanos = telemetry.startCommand();
+    try {
+      sendCommand(args);
+      Object reply = getOne();
+      telemetry.recordCommandSuccess(args, startNanos);
+      return reply;
+    } catch (RuntimeException | Error e) {
+      telemetry.recordCommandError(args, startNanos, e);
+      throw e;
+    }
   }
 
   public <T> T executeCommand(final CommandObject<T> commandObject) {
     final CommandArguments args = commandObject.getArguments();
-    sendCommand(args);
-    if (!args.isBlocking()) {
-      return commandObject.getBuilder().build(getOne());
-    } else {
-      try {
-        setTimeoutInfinite();
-        return commandObject.getBuilder().build(getOne());
-      } finally {
-        rollbackTimeout();
+    long startNanos = telemetry.startCommand();
+    try {
+      sendCommand(args);
+      T reply;
+      if (!args.isBlocking()) {
+        reply = commandObject.getBuilder().build(getOne());
+      } else {
+        try {
+          setTimeoutInfinite();
+          reply = commandObject.getBuilder().build(getOne());
+        } finally {
+          rollbackTimeout();
+        }
       }
+      telemetry.recordCommandSuccess(args, startNanos);
+      return reply;
+    } catch (RuntimeException | Error e) {
+      telemetry.recordCommandError(args, startNanos, e);
+      throw e;
     }
   }
 
@@ -200,6 +220,7 @@ public class Connection implements Closeable {
   }
 
   public void sendCommand(final CommandArguments args) {
+    telemetry.recordCommandSent(args);
     try {
       connect();
       Protocol.sendCommand(outputStream, args);
@@ -236,16 +257,20 @@ public class Connection implements Closeable {
         inputStream = new RedisInputStream(socket.getInputStream());
 
         broken = false; // unset broken status when connection is (re)initialized
+        telemetry.recordConnectionOpened();
 
       } catch (JedisConnectionException jce) {
 
         setBroken();
+        telemetry.recordConnectionError(jce);
         throw jce;
 
       } catch (IOException ioe) {
 
         setBroken();
-        throw new JedisConnectionException("Failed to create input/output stream", ioe);
+        JedisConnectionException jce = new JedisConnectionException("Failed to create input/output stream", ioe);
+        telemetry.recordConnectionError(jce);
+        throw jce;
 
       } finally {
 
@@ -280,10 +305,12 @@ public class Connection implements Closeable {
         outputStream.flush();
         socket.close();
       } catch (IOException ex) {
+        telemetry.recordConnectionError(ex);
         throw new JedisConnectionException(ex);
       } finally {
         IOUtils.closeQuietly(socket);
         setBroken();
+        telemetry.recordConnectionClosed();
       }
     }
   }
@@ -613,5 +640,12 @@ public class Connection implements Closeable {
 
   protected AuthXManager getAuthXManager() {
     return authXManager;
+  }
+
+  private HostAndPort getTelemetryHostAndPort() {
+    if (socketFactory instanceof DefaultJedisSocketFactory) {
+      return ((DefaultJedisSocketFactory) socketFactory).getHostAndPort();
+    }
+    return null;
   }
 }

--- a/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
@@ -5,6 +5,7 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
 
+import io.opentelemetry.api.OpenTelemetry;
 import redis.clients.jedis.authentication.AuthXManager;
 
 public final class DefaultJedisClientConfig implements JedisClientConfig {
@@ -33,6 +34,8 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
 
   private final AuthXManager authXManager;
 
+  private final JedisTelemetryConfig telemetryConfig;
+
   private DefaultJedisClientConfig(DefaultJedisClientConfig.Builder builder) {
     this.redisProtocol = builder.redisProtocol;
     this.connectionTimeoutMillis = builder.connectionTimeoutMillis;
@@ -50,6 +53,7 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
     this.clientSetInfoConfig = builder.clientSetInfoConfig;
     this.readOnlyForRedisClusterReplicas = builder.readOnlyForRedisClusterReplicas;
     this.authXManager = builder.authXManager;
+    this.telemetryConfig = builder.telemetryConfig;
   }
 
   @Override
@@ -143,6 +147,11 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
     return readOnlyForRedisClusterReplicas;
   }
 
+  @Override
+  public JedisTelemetryConfig getTelemetryConfig() {
+    return telemetryConfig;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -174,6 +183,8 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
     private boolean readOnlyForRedisClusterReplicas = false;
 
     private AuthXManager authXManager = null;
+
+    private JedisTelemetryConfig telemetryConfig = JedisTelemetryConfig.disabled();
 
     private Builder() {
     }
@@ -297,6 +308,16 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
       return this;
     }
 
+    public Builder telemetryConfig(JedisTelemetryConfig telemetryConfig) {
+      this.telemetryConfig = telemetryConfig == null ? JedisTelemetryConfig.disabled() : telemetryConfig;
+      return this;
+    }
+
+    public Builder openTelemetry(OpenTelemetry openTelemetry) {
+      this.telemetryConfig = JedisTelemetryConfig.builder().openTelemetry(openTelemetry).build();
+      return this;
+    }
+
     public Builder from(JedisClientConfig instance) {
       this.redisProtocol = instance.getRedisProtocol();
       this.connectionTimeoutMillis = instance.getConnectionTimeoutMillis();
@@ -314,6 +335,7 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
       this.clientSetInfoConfig = instance.getClientSetInfoConfig();
       this.readOnlyForRedisClusterReplicas = instance.isReadOnlyForRedisClusterReplicas();
       this.authXManager = instance.getAuthXManager();
+      this.telemetryConfig = instance.getTelemetryConfig();
       return this;
     }
   }
@@ -375,6 +397,7 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
     }
 
     builder.authXManager(copy.getAuthXManager());
+    builder.telemetryConfig(copy.getTelemetryConfig());
 
     return builder.build();
   }

--- a/src/main/java/redis/clients/jedis/JedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/JedisClientConfig.java
@@ -115,4 +115,12 @@ public interface JedisClientConfig {
   default ClientSetInfoConfig getClientSetInfoConfig() {
     return ClientSetInfoConfig.DEFAULT;
   }
+
+  /**
+   * 获取 OpenTelemetry 指标配置。
+   * @return OpenTelemetry 指标配置
+   */
+  default JedisTelemetryConfig getTelemetryConfig() {
+    return JedisTelemetryConfig.disabled();
+  }
 }

--- a/src/main/java/redis/clients/jedis/JedisTelemetry.java
+++ b/src/main/java/redis/clients/jedis/JedisTelemetry.java
@@ -1,0 +1,205 @@
+package redis.clients.jedis;
+
+import java.util.Locale;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import redis.clients.jedis.commands.ProtocolCommand;
+
+final class JedisTelemetry {
+
+  private static final String INSTRUMENTATION_NAME = "redis.clients.jedis";
+  private static final JedisTelemetry NOOP = new JedisTelemetry();
+
+  private final boolean enabled;
+  private final Attributes baseAttributes;
+  private final LongCounter commandSentCounter;
+  private final LongCounter commandErrorCounter;
+  private final DoubleHistogram commandDurationHistogram;
+  private final LongCounter connectionOpenedCounter;
+  private final LongCounter connectionClosedCounter;
+  private final LongCounter connectionErrorCounter;
+
+  private JedisTelemetry() {
+    this.enabled = false;
+    this.baseAttributes = Attributes.empty();
+    this.commandSentCounter = null;
+    this.commandErrorCounter = null;
+    this.commandDurationHistogram = null;
+    this.connectionOpenedCounter = null;
+    this.connectionClosedCounter = null;
+    this.connectionErrorCounter = null;
+  }
+
+  private JedisTelemetry(Meter meter, Attributes baseAttributes) {
+    this.enabled = true;
+    this.baseAttributes = baseAttributes;
+    this.commandSentCounter = meter.counterBuilder("jedis.command.sent")
+        .setDescription("Number of Redis commands sent by Jedis.")
+        .setUnit("{command}")
+        .build();
+    this.commandErrorCounter = meter.counterBuilder("jedis.command.errors")
+        .setDescription("Number of Redis command executions that failed in Jedis.")
+        .setUnit("{error}")
+        .build();
+    this.commandDurationHistogram = meter.histogramBuilder("jedis.command.duration")
+        .setDescription("Redis command execution duration observed by Jedis.")
+        .setUnit("ms")
+        .build();
+    this.connectionOpenedCounter = meter.counterBuilder("jedis.connection.opened")
+        .setDescription("Number of Redis connections opened by Jedis.")
+        .setUnit("{connection}")
+        .build();
+    this.connectionClosedCounter = meter.counterBuilder("jedis.connection.closed")
+        .setDescription("Number of Redis connections closed by Jedis.")
+        .setUnit("{connection}")
+        .build();
+    this.connectionErrorCounter = meter.counterBuilder("jedis.connection.errors")
+        .setDescription("Number of Redis connection failures observed by Jedis.")
+        .setUnit("{error}")
+        .build();
+  }
+
+  /**
+   * 获取禁用指标采集的 recorder。
+   * @return noop recorder
+   */
+  static JedisTelemetry noop() {
+    return NOOP;
+  }
+
+  /**
+   * 根据客户端配置和连接信息创建指标 recorder。
+   * @param config 指标配置
+   * @param hostAndPort Redis 地址
+   * @param protocol Redis 协议
+   * @return 指标 recorder
+   */
+  static JedisTelemetry create(JedisTelemetryConfig config, HostAndPort hostAndPort, RedisProtocol protocol) {
+    if (config == null || !config.isEnabled()) {
+      return NOOP;
+    }
+
+    OpenTelemetry openTelemetry = config.getOpenTelemetry();
+    String version = JedisMetaInfo.getVersion();
+    Meter meter = openTelemetry.meterBuilder(INSTRUMENTATION_NAME)
+        .setInstrumentationVersion(version == null ? "unknown" : version)
+        .build();
+
+    AttributesBuilder attributes = Attributes.builder()
+        .put("db.system", "redis")
+        .putAll(config.getCommonAttributes());
+    if (hostAndPort != null) {
+      attributes.put("server.address", hostAndPort.getHost());
+      attributes.put("server.port", hostAndPort.getPort());
+    }
+    if (protocol != null) {
+      attributes.put("redis.protocol", protocol.name());
+    }
+    return new JedisTelemetry(meter, attributes.build());
+  }
+
+  /**
+   * 记录命令已发送。
+   * @param args 命令参数
+   */
+  void recordCommandSent(CommandArguments args) {
+    if (!enabled) {
+      return;
+    }
+    commandSentCounter.add(1, commandAttributes(args));
+  }
+
+  /**
+   * 创建命令执行开始时间。
+   * @return 纳秒时间戳
+   */
+  long startCommand() {
+    return enabled ? System.nanoTime() : 0L;
+  }
+
+  /**
+   * 记录命令执行成功。
+   * @param args 命令参数
+   * @param startNanos 开始时间
+   */
+  void recordCommandSuccess(CommandArguments args, long startNanos) {
+    if (!enabled) {
+      return;
+    }
+    commandDurationHistogram.record(elapsedMillis(startNanos), commandAttributes(args));
+  }
+
+  /**
+   * 记录命令执行失败。
+   * @param args 命令参数
+   * @param startNanos 开始时间
+   * @param error 异常
+   */
+  void recordCommandError(CommandArguments args, long startNanos, Throwable error) {
+    if (!enabled) {
+      return;
+    }
+    Attributes attributes = commandAttributes(args).toBuilder()
+        .put("error.type", error.getClass().getName())
+        .build();
+    commandErrorCounter.add(1, attributes);
+    commandDurationHistogram.record(elapsedMillis(startNanos), attributes);
+  }
+
+  /**
+   * 记录连接已打开。
+   */
+  void recordConnectionOpened() {
+    if (enabled) {
+      connectionOpenedCounter.add(1, baseAttributes);
+    }
+  }
+
+  /**
+   * 记录连接已关闭。
+   */
+  void recordConnectionClosed() {
+    if (enabled) {
+      connectionClosedCounter.add(1, baseAttributes);
+    }
+  }
+
+  /**
+   * 记录连接异常。
+   * @param error 异常
+   */
+  void recordConnectionError(Throwable error) {
+    if (!enabled) {
+      return;
+    }
+    connectionErrorCounter.add(1, baseAttributes.toBuilder()
+        .put("error.type", error.getClass().getName())
+        .build());
+  }
+
+  private Attributes commandAttributes(CommandArguments args) {
+    return baseAttributes.toBuilder()
+        .put("redis.command", commandName(args))
+        .build();
+  }
+
+  private static double elapsedMillis(long startNanos) {
+    return (System.nanoTime() - startNanos) / 1_000_000.0d;
+  }
+
+  private static String commandName(CommandArguments args) {
+    if (args == null) {
+      return "UNKNOWN";
+    }
+    ProtocolCommand command = args.getCommand();
+    if (command == null || command.getRaw() == null) {
+      return "UNKNOWN";
+    }
+    return new String(command.getRaw(), Protocol.CHARSET).toUpperCase(Locale.ROOT);
+  }
+}

--- a/src/main/java/redis/clients/jedis/JedisTelemetryConfig.java
+++ b/src/main/java/redis/clients/jedis/JedisTelemetryConfig.java
@@ -1,0 +1,113 @@
+package redis.clients.jedis;
+
+import java.util.Objects;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+
+public final class JedisTelemetryConfig {
+
+  private static final JedisTelemetryConfig DISABLED
+      = new JedisTelemetryConfig(false, OpenTelemetry.noop(), Attributes.empty());
+
+  private final boolean enabled;
+  private final OpenTelemetry openTelemetry;
+  private final Attributes commonAttributes;
+
+  private JedisTelemetryConfig(boolean enabled, OpenTelemetry openTelemetry, Attributes commonAttributes) {
+    this.enabled = enabled;
+    this.openTelemetry = openTelemetry;
+    this.commonAttributes = commonAttributes;
+  }
+
+  /**
+   * 获取禁用 OpenTelemetry 指标采集的配置。
+   * @return 禁用状态的配置
+   */
+  public static JedisTelemetryConfig disabled() {
+    return DISABLED;
+  }
+
+  /**
+   * 创建 OpenTelemetry 指标配置构建器。
+   * @return 配置构建器
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * 判断是否启用指标采集。
+   * @return true 表示启用
+   */
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  /**
+   * 获取用于创建 Meter 的 OpenTelemetry 实例。
+   * @return OpenTelemetry 实例
+   */
+  public OpenTelemetry getOpenTelemetry() {
+    return openTelemetry;
+  }
+
+  /**
+   * 获取附加到所有 Jedis 指标上的公共属性。
+   * @return 公共属性
+   */
+  public Attributes getCommonAttributes() {
+    return commonAttributes;
+  }
+
+  public static final class Builder {
+
+    private boolean enabled = true;
+    private OpenTelemetry openTelemetry = OpenTelemetry.noop();
+    private Attributes commonAttributes = Attributes.empty();
+
+    private Builder() {
+    }
+
+    /**
+     * 设置是否启用指标采集。
+     * @param enabled true 表示启用
+     * @return 当前构建器
+     */
+    public Builder enabled(boolean enabled) {
+      this.enabled = enabled;
+      return this;
+    }
+
+    /**
+     * 设置 OpenTelemetry 实例。
+     * @param openTelemetry OpenTelemetry 实例
+     * @return 当前构建器
+     */
+    public Builder openTelemetry(OpenTelemetry openTelemetry) {
+      this.openTelemetry = Objects.requireNonNull(openTelemetry, "openTelemetry");
+      return this;
+    }
+
+    /**
+     * 设置公共指标属性。
+     * @param commonAttributes 公共属性
+     * @return 当前构建器
+     */
+    public Builder commonAttributes(Attributes commonAttributes) {
+      this.commonAttributes = Objects.requireNonNull(commonAttributes, "commonAttributes");
+      return this;
+    }
+
+    /**
+     * 构建 Jedis OpenTelemetry 指标配置。
+     * @return 指标配置
+     */
+    public JedisTelemetryConfig build() {
+      if (!enabled) {
+        return DISABLED;
+      }
+      return new JedisTelemetryConfig(true, openTelemetry, commonAttributes);
+    }
+  }
+}

--- a/src/test/java/redis/clients/jedis/JedisTelemetryTest.java
+++ b/src/test/java/redis/clients/jedis/JedisTelemetryTest.java
@@ -1,0 +1,85 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+public class JedisTelemetryTest {
+
+  @Test
+  public void recordsCommandMetrics() {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    SdkMeterProvider meterProvider = SdkMeterProvider.builder().registerMetricReader(reader).build();
+    OpenTelemetry openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build();
+
+    JedisTelemetry telemetry = JedisTelemetry.create(
+      JedisTelemetryConfig.builder().openTelemetry(openTelemetry).build(),
+      new HostAndPort("localhost", 6379),
+      RedisProtocol.RESP2);
+
+    CommandArguments args = new CommandArguments(Protocol.Command.GET).key("key");
+    long startNanos = telemetry.startCommand();
+    telemetry.recordCommandSent(args);
+    telemetry.recordCommandSuccess(args, startNanos);
+
+    Collection<MetricData> metrics = reader.collectAllMetrics();
+    assertEquals(1L, longSumValue(metrics, "jedis.command.sent"));
+    assertEquals(1L, histogramCount(metrics, "jedis.command.duration"));
+
+    meterProvider.close();
+  }
+
+  @Test
+  public void recordsErrorAndConnectionMetrics() {
+    InMemoryMetricReader reader = InMemoryMetricReader.create();
+    SdkMeterProvider meterProvider = SdkMeterProvider.builder().registerMetricReader(reader).build();
+    OpenTelemetry openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build();
+
+    JedisTelemetry telemetry = JedisTelemetry.create(
+      JedisTelemetryConfig.builder().openTelemetry(openTelemetry).build(),
+      new HostAndPort("localhost", 6379),
+      RedisProtocol.RESP3);
+
+    CommandArguments args = new CommandArguments(Protocol.Command.SET).key("key").add("value");
+    long startNanos = telemetry.startCommand();
+    telemetry.recordCommandError(args, startNanos, new JedisConnectionException("boom"));
+    telemetry.recordConnectionOpened();
+    telemetry.recordConnectionClosed();
+    telemetry.recordConnectionError(new JedisConnectionException("boom"));
+
+    Collection<MetricData> metrics = reader.collectAllMetrics();
+    assertEquals(1L, longSumValue(metrics, "jedis.command.errors"));
+    assertEquals(1L, longSumValue(metrics, "jedis.connection.opened"));
+    assertEquals(1L, longSumValue(metrics, "jedis.connection.closed"));
+    assertEquals(1L, longSumValue(metrics, "jedis.connection.errors"));
+
+    meterProvider.close();
+  }
+
+  private static long longSumValue(Collection<MetricData> metrics, String name) {
+    return findMetric(metrics, name).getLongSumData().getPoints().iterator().next().getValue();
+  }
+
+  private static long histogramCount(Collection<MetricData> metrics, String name) {
+    return findMetric(metrics, name).getHistogramData().getPoints().iterator().next().getCount();
+  }
+
+  private static MetricData findMetric(Collection<MetricData> metrics, String name) {
+    for (MetricData metric : metrics) {
+      if (name.equals(metric.getName())) {
+        return metric;
+      }
+    }
+    assertTrue(false, "Metric not found: " + name);
+    return null;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core `Connection` command/connection execution paths to emit metrics, which could affect error handling and performance. Also changes Maven coordinates and distribution target, impacting downstream consumers and release/publishing workflow.
> 
> **Overview**
> **Adds optional OpenTelemetry metrics instrumentation.** Introduces `JedisTelemetry`/`JedisTelemetryConfig` and wires them into `Connection` to record command sent/success/error timing plus connection open/close/error counters, configurable via `JedisClientConfig`/`DefaultJedisClientConfig` (including a builder `openTelemetry(...)` shortcut), with new unit tests using the OTel in-memory metric reader.
> 
> **Updates build/publishing metadata.** Changes Maven `groupId`/SCM URL to `io.github.stellhub`, finalizes version `6.0.0`, adds OpenTelemetry dependencies, and switches `distributionManagement` from Sonatype OSSRH to GitHub Packages while removing the Nexus staging plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa5ec2a4a280699502e628447ee2f20cbbde243b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->