### PR TITLE
Refresh slot cache when slot connection acquisition fails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -543,6 +543,7 @@
                         <include>src/test/java/redis/clients/jedis/commands/unified/cluster/ClusterStringValuesCommandsTest.java</include>
                         <include>src/test/java/redis/clients/jedis/ProtocolFallbackPropagationTest.java</include>
                         <include>src/test/java/redis/clients/jedis/ConnectionHelloAuthTest.java</include>
+						<include>src/test/java/redis/clients/jedis/providers/ClusterConnectionProviderTest.java</include>
 						<include>**/VectorSet*.java</include>
 						<include>**/VectorTestUtils.java</include>
 						<include>**/VAddParams.java</include>

--- a/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
@@ -19,6 +19,7 @@ import redis.clients.jedis.JedisClusterInfoCache;
 import redis.clients.jedis.annots.Experimental;
 import redis.clients.jedis.csc.Cache;
 import redis.clients.jedis.exceptions.JedisClusterOperationException;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
 
 import static redis.clients.jedis.RedisClusterClient.INIT_NO_ERROR_PROPERTY;
@@ -182,22 +183,45 @@ public class ClusterConnectionProvider implements ConnectionProvider {
     throw noReachableNode;
   }
 
+  private Connection getConnectionFromSlotAfterRenewing(int slot, JedisConnectionException previousException) {
+    // It's abnormal situation for cluster mode that we have just nothing for slot,
+    // or the mapped node is unreachable. Try to rediscover state.
+    renewSlotCache();
+    ConnectionPool connectionPool = cache.getSlotPool(slot);
+    if (connectionPool != null) {
+      try {
+        return connectionPool.getResource();
+      } catch (JedisConnectionException e) {
+        if (previousException != null) {
+          // we throw the retry failure, but attach the original failure as suppressed.
+          e.addSuppressed(previousException);
+        }
+        throw e;
+      }
+    } else {
+      // no choice, fallback to new connection to random node
+      try {
+        return getConnection();
+      } catch (JedisException e) {
+        if (previousException != null) {
+          e.addSuppressed(previousException);
+        }
+        throw e;
+      }
+    }
+  }
+
   public Connection getConnectionFromSlot(int slot) {
     ConnectionPool connectionPool = cache.getSlotPool(slot);
     if (connectionPool != null) {
       // It can't guaranteed to get valid connection because of node assignment
-      return connectionPool.getResource();
-    } else {
-      // It's abnormal situation for cluster mode that we have just nothing for slot.
-      // Try to rediscover state
-      renewSlotCache();
-      connectionPool = cache.getSlotPool(slot);
-      if (connectionPool != null) {
+      try {
         return connectionPool.getResource();
-      } else {
-        // no choice, fallback to new connection to random node
-        return getConnection();
+      } catch(JedisConnectionException e) {
+        return getConnectionFromSlotAfterRenewing(slot, e);
       }
+    } else {
+      return getConnectionFromSlotAfterRenewing(slot, null);
     }
   }
 

--- a/src/test/java/redis/clients/jedis/providers/ClusterConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/providers/ClusterConnectionProviderTest.java
@@ -1,0 +1,56 @@
+package redis.clients.jedis.providers;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.ConnectionPool;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisClusterInfoCache;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+@Tag("unit")
+class ClusterConnectionProviderTest {
+
+  private static final HostAndPort START_NODE = new HostAndPort("127.0.0.1", 7000);
+  private static final int SLOT = 42;
+
+  @Test
+  void getConnectionFromSlotRenewsSlotCacheAndRetriesWhenSlotPoolConnectionFails() {
+    ConnectionPool stalePool = Mockito.mock(ConnectionPool.class);
+    ConnectionPool refreshedPool = Mockito.mock(ConnectionPool.class);
+    Connection refreshedConnection = Mockito.mock(Connection.class);
+
+    try (
+        MockedConstruction<JedisClusterInfoCache> mockedCaches = Mockito
+            .mockConstruction(JedisClusterInfoCache.class);
+        MockedConstruction<Connection> ignored = Mockito.mockConstruction(Connection.class)) {
+      ClusterConnectionProvider provider = new ClusterConnectionProvider(
+          Collections.singleton(START_NODE), DefaultJedisClientConfig.builder().build());
+      JedisClusterInfoCache cache = mockedCaches.constructed().get(0);
+
+      when(cache.getSlotPool(SLOT)).thenReturn(stalePool, refreshedPool);
+      when(stalePool.getResource()).thenThrow(new JedisConnectionException("stale slot node"));
+      when(refreshedPool.getResource()).thenReturn(refreshedConnection);
+
+      Connection connection = provider.getConnectionFromSlot(SLOT);
+
+      assertSame(refreshedConnection, connection);
+      verify(cache, times(2)).getSlotPool(SLOT);
+      verify(cache).renewClusterSlots(isNull());
+      verify(stalePool).getResource();
+      verify(refreshedPool).getResource();
+    }
+  }
+}


### PR DESCRIPTION
`getConnectionFromSlot()` previously refreshed the cluster slot cache only when no pool was mapped for the requested slot. If a slot did have a mapped pool but borrowing a connection from that pool failed with a `JedisConnectionException`, the exception was propagated immediately.
This made `getConnectionFromSlot()` behave differently from normal command execution, where connection failures trigger retry handling and slot cache renewal.


Implemented the fallback in `getConnectionFromSlot()` for `JedisConnectionException` to renew the slot cache after a connection failure from the mapped slot pool, then resolve the slot again and retry connection acquisition. Preserve the existing fallback to a random reachable node when the slot is still unmapped after renewal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster slot connection selection used by command routing and direct slot APIs; behavior is more resilient but alters failure/retry timing during topology or node outages.
> 
> **Overview**
> **`ClusterConnectionProvider.getConnectionFromSlot()`** now treats a failed borrow from the mapped slot pool like other cluster paths: on **`JedisConnectionException`**, it renews the slot cache, looks up the slot again, and retries (or falls back to a random reachable node if the slot is still unmapped). Renewal and retry logic live in a new **`getConnectionFromSlotAfterRenewing()`** helper, with the original connection failure attached as a suppressed exception when retries still fail.
> 
> A **unit test** (`ClusterConnectionProviderTest`) verifies cache renewal and a successful second borrow after a stale pool throws. The test class is added to the formatter plugin includes in **`pom.xml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32fcf362b116d001f8b682a45f8feff39fcd875b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->