### PR TITLE
test: flush test database to prevent cross-test pollution

### DIFF
--- a/src/test/java/redis/clients/jedis/RedisClientTest.java
+++ b/src/test/java/redis/clients/jedis/RedisClientTest.java
@@ -39,6 +39,11 @@ public class RedisClientTest {
   public static void prepareEndpoints() {
     endpointStandalone7 = Endpoints.getRedisEndpoint("standalone7-with-lfu-policy");
     endpointStandalone1 = Endpoints.getRedisEndpoint("standalone1");
+
+    try (Jedis control = new Jedis(endpointStandalone1.getHostAndPort(),
+        endpointStandalone1.getClientConfigBuilder().build())) {
+      control.flushAll();
+    }
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/csc/ClientSideCacheTestBase.java
+++ b/src/test/java/redis/clients/jedis/csc/ClientSideCacheTestBase.java
@@ -44,7 +44,11 @@ public abstract class ClientSideCacheTestBase {
 
   @AfterEach
   public void tearDown() throws Exception {
-    control.close();
+    try {
+      control.flushAll();
+    } finally {
+      control.close();
+    }
   }
 
   protected static final Supplier<JedisClientConfig> clientConfig = () -> endpoint.getClientConfigBuilder().resp3().build();


### PR DESCRIPTION
# Summary

`RedisClientTest.testCredentialsProvider` and `testResetValidCredentials` call `pool.get("foo")` without setting `foo` first. When `ClientSideCacheFunctionalityTest.differentInstanceOnEachCacheHit` runs earlier in the same Surefire fork, it leaves `foo` behind as a SET (it calls `SADD foo` and never cleans up), causing `WRONGTYPE`. The failure is intermittent because test-class order isn't deterministic.

Fix: flush the database in `RedisClientTest` `@BeforeAll`, and add a symmetric `@AfterEach` flush to `ClientSideCacheTestBase` so each class leaves a clean state.

Example failure
```
     RedisClientTest.testCredentialsProvider:306
       JedisDataException: WRONGTYPE Operation against a key holding the wrong kind of value
         at pool.get("foo")

     RedisClientTest.testResetValidCredentials:240
       JedisDataException: WRONGTYPE Operation against a key holding the wrong kind of value
        at pool.get("foo")
```
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add extra `flushAll()` calls; main impact is potential added runtime and dependence on `FLUSHALL` permissions in the test Redis setup.
> 
> **Overview**
> Ensures integration tests start and end with a clean Redis database to avoid cross-class key pollution.
> 
> `RedisClientTest` now runs a `flushAll()` once in `@BeforeAll`, and `ClientSideCacheTestBase` now `flushAll()`s again during `@AfterEach` (in a `finally` that always closes the control connection) to leave the server clean for subsequent tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da2db6824aeb97b2a390990988781ab53d4719b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->