### PR TITLE
docs: include benchmarks dashboard and add manual dispatch with deplo…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,12 @@ name: Publish Docs
 on:
   push:
     branches: ["master"]
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: 'Deploy to GitHub Pages'
+        type: boolean
+        default: false
 permissions:
   contents: read
   pages: write
@@ -32,5 +38,6 @@ jobs:
         with:
           path: 'docsbuild'
       - name: Deploy to GitHub Pages
+        if: github.event_name != 'workflow_dispatch' || inputs.deploy
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
…y toggle

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that just gates GitHub Pages deployment behind a manual toggle on `workflow_dispatch` runs.
> 
> **Overview**
> Adds `workflow_dispatch` support to the docs publishing workflow with a boolean `deploy` input.
> 
> On manually triggered runs, the workflow will still build and upload the docs artifact but will *only* run the GitHub Pages deploy step when `inputs.deploy` is true; push-to-`master` behavior remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27c1e5ed463d9c710aa514d674ba24e142da90e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->