### PR TITLE
Adding support for the broadcast mode

### DIFF
--- a/src/main/java/redis/clients/jedis/csc/AbstractCache.java
+++ b/src/main/java/redis/clients/jedis/csc/AbstractCache.java
@@ -3,6 +3,7 @@ package redis.clients.jedis.csc;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -25,14 +26,31 @@ public abstract class AbstractCache implements Cache {
   private final int maximumSize;
   private ReentrantLock lock = new ReentrantLock();
   private volatile CacheStats stats = new CacheStats();
+  private final boolean broadcastMode;
+  private final List<String> prefixes;
+  private final boolean noLoop;
 
   protected AbstractCache(int maximumSize) {
     this(maximumSize, DefaultCacheable.INSTANCE);
   }
 
   protected AbstractCache(int maximumSize, Cacheable cacheable) {
+    this(maximumSize, cacheable, false, Collections.emptyList(), false);
+  }
+
+  protected AbstractCache(int maximumSize, Cacheable cacheable, boolean broadcastMode,
+      List<String> prefixes) {
+    this(maximumSize, cacheable, broadcastMode, prefixes, false);
+  }
+
+  protected AbstractCache(int maximumSize, Cacheable cacheable, boolean broadcastMode,
+      List<String> prefixes, boolean noLoop) {
     this.maximumSize = maximumSize;
     this.cacheable = cacheable;
+    this.broadcastMode = broadcastMode;
+    this.prefixes = (prefixes == null) ? Collections.emptyList()
+        : Collections.unmodifiableList(new ArrayList<>(prefixes));
+    this.noLoop = noLoop;
   }
 
   // Cache interface methods
@@ -196,6 +214,21 @@ public abstract class AbstractCache implements Cache {
   @Override
   public boolean compatibilityMode() {
     return false;
+  }
+
+  @Override
+  public boolean isBroadcastMode() {
+    return broadcastMode;
+  }
+
+  @Override
+  public List<String> getPrefixes() {
+    return prefixes;
+  }
+
+  @Override
+  public boolean isNoLoop() {
+    return noLoop;
   }
   // End of Cache interface methods
 

--- a/src/main/java/redis/clients/jedis/csc/Cache.java
+++ b/src/main/java/redis/clients/jedis/csc/Cache.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis.csc;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -110,4 +111,32 @@ public interface Cache {
      * @return The compatibility of cache against different Redis versions
      */
     boolean compatibilityMode();
+
+    /**
+     * @return Whether the connection that uses this cache should enable BCAST tracking mode.
+     * When {@code true}, the server broadcasts invalidations for any key matching one of the
+     * {@link #getPrefixes() configured prefixes} (or for all keys if no prefixes are set),
+     * instead of tracking the individual keys this connection has read.
+     */
+    default boolean isBroadcastMode() {
+        return false;
+    }
+
+    /**
+     * @return The list of key prefixes to subscribe to when {@link #isBroadcastMode()} is enabled.
+     * Never {@code null}. An empty list means BCAST is enabled without any PREFIX filter.
+     */
+    default List<String> getPrefixes() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * @return Whether the {@code NOLOOP} flag should be sent with {@code CLIENT TRACKING}.
+     * When {@code true}, the server suppresses invalidation messages back to this connection
+     * for keys that this same connection itself modifies. Applicable in both default and
+     * {@link #isBroadcastMode() BCAST} modes.
+     */
+    default boolean isNoLoop() {
+        return false;
+    }
 }

--- a/src/main/java/redis/clients/jedis/csc/CacheConfig.java
+++ b/src/main/java/redis/clients/jedis/csc/CacheConfig.java
@@ -1,11 +1,17 @@
 package redis.clients.jedis.csc;
 
+import java.util.Collections;
+import java.util.List;
+
 public class CacheConfig {
 
     private int maxSize;
     private Cacheable cacheable;
     private EvictionPolicy evictionPolicy;
     private Class cacheClass;
+    private boolean broadcastMode;
+    private List<String> prefixes;
+    private boolean noLoop;
 
     public int getMaxSize() {
         return maxSize;
@@ -22,6 +28,19 @@ public class CacheConfig {
     public Class getCacheClass() {
         return cacheClass;
     }
+
+    public boolean isBroadcastMode() {
+        return broadcastMode;
+    }
+
+    public List<String> getPrefixes() {
+        return prefixes;
+    }
+
+    public boolean noloop() {
+        return noLoop;
+    }
+    
     public static Builder builder() {
         return new Builder();
     }
@@ -32,6 +51,9 @@ public class CacheConfig {
         private Cacheable cacheable = DefaultCacheable.INSTANCE;
         private EvictionPolicy evictionPolicy;
         private Class cacheClass;
+        private boolean broadcastMode = false;
+        private boolean noLoop = false;
+        private List<String> prefixes = Collections.emptyList();
 
         public Builder maxSize(int maxSize) {
             this.maxSize = maxSize;
@@ -53,12 +75,39 @@ public class CacheConfig {
             return this;
         }
 
+        public Builder bcast() {
+            this.broadcastMode = true;
+            return this;
+        }
+
+        public Builder noloop() {
+            this.noLoop = true;
+            return this;
+        }
+
+        public Builder prefixes(List<String> prefixes) {
+            this.prefixes = (prefixes == null) ? Collections.emptyList() : prefixes;
+            return this;
+        }
+
+        public Builder prefixes(String... prefixes) {
+            if (prefixes == null || prefixes.length == 0) {
+                this.prefixes = Collections.emptyList();
+            } else {
+                this.prefixes = java.util.Arrays.asList(prefixes);
+            }
+            return this;
+        }
+
         public CacheConfig build() {
             CacheConfig cacheConfig = new CacheConfig();
             cacheConfig.maxSize = this.maxSize;
             cacheConfig.cacheable = this.cacheable;
             cacheConfig.evictionPolicy = this.evictionPolicy;
             cacheConfig.cacheClass = this.cacheClass;
+            cacheConfig.broadcastMode = this.broadcastMode;
+            cacheConfig.prefixes = this.prefixes;
+            cacheConfig.noLoop = this.noLoop;
             return cacheConfig;
         }
     }

--- a/src/main/java/redis/clients/jedis/csc/CacheConnection.java
+++ b/src/main/java/redis/clients/jedis/csc/CacheConnection.java
@@ -1,5 +1,7 @@
 package redis.clients.jedis.csc;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -159,11 +161,32 @@ public class CacheConnection extends Connection {
       }
     }
     addPushConsumer(new PushInvalidateConsumer(cache));
-    sendCommand(Protocol.Command.CLIENT, "TRACKING", "ON");
+    sendCommand(Protocol.Command.CLIENT, buildTrackingArgs(cache));
     String reply = getStatusCodeReply();
     if (!"OK".equals(reply)) {
       throw new JedisException("Could not enable client tracking. Reply: " + reply);
     }
+  }
+
+  public String[] buildTrackingArgs(Cache cache) {
+    List<String> args = new ArrayList<>();
+    args.add("TRACKING");
+    args.add("ON");
+    if (cache.isBroadcastMode()) {
+      args.add("BCAST");
+      for (String prefix : cache.getPrefixes()) {
+        if (prefix == null || prefix.isEmpty()) {
+          throw new JedisException("BCAST prefixes must be non-empty strings.");
+        }
+        args.add("PREFIX");
+        args.add(prefix);
+      }
+    }
+    
+    if (cache.isNoLoop()) {
+      args.add("NOLOOP");
+    }
+    return args.toArray(new String[0]);
   }
 
   private CacheEntry validateEntry(CacheEntry cacheEntry) {

--- a/src/main/java/redis/clients/jedis/csc/CacheFactory.java
+++ b/src/main/java/redis/clients/jedis/csc/CacheFactory.java
@@ -3,6 +3,7 @@ package redis.clients.jedis.csc;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
+import java.util.List;
 
 import redis.clients.jedis.exceptions.JedisCacheException;
 
@@ -13,7 +14,8 @@ public final class CacheFactory {
             if (config.getCacheable() == null) {
                 throw new JedisCacheException("Cacheable is required to create the default cache!");
             }
-            return new DefaultCache(config.getMaxSize(), config.getCacheable(), getEvictionPolicy(config));
+            return new DefaultCache(config.getMaxSize(), config.getCacheable(), getEvictionPolicy(config),
+                    config.isBroadcastMode(), config.getPrefixes(), config.noloop());
         }
         return instantiateCustomCache(config);
     }
@@ -21,6 +23,16 @@ public final class CacheFactory {
     private static Cache instantiateCustomCache(CacheConfig config) {
         try {
             if (config.getCacheable() != null) {
+                Constructor ctorWithTrackingNoLoop = findConstructorWithTrackingNoLoop(config.getCacheClass());
+                if (ctorWithTrackingNoLoop != null) {
+                    return (Cache) ctorWithTrackingNoLoop.newInstance(config.getMaxSize(), getEvictionPolicy(config),
+                            config.getCacheable(), config.isBroadcastMode(), config.getPrefixes(), config.noloop());
+                }
+                Constructor ctorWithTracking = findConstructorWithTracking(config.getCacheClass());
+                if (ctorWithTracking != null) {
+                    return (Cache) ctorWithTracking.newInstance(config.getMaxSize(), getEvictionPolicy(config),
+                            config.getCacheable(), config.isBroadcastMode(), config.getPrefixes());
+                }
                 Constructor ctorWithCacheable = findConstructorWithCacheable(config.getCacheClass());
                 if (ctorWithCacheable != null) {
                     return (Cache) ctorWithCacheable.newInstance(config.getMaxSize(), getEvictionPolicy(config), config.getCacheable());
@@ -37,6 +49,20 @@ public final class CacheFactory {
     private static Constructor findConstructorWithCacheable(Class customCacheType) {
         return Arrays.stream(customCacheType.getConstructors())
                 .filter(ctor -> Arrays.equals(ctor.getParameterTypes(), new Class[] { int.class, EvictionPolicy.class, Cacheable.class }))
+                .findFirst().orElse(null);
+    }
+
+    private static Constructor findConstructorWithTracking(Class customCacheType) {
+        return Arrays.stream(customCacheType.getConstructors())
+                .filter(ctor -> Arrays.equals(ctor.getParameterTypes(),
+                        new Class[] { int.class, EvictionPolicy.class, Cacheable.class, boolean.class, List.class }))
+                .findFirst().orElse(null);
+    }
+
+    private static Constructor findConstructorWithTrackingNoLoop(Class customCacheType) {
+        return Arrays.stream(customCacheType.getConstructors())
+                .filter(ctor -> Arrays.equals(ctor.getParameterTypes(),
+                        new Class[] { int.class, EvictionPolicy.class, Cacheable.class, boolean.class, List.class, boolean.class }))
                 .findFirst().orElse(null);
     }
 

--- a/src/main/java/redis/clients/jedis/csc/DefaultCache.java
+++ b/src/main/java/redis/clients/jedis/csc/DefaultCache.java
@@ -1,7 +1,9 @@
 package redis.clients.jedis.csc;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class DefaultCache extends AbstractCache {
@@ -26,7 +28,29 @@ public class DefaultCache extends AbstractCache {
     }
 
     protected DefaultCache(int maximumSize, Map<CacheKey, CacheEntry> map, Cacheable cacheable, EvictionPolicy evictionPolicy) {
-        super(maximumSize, cacheable);
+        this(maximumSize, map, cacheable, evictionPolicy, false, Collections.emptyList(), false);
+    }
+
+    protected DefaultCache(int maximumSize, Cacheable cacheable, EvictionPolicy evictionPolicy,
+            boolean broadcastMode, List<String> prefixes) {
+        this(maximumSize, new HashMap<CacheKey, CacheEntry>(), cacheable, evictionPolicy, broadcastMode,
+                prefixes, false);
+    }
+
+    protected DefaultCache(int maximumSize, Cacheable cacheable, EvictionPolicy evictionPolicy,
+            boolean broadcastMode, List<String> prefixes, boolean noLoop) {
+        this(maximumSize, new HashMap<CacheKey, CacheEntry>(), cacheable, evictionPolicy, broadcastMode,
+                prefixes, noLoop);
+    }
+
+    protected DefaultCache(int maximumSize, Map<CacheKey, CacheEntry> map, Cacheable cacheable,
+            EvictionPolicy evictionPolicy, boolean broadcastMode, List<String> prefixes) {
+        this(maximumSize, map, cacheable, evictionPolicy, broadcastMode, prefixes, false);
+    }
+
+    protected DefaultCache(int maximumSize, Map<CacheKey, CacheEntry> map, Cacheable cacheable,
+            EvictionPolicy evictionPolicy, boolean broadcastMode, List<String> prefixes, boolean noLoop) {
+        super(maximumSize, cacheable, broadcastMode, prefixes, noLoop);
         this.cache = map;
         this.evictionPolicy = evictionPolicy;
         this.evictionPolicy.setCache(this);

--- a/src/test/java/redis/clients/jedis/csc/BroadcastTrackingArgsTest.java
+++ b/src/test/java/redis/clients/jedis/csc/BroadcastTrackingArgsTest.java
@@ -1,0 +1,56 @@
+package redis.clients.jedis.csc;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pure unit tests for the BCAST / NOLOOP tracking-mode wiring. These exercise
+ * {@link CacheConfig}, {@link DefaultCache}, and the package-private
+ * {@link CacheConnection#buildTrackingArgs(Cache)} helper without requiring a running Redis
+ * instance.
+ */
+public class BroadcastTrackingArgsTest {
+
+  @Test
+  public void configDefaultsAreNonBroadcast() {
+    CacheConfig cfg = CacheConfig.builder().build();
+    assertFalse(cfg.isBroadcastMode());
+    assertEquals(Collections.emptyList(), cfg.getPrefixes());
+    assertFalse(cfg.noloop());
+  }
+
+  @Test
+  public void configBuilderStoresBroadcastAndPrefixes() {
+    CacheConfig cfg = CacheConfig.builder()
+        .bcast()
+        .prefixes("user:", "order:")
+        .build();
+    assertTrue(cfg.isBroadcastMode());
+    assertEquals(Arrays.asList("user:", "order:"), cfg.getPrefixes());
+  }
+
+  @Test
+  public void configPrefixesNullCoercedToEmptyList() {
+    CacheConfig cfg = CacheConfig.builder()
+        .bcast()
+        .prefixes((List<String>) null)
+        .build();
+    assertEquals(Collections.emptyList(), cfg.getPrefixes());
+  }
+
+  @Test
+  public void cacheReflectsConfigViaFactory() {
+    CacheConfig cfg = CacheConfig.builder()
+        .bcast()
+        .prefixes("user:")
+        .build();
+    Cache cache = CacheFactory.getCache(cfg);
+    assertTrue(cache.isBroadcastMode());
+    assertEquals(Collections.singletonList("user:"), cache.getPrefixes());
+  }
+}

--- a/src/test/java/redis/clients/jedis/csc/BroadcastTrackingIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/csc/BroadcastTrackingIntegrationTest.java
@@ -1,0 +1,88 @@
+package redis.clients.jedis.csc;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.RedisClient;
+
+/**
+ * Integration tests that exercise BCAST tracking mode end-to-end against a real Redis 7.4+
+ * standalone server.
+ *
+ * <p>The behaviors under test:
+ * <ul>
+ *   <li>A modification to a key matching one of the configured prefixes invalidates the cache
+ *       entry.</li>
+ *   <li>A modification to a key that does <i>not</i> match any prefix does <b>not</b> trigger
+ *       an invalidation. In BCAST mode the server only broadcasts for matching prefixes.</li>
+ * </ul>
+ */
+public class BroadcastTrackingIntegrationTest extends ClientSideCacheTestBase {
+
+  @Test
+  public void invalidationFiresForPrefixedKey() {
+    CacheConfig cfg = CacheConfig.builder()
+        .bcast()
+        .prefixes("user:")
+        .build();
+
+    try (RedisClient jedis = RedisClient.builder()
+        .hostAndPort(hnp)
+        .clientConfig(clientConfig.get())
+        .cacheConfig(cfg)
+        .poolConfig(singleConnectionPoolConfig.get())
+        .build()) {
+      Cache cache = jedis.getCache();
+
+      control.set("user:1", "alice");
+      assertEquals("alice", jedis.get("user:1"));
+      assertEquals(1, cache.getSize());
+
+      // Mutate the prefixed key from another connection — server should broadcast invalidate.
+      control.set("user:1", "bob");
+
+      await().atMost(Duration.ofSeconds(5))
+          .until(() -> cache.getSize() == 0);
+    }
+  }
+
+  @Test
+  public void noInvalidationForNonPrefixedKey() {
+    CacheConfig cfg = CacheConfig.builder()
+        .bcast()
+        .prefixes("user:")
+        .build();
+
+    try (RedisClient jedis = RedisClient.builder()
+        .hostAndPort(hnp)
+        .clientConfig(clientConfig.get())
+        .cacheConfig(cfg)
+        .poolConfig(singleConnectionPoolConfig.get())
+        .build()) {
+      Cache cache = jedis.getCache();
+
+      control.set("other:1", "x");
+      assertEquals("x", jedis.get("other:1"));
+      assertEquals(1, cache.getSize());
+
+      // Mutate a non-prefixed key. In BCAST mode with PREFIX user: the server must NOT
+      // send an invalidation for this key. Cache size should remain stable.
+      control.set("other:1", "y");
+
+      // Give the server a moment to deliver any (unexpected) push messages.
+      try {
+        Thread.sleep(500);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+
+      // Trigger any pending pushes by issuing a no-op command.
+      jedis.ping();
+      assertEquals(1, cache.getSize(), "Non-prefixed key changes must not invalidate the cache");
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how invalidations are scoped (prefix-based broadcast vs per-connection tracking), which can cause stale cache entries if misconfigured; defaults preserve prior non-BCAST behavior.
> 
> **Overview**
> Adds **Redis `CLIENT TRACKING` BCAST mode** to client-side caching so invalidations can follow **prefix filters** instead of only keys this connection has read.
> 
> **Configuration** flows through `CacheConfig` (`bcast()`, `prefixes(...)`, `noloop()`), the `Cache` API (`isBroadcastMode`, `getPrefixes`, `isNoLoop`), `AbstractCache` / `DefaultCache`, and `CacheFactory` (including optional constructors on custom cache types). **`CacheConnection`** now builds tracking arguments dynamically (`TRACKING ON`, optional `BCAST` + `PREFIX`, optional `NOLOOP`) instead of a fixed `TRACKING ON`.
> 
> **Tests** cover config/factory wiring (`BroadcastTrackingArgsTest`) and Redis 7.4+ behavior: prefixed keys invalidate on external writes; non-prefixed keys do not when prefixes are set (`BroadcastTrackingIntegrationTest`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c04462ec815528830bf283684be9286ca8519d17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->