### PR TITLE
Expose renewSlotCache on JedisCluster as public API

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -407,6 +407,18 @@ public class JedisCluster extends UnifiedJedis {
     return ((ClusterConnectionProvider) provider).getConnectionFromSlot(slot);
   }
 
+  /**
+   * Forces an immediate refresh of the in-memory Redis Cluster topology
+   * (node map, primary and replica slot assignments).
+   * <p>
+   * Useful before {@link #getConnectionFromSlot(int)} when stale topology is
+   * detected outside the command retry path. Best-effort; a no-op if a refresh
+   * is already in progress.
+   */
+  public void refreshClusterTopology() {
+    ((ClusterConnectionProvider) provider).renewSlotCache();
+  }
+
   // commands
   public long spublish(String channel, String message) {
     return executeCommand(commandObjects.spublish(channel, message));

--- a/src/main/java/redis/clients/jedis/RedisClusterClient.java
+++ b/src/main/java/redis/clients/jedis/RedisClusterClient.java
@@ -173,6 +173,18 @@ public class RedisClusterClient extends UnifiedJedis {
     return ((ClusterConnectionProvider) provider).getConnectionFromSlot(slot);
   }
 
+  /**
+   * Forces an immediate refresh of the in-memory Redis Cluster topology
+   * (node map, primary and replica slot assignments).
+   * <p>
+   * Useful before {@link #getConnectionFromSlot(int)} when stale topology is
+   * detected outside the command retry path. Best-effort; a no-op if a refresh
+   * is already in progress.
+   */
+  public void refreshClusterTopology() {
+    ((ClusterConnectionProvider) provider).renewSlotCache();
+  }
+
   // commands
   public long spublish(String channel, String message) {
     return executeCommand(commandObjects.spublish(channel, message));

--- a/src/test/java/redis/clients/jedis/JedisClusterWithoutSetupTest.java
+++ b/src/test/java/redis/clients/jedis/JedisClusterWithoutSetupTest.java
@@ -3,9 +3,15 @@ package redis.clients.jedis;
 import static java.util.Collections.emptySet;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 import redis.clients.jedis.exceptions.JedisClusterOperationException;
+import redis.clients.jedis.providers.ClusterConnectionProvider;
+
 
 public class JedisClusterWithoutSetupTest {
 
@@ -24,6 +30,17 @@ public class JedisClusterWithoutSetupTest {
         () -> new JedisCluster(new HostAndPort("localhost", 7378)));
     assertEquals("Could not initialize cluster slots cache.", operationException.getMessage());
     assertEquals(1, operationException.getSuppressed().length);
+  }
+
+  @Test
+  public void refreshClusterTopology() {
+    ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class);
+    JedisCluster cluster = new JedisCluster(provider, JedisCluster.DEFAULT_MAX_ATTEMPTS,
+        Duration.ofMillis(JedisCluster.DEFAULT_TIMEOUT * JedisCluster.DEFAULT_MAX_ATTEMPTS));
+
+    cluster.refreshClusterTopology();
+
+    verify(provider).renewSlotCache();
   }
 
 }

--- a/src/test/java/redis/clients/jedis/builders/ClusterClientBuilderTest.java
+++ b/src/test/java/redis/clients/jedis/builders/ClusterClientBuilderTest.java
@@ -285,4 +285,16 @@ class ClusterClientBuilderTest {
       }
     }
   }
+
+  @Test
+  void refreshClusterTopology() {
+    ClusterConnectionProvider mockProvider = Mockito.mock(ClusterConnectionProvider.class);
+
+    try (RedisClusterClient client = RedisClusterClient.builder().nodes(someNodes())
+        .connectionProvider(mockProvider).build()) {
+      client.refreshClusterTopology();
+    }
+
+    verify(mockProvider).renewSlotCache();
+  }
 }


### PR DESCRIPTION
Jedis already supports refreshing the Redis Cluster slot cache internally through `ClusterConnectionProvider.renewSlotCache()`, but callers directly using do not have a public API to trigger that refresh directly.

This is useful for applications that detect stale or incomplete cluster topology state outside the normal command retry path, especially for direct slot/node workflows such as `getConnectionFromSlot()`.

Add `JedisCluster#refreshClusterTopology()` as a public API that delegates to the existing `ClusterConnectionProvider` renewal path. 
This gives applications an explicit way to refresh the in-memory cluster slot cache when they detect stale topology state outside the normal command retry flow.

Closes : #4154 
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin public wrapper over existing renewal logic; no new topology algorithm, only broader caller access to a path already used internally.
> 
> **Overview**
> Adds **`refreshClusterTopology()`** on **`JedisCluster`** and **`RedisClusterClient`**, exposing a way for apps to force an in-memory cluster topology refresh (nodes and slot map) by delegating to the existing **`ClusterConnectionProvider#renewSlotCache()`** path—intended when stale routing is noticed outside normal command retries, e.g. before **`getConnectionFromSlot(int)`**.
> 
> Unit tests assert both clients call **`renewSlotCache()`** on the provider (mocked **`JedisCluster`** constructor and **`RedisClusterClient`** builder).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bcab782d91049d0b810cc025694d2d2b3cc1dd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->