### PR TITLE
Fix double initialization of pooled Connection in TrackingConnectionPool

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -54,9 +54,49 @@ public class Connection implements Closeable {
     }
 
     public Connection build() {
-      Connection conn = new Connection(this);
+      Connection conn = createConnection();
       conn.initializeFromClientConfig();
       return conn;
+    }
+
+    /**
+     * Construct a fresh, uninitialized {@link Connection} for this builder.
+     * <p>
+     * Template-method hook for subclasses to return their concrete {@code Connection} subtype
+     * (see {@link redis.clients.jedis.csc.CacheConnection.Builder} for an example). The
+     * returned instance has its socket factory and client config wired up, but the network
+     * handshake has not run yet.
+     * <p>
+     * Two callers drive initialization differently:
+     * <ul>
+     *   <li>{@link #build()} — the public entry point — invokes
+     *       {@link Connection#initializeFromClientConfig()} on the returned instance before
+     *       handing it back, so external callers receive a ready-to-use connection.</li>
+     *   <li>{@link #buildUninitialized()} — the package-private accessor used by pool
+     *       factories — returns the uninitialized instance so the factory can interpose
+     *       between construction and initialization (e.g. to track an in-flight handshake
+     *       so a forced disconnect can interrupt it).</li>
+     * </ul>
+     * <p>
+     * Implementations must be free of side effects: do not open sockets, send commands, or
+     * invoke {@link Connection#initializeFromClientConfig()} — running initialization here
+     * would break the {@code buildUninitialized()} contract that pool factories rely on.
+     *
+     * @return a freshly constructed, uninitialized {@code Connection}
+     */
+    protected Connection createConnection() {
+      return new Connection(this);
+    }
+
+    /**
+     * Package-private entry point for pool factories that need to interpose between construction
+     * and initialization (e.g. to track in-flight connections so a forced disconnect can
+     * interrupt the init handshake). Callers MUST invoke
+     * {@link Connection#initializeFromClientConfig()} exactly once before handing the connection
+     * out.
+     */
+    final Connection buildUninitialized() {
+      return createConnection();
     }
   }
 

--- a/src/main/java/redis/clients/jedis/ConnectionFactory.java
+++ b/src/main/java/redis/clients/jedis/ConnectionFactory.java
@@ -151,7 +151,19 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
   }
 
   private Connection build() {
-    return connectionBuilder.build();
+    Connection conn = connectionBuilder.buildUninitialized();
+    initialize(conn);
+    return conn;
+  }
+
+  /**
+   * Initialize a freshly built {@link Connection}.
+   * <p>
+   * Subclasses may override to wrap initialization (for example, with cancellation tracking),
+   * but must ensure {@link Connection#initializeFromClientConfig()} is invoked exactly once.
+   */
+  protected void initialize(Connection conn) {
+      conn.initializeFromClientConfig();
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/csc/CacheConnection.java
+++ b/src/main/java/redis/clients/jedis/csc/CacheConnection.java
@@ -43,10 +43,8 @@ public class CacheConnection extends Connection {
     }
 
     @Override
-    public Connection build() {
-      CacheConnection conn = new CacheConnection(this);
-      conn.initializeFromClientConfig();
-      return conn;
+    protected Connection createConnection() {
+      return new CacheConnection(this);
     }
   }
 

--- a/src/main/java/redis/clients/jedis/mcf/TrackingConnectionPool.java
+++ b/src/main/java/redis/clients/jedis/mcf/TrackingConnectionPool.java
@@ -47,12 +47,6 @@ public class TrackingConnectionPool extends ConnectionPool {
       }
       try {
         PooledObject<Connection> object = super.makeObject();
-        factoryTrackedObjects.add(object.getObject());
-        try {
-          object.getObject().initializeFromClientConfig();
-        } finally {
-          factoryTrackedObjects.remove(object.getObject());
-        }
         // this can make a marginal improvement on fast failover duration!
         if (failFast) {
           object.getObject().close();
@@ -63,6 +57,18 @@ public class TrackingConnectionPool extends ConnectionPool {
         throw e;
       } catch (Exception e) {
         throw new JedisConnectionException(e);
+      }
+    }
+
+    @Override
+    protected void initialize(Connection conn) {
+      // Track the connection while it is being initialized so forceDisconnect() can interrupt
+      // a thread that is blocked inside HELLO/AUTH/CLIENT round-trips.
+      factoryTrackedObjects.add(conn);
+      try {
+        super.initialize(conn);
+      } finally {
+        factoryTrackedObjects.remove(conn);
       }
     }
 

--- a/src/test/java/redis/clients/jedis/mcf/TrackingConnectionPoolInitTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/TrackingConnectionPoolInitTest.java
@@ -3,6 +3,10 @@ package redis.clients.jedis.mcf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.util.List;
@@ -10,6 +14,7 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
 
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.ConnectionTestHelper;
@@ -56,6 +61,29 @@ public class TrackingConnectionPoolInitTest {
       List<PushConsumer> consumers = ConnectionTestHelper.getPushConsumers(conn);
       // contains(...) is an exact-length matcher: two copies of PUBSUB_CONSUMER would fail.
       assertThat(consumers, contains(is(PushConsumerChainImpl.PUBSUB_CONSUMER)));
+    }
+  }
+
+  /**
+   * Verifies that a {@link Connection} borrowed from a {@code TrackingConnectionPool} is
+   * initialized exactly once.
+   */
+  @Test
+  public void pooledConnectionInitializedExactlyOnce() {
+    DefaultJedisClientConfig config = DefaultJedisClientConfig.builder().resp3().build();
+    HostAndPort hostAndPort = new HostAndPort("localhost", mockServer.getPort());
+
+    // Mock the constructor so the borrow runs without opening a socket.
+    try (MockedConstruction<Connection> mocked = mockConstruction(Connection.class)) {
+      try (TrackingConnectionPool pool = TrackingConnectionPool.builder().hostAndPort(hostAndPort)
+          .clientConfig(config).build()) {
+
+        pool.getResource();
+
+        assertEquals(1, mocked.constructed().size());
+        Connection pooledConnection = mocked.constructed().get(0);
+        verify(pooledConnection, times(1)).initializeFromClientConfig();
+      }
     }
   }
 }

--- a/src/test/java/redis/clients/jedis/mcf/TrackingConnectionPoolInitTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/TrackingConnectionPoolInitTest.java
@@ -19,7 +19,6 @@ import redis.clients.jedis.PushConsumer;
 import redis.clients.jedis.PushConsumerChainImpl;
 import redis.clients.jedis.util.server.TcpMockServer;
 
-
 public class TrackingConnectionPoolInitTest {
 
   private TcpMockServer mockServer;

--- a/src/test/java/redis/clients/jedis/mcf/TrackingConnectionPoolInitTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/TrackingConnectionPoolInitTest.java
@@ -1,0 +1,62 @@
+package redis.clients.jedis.mcf;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.ConnectionTestHelper;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.PushConsumer;
+import redis.clients.jedis.PushConsumerChainImpl;
+import redis.clients.jedis.util.server.TcpMockServer;
+
+
+public class TrackingConnectionPoolInitTest {
+
+  private TcpMockServer mockServer;
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    mockServer = new TcpMockServer();
+    mockServer.start();
+  }
+
+  @AfterEach
+  public void tearDown() throws IOException {
+    if (mockServer != null) {
+      mockServer.stop();
+    }
+  }
+
+  /**
+   * Regression test for the double-initialization bug in {@link TrackingConnectionPool}.
+   * <p>
+   * Before the fix, a {@link Connection} obtained through a {@code TrackingConnectionPool} was
+   * initialized twice.
+   * </p>
+   */
+  @Test
+  public void pooledConnectionRegistersPubSubConsumerExactlyOnce() {
+    DefaultJedisClientConfig config = DefaultJedisClientConfig.builder().resp3().build();
+    HostAndPort hostAndPort = new HostAndPort("localhost", mockServer.getPort());
+
+    try (
+        TrackingConnectionPool pool = TrackingConnectionPool.builder().hostAndPort(hostAndPort)
+            .clientConfig(config).build();
+        Connection conn = pool.getResource()) {
+
+      List<PushConsumer> consumers = ConnectionTestHelper.getPushConsumers(conn);
+      // contains(...) is an exact-length matcher: two copies of PUBSUB_CONSUMER would fail.
+      assertThat(consumers, contains(is(PushConsumerChainImpl.PUBSUB_CONSUMER)));
+    }
+  }
+}


### PR DESCRIPTION
## What

When you get a `Connection` from a `TrackingConnectionPool` (i.e., every `MultiDbClient` database), it was being initialized twice: once by `Connection.Builder.build()`, and a second time by `FailFastConnectionFactory.makeObject()`.

Two visible effects, per pooled connection:
- An extra `HELLO`/`CLIENT` round-trip on the wire.
- The default `PUBSUB_CONSUMER` registered twice on the push-consumer chain.

Present since v7.0.0.

## Why it happened

`Connection.Builder.build()` has always initialized the connection it returns. The pool factory then ran initialization a second time on top, after `super.makeObject()` had already done it.

## Fix

Split construction from initialization so the pool factory can interpose without re-initializing:

- New protected `createConnection()` hook on `Connection.Builder` — subclasses (e.g. `CacheConnection.Builder`) override this to pick the concrete type.
- Package-private `buildUninitialized()` lets `ConnectionFactory` build without auto-init.
- `ConnectionFactory` exposes a protected `initialize()` hook that `FailFastConnectionFactory` overrides to wrap the (now sole) init in its existing tracking — which, as a side benefit, finally makes `forceDisconnect()` able to interrupt a connection mid-handshake.

Public API is unchanged.

## Tests

New `TrackingConnectionPoolInitTest` checks that a pool-obtained connection has exactly one `PUBSUB_CONSUMER` registered. Fails on the buggy version, passes here.

## Follow-up

`Connection.initializeFromClientConfig()` has no out-of-package caller after this — its visibility can be tightened in a separate PR for the next major release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connection pooling and handshake initialization paths used by MultiDbClient; behavior fix is targeted but affects every pooled connection lifecycle.
> 
> **Overview**
> Fixes **double initialization** of pooled `Connection` instances from `TrackingConnectionPool` (used by multi-DB clients): `Connection.Builder.build()` and the pool factory both ran `initializeFromClientConfig()`, causing an extra HELLO/CLIENT handshake and **duplicate `PUBSUB_CONSUMER` registration**.
> 
> **Construction vs initialization** is split without changing public `build()` behavior: `Connection.Builder` adds `createConnection()` (subclass hook, e.g. `CacheConnection`) and package-private `buildUninitialized()`; `ConnectionFactory` builds uninitialized connections and calls a new protected `initialize()` that runs init once.
> 
> `FailFastConnectionFactory` drops the second init in `makeObject()` and **overrides `initialize()`** to add/remove connections in `factoryTrackedObjects` during the sole init, so `forceDisconnect()` can interrupt in-flight HELLO/AUTH/CLIENT handshakes.
> 
> Adds `TrackingConnectionPoolInitTest` to assert single init and a single pub/sub push consumer on borrowed connections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d1b06bb6dce7e12286ad948233434a4ea236386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->