### PR TITLE
ci(format_check): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - '**/*.java' # Only trigger for Java file changes
 
+permissions:
+  contents: read
+
 jobs:
   check-format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `format_check` workflow only runs the formatter check. No GitHub API writes, so a workflow-level `contents: read` is the right cap for the default `GITHUB_TOKEN`.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tightens GitHub Actions workflow token permissions and does not change build or formatting logic.
> 
> **Overview**
> Restricts the `format_check` GitHub Actions workflow’s default `GITHUB_TOKEN` by adding workflow-level `permissions: contents: read`, reducing exposure while keeping the Java formatting check behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaf37a373007935838388bc63dc2c4fad142cc6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->