### PR TITLE
Upgrade GitHub Actions versions

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -54,7 +54,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
@@ -102,7 +102,7 @@ runs:
         fi
 
     - name: Set up Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: ${{ inputs.java_version }}
         distribution: ${{ inputs.java_distribution }}
@@ -115,7 +115,7 @@ runs:
         make compile-module
 
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.m2/repository
@@ -156,14 +156,14 @@ runs:
 
     - name: Upload Heap Dumps
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: heap-dumps-${{ steps.args.outputs.redis_version_label }}
         path: ${{ runner.temp }}/heapdump-${{ steps.args.outputs.redis_version_label }}.hprof
         retention-days: 5
 
     - name: Upload Surefire Dump File
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: surefire-dumpstream
         path: target/surefire-reports/*.dumpstream
@@ -187,7 +187,7 @@ runs:
 
     - name: Upload logs on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: redis-env-work-logs-${{ steps.args.outputs.redis_version_label }}
         path: ${{ steps.args.outputs.redis_env_work_dir }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,18 +21,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: java
         dependency-caching: true
         build-mode: manual
 
     - name: Set up JDK 8
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: '8'
@@ -42,4 +42,4 @@ jobs:
       run: mvn -B package
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,10 +24,10 @@ jobs:
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: master
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.13
       - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
         run: |
           mkdocs build -d docsbuild
       - name: Pull benchmark dashboard
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: benchmark-data
           path: benchmark-data
@@ -47,12 +47,12 @@ jobs:
           mkdir -p docsbuild/benchmarks
           cp -r benchmark-data/jedis/* docsbuild/benchmarks/
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: 'docsbuild'
       - name: Deploy to GitHub Pages
         if: github.event_name != 'workflow_dispatch' || inputs.deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -20,16 +20,16 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
             /var/cache/apt
           key: jedis-${{hashFiles('**/pom.xml')}}
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '11'
           distribution: 'temurin'

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       # Step 1: Checkout the PR code
       - name: Checkout code
-        uses: actions/checkout@v3 
+        uses: actions/checkout@v6
 
       # Step 2: Set up Java (if needed for format check tools)
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '11'
           distribution: 'temurin'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,9 +26,9 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up publishing to maven central
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '8'
           distribution: 'temurin'
@@ -38,7 +38,7 @@ jobs:
           sudo apt install -y make
           make system-setup
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -15,9 +15,9 @@ jobs:
     name: Deploy Snapshot
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up publishing to maven central
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '8'
           distribution: 'temurin'
@@ -25,7 +25,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/spring-data-redis-integration.yml
+++ b/.github/workflows/spring-data-redis-integration.yml
@@ -25,18 +25,18 @@ jobs:
 
     steps:
       - name: Checkout Jedis
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: jedis
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -52,7 +52,7 @@ jobs:
           echo "Built Jedis version: $JEDIS_VERSION"
 
       - name: Checkout Spring Data Redis
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: spring-projects/spring-data-redis
           ref: ${{ github.event.inputs.spring_data_redis_branch || 'main' }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: sdr-test-results
           path: |

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -12,7 +12,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v10
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is marked stale. It will be closed in 30 days if it is not updated.'

--- a/.github/workflows/test-on-docker.yml
+++ b/.github/workflows/test-on-docker.yml
@@ -50,7 +50,7 @@ jobs:
           # - "6.2"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: ./.github/actions/run-tests
         with:
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: ./.github/actions/run-tests
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,16 +25,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '8'
           distribution: 'temurin'
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: get version from tag
         id: get_version
@@ -19,7 +19,7 @@ jobs:
           echo "VERSION=$realversion" >> $GITHUB_OUTPUT
 
       - name: Set up publishing to maven central
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '8'
           distribution: 'temurin'


### PR DESCRIPTION
Preparation for Node.js v20 deprecation on GitHub Actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only workflow and composite-action version pins change; no Jedis library or runtime application code is modified.
> 
> **Overview**
> Bumps pinned **GitHub Actions** versions across `.github/workflows/*` and the composite **`.github/actions/run-tests`** action so CI stays on supported runtimes ahead of **Node.js 20** deprecation on Actions runners.
> 
> Common upgrades include **`actions/checkout@v6`**, **`actions/setup-java@v5`**, **`actions/cache@v5`**, and **`actions/upload-artifact@v5`**. Docs/GitHub Pages workflows also move **`setup-python`**, **`configure-pages`**, **`upload-pages-artifact`**, and **`deploy-pages`** to newer majors; **CodeQL** uses **`github/codeql-action` v4**; housekeeping jobs bump **`release-drafter@v6`** and **`actions/stale@v10`** (including **`format_check.yml`** checkout from v3).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ad637db7ef7cec4f465baf54a954d83c40a07bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->