### PR TITLE
Add 8.10 preview build and adjust RTS align test

### DIFF
--- a/.github/workflows/test-on-docker.yml
+++ b/.github/workflows/test-on-docker.yml
@@ -40,6 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         redis_version:
+          - "8.10"
           - "8.8"
           - "8.6"
           - "8.4"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PATH := ./redis-git/src:${PATH}
 
 # Supported test env versions
-SUPPORTED_TEST_ENV_VERSIONS := 8.8 8.6 8.4 8.2 8.0 7.4 7.2 6.2
+SUPPORTED_TEST_ENV_VERSIONS := 8.10 8.8 8.6 8.4 8.2 8.0 7.4 7.2 6.2
 DEFAULT_TEST_ENV_VERSION := 8.8
 REDIS_ENV_WORK_DIR := $(or ${REDIS_ENV_WORK_DIR},/tmp/redis-env-work)
 TOXIPROXY_IMAGE := ghcr.io/shopify/toxiproxy:2.8.0

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis.commands.unified.timeseries;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -519,40 +520,85 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
             .duplicatePolicy(DuplicatePolicy.MAX).ignore(50, 12.5).labels(labels)));
   }
 
+  /**
+   * Verify ALIGN modes. Non-keyword key: ALIGN option parsing is unaffected
+   * @see #alignKeyNotConsumedAsOption()
+   */
   @Test
-  @SinceRedisVersion(value = "8.10.0", message = "Requires the RedisTimeSeries TS.RANGE option-parsing fix "
-      + "(RedisTimeSeries PR #2052). Before it, a series key named like an option keyword "
-      + "(here \"align\") was matched as the ALIGN option, so the alignment was silently "
-      + "taken from the fromTimestamp and every ALIGN mode returned the same buckets.")
   public void align() {
-    // The series key is intentionally named "align" to guard against the option-keyword
-    // shadowing regression fixed in RedisTimeSeries PR #2052: option parsing must start after
-    // the key, so the key name must NOT be consumed as the ALIGN option.
-    jedis.tsAdd("align", 1, 10d);
-    jedis.tsAdd("align", 3, 5d);
-    jedis.tsAdd("align", 11, 10d);
-    jedis.tsAdd("align", 25, 11d);
+
+    final String key = "ts:align";
+
+    jedis.tsAdd(key, 1, 10d);
+    jedis.tsAdd(key, 3, 5d);
+    jedis.tsAdd(key, 11, 10d);
+    jedis.tsAdd(key, 25, 11d);
 
     // No ALIGN -> default alignment is 0 (epoch): buckets start at 0, 10, 20.
-    List<TSElement> values = jedis.tsRange("align",
+    List<TSElement> values = jedis.tsRange(key,
       TSRangeParams.rangeParams(1L, 30L).aggregation(AggregationType.COUNT, 10));
     assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(10, 1), new TSElement(20, 1)),
       values);
 
     // ALIGN start -> align to fromTimestamp (1): buckets start at 1, 11, 21.
-    values = jedis.tsRange("align",
+    values = jedis.tsRange(key,
       TSRangeParams.rangeParams(1L, 30L).alignStart().aggregation(AggregationType.COUNT, 10));
     assertEquals(Arrays.asList(new TSElement(1, 2), new TSElement(11, 1), new TSElement(21, 1)),
       values);
 
     // ALIGN end -> align to toTimestamp (30 ≡ 0 mod 10): buckets start at 0, 10, 20.
-    values = jedis.tsRange("align",
+    values = jedis.tsRange(key,
       TSRangeParams.rangeParams(1L, 30L).alignEnd().aggregation(AggregationType.COUNT, 10));
     assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(10, 1), new TSElement(20, 1)),
       values);
 
     // ALIGN 5 -> align to timestamp 5: buckets start at 0 (clamped), 5, 25.
-    values = jedis.tsRange("align",
+    values = jedis.tsRange(key,
+      TSRangeParams.rangeParams(1L, 30L).align(5).aggregation(AggregationType.COUNT, 10));
+    assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(5, 1), new TSElement(25, 1)),
+      values);
+  }
+
+  /**
+   * Verify that the series key is not consumed as the ALIGN option. See RedisTimeSeries #2052.
+   * @see #align()
+   */
+  @Test
+  @SinceRedisVersion(value = "8.10.0", message = "Requires the RedisTimeSeries TS.RANGE option-parsing fix "
+      + "(RedisTimeSeries PR #2052). Before it, a series key named like an option keyword "
+      + "(here \"align\") was matched as the ALIGN option, so the alignment was silently "
+      + "taken from the fromTimestamp and every ALIGN mode returned the same buckets.")
+  public void alignKeyNotConsumedAsOption() {
+    // The series key is intentionally named "align" to guard against the option-keyword
+    // shadowing regression fixed in RedisTimeSeries PR #2052: option parsing must start after
+    // the key, so the key name must NOT be consumed as the ALIGN option.
+    final String key = "align";
+
+    jedis.tsAdd(key, 1, 10d);
+    jedis.tsAdd(key, 3, 5d);
+    jedis.tsAdd(key, 11, 10d);
+    jedis.tsAdd(key, 25, 11d);
+
+    // No ALIGN -> default alignment is 0 (epoch): buckets start at 0, 10, 20.
+    List<TSElement> values = jedis.tsRange(key,
+      TSRangeParams.rangeParams(1L, 30L).aggregation(AggregationType.COUNT, 10));
+    assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(10, 1), new TSElement(20, 1)),
+      values);
+
+    // ALIGN start -> align to fromTimestamp (1): buckets start at 1, 11, 21.
+    values = jedis.tsRange(key,
+      TSRangeParams.rangeParams(1L, 30L).alignStart().aggregation(AggregationType.COUNT, 10));
+    assertEquals(Arrays.asList(new TSElement(1, 2), new TSElement(11, 1), new TSElement(21, 1)),
+      values);
+
+    // ALIGN end -> align to toTimestamp (30 ≡ 0 mod 10): buckets start at 0, 10, 20.
+    values = jedis.tsRange(key,
+      TSRangeParams.rangeParams(1L, 30L).alignEnd().aggregation(AggregationType.COUNT, 10));
+    assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(10, 1), new TSElement(20, 1)),
+      values);
+
+    // ALIGN 5 -> align to timestamp 5: buckets start at 0 (clamped), 5, 25.
+    values = jedis.tsRange(key,
       TSRangeParams.rangeParams(1L, 30L).align(5).aggregation(AggregationType.COUNT, 10));
     assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(5, 1), new TSElement(25, 1)),
       values);

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -520,11 +520,10 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   }
 
   @Test
-  @SinceRedisVersion(value = "8.10.0",
-      message = "Requires the RedisTimeSeries TS.RANGE option-parsing fix "
-          + "(RedisTimeSeries PR #2052). Before it, a series key named like an option keyword "
-          + "(here \"align\") was matched as the ALIGN option, so the alignment was silently "
-          + "taken from the fromTimestamp and every ALIGN mode returned the same buckets.")
+  @SinceRedisVersion(value = "8.10.0", message = "Requires the RedisTimeSeries TS.RANGE option-parsing fix "
+      + "(RedisTimeSeries PR #2052). Before it, a series key named like an option keyword "
+      + "(here \"align\") was matched as the ALIGN option, so the alignment was silently "
+      + "taken from the fromTimestamp and every ALIGN mode returned the same buckets.")
   public void align() {
     // The series key is intentionally named "align" to guard against the option-keyword
     // shadowing regression fixed in RedisTimeSeries PR #2052: option parsing must start after

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -520,30 +520,42 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   }
 
   @Test
+  @SinceRedisVersion(value = "8.10.0",
+      message = "Requires the RedisTimeSeries TS.RANGE option-parsing fix "
+          + "(RedisTimeSeries PR #2052). Before it, a series key named like an option keyword "
+          + "(here \"align\") was matched as the ALIGN option, so the alignment was silently "
+          + "taken from the fromTimestamp and every ALIGN mode returned the same buckets.")
   public void align() {
+    // The series key is intentionally named "align" to guard against the option-keyword
+    // shadowing regression fixed in RedisTimeSeries PR #2052: option parsing must start after
+    // the key, so the key name must NOT be consumed as the ALIGN option.
     jedis.tsAdd("align", 1, 10d);
     jedis.tsAdd("align", 3, 5d);
     jedis.tsAdd("align", 11, 10d);
     jedis.tsAdd("align", 25, 11d);
 
+    // No ALIGN -> default alignment is 0 (epoch): buckets start at 0, 10, 20.
     List<TSElement> values = jedis.tsRange("align",
       TSRangeParams.rangeParams(1L, 30L).aggregation(AggregationType.COUNT, 10));
-    assertEquals(Arrays.asList(new TSElement(1, 2), new TSElement(11, 1), new TSElement(21, 1)),
+    assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(10, 1), new TSElement(20, 1)),
       values);
 
+    // ALIGN start -> align to fromTimestamp (1): buckets start at 1, 11, 21.
     values = jedis.tsRange("align",
       TSRangeParams.rangeParams(1L, 30L).alignStart().aggregation(AggregationType.COUNT, 10));
     assertEquals(Arrays.asList(new TSElement(1, 2), new TSElement(11, 1), new TSElement(21, 1)),
       values);
 
+    // ALIGN end -> align to toTimestamp (30 ≡ 0 mod 10): buckets start at 0, 10, 20.
     values = jedis.tsRange("align",
       TSRangeParams.rangeParams(1L, 30L).alignEnd().aggregation(AggregationType.COUNT, 10));
-    assertEquals(Arrays.asList(new TSElement(1, 2), new TSElement(11, 1), new TSElement(21, 1)),
+    assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(10, 1), new TSElement(20, 1)),
       values);
 
+    // ALIGN 5 -> align to timestamp 5: buckets start at 0 (clamped), 5, 25.
     values = jedis.tsRange("align",
       TSRangeParams.rangeParams(1L, 30L).align(5).aggregation(AggregationType.COUNT, 10));
-    assertEquals(Arrays.asList(new TSElement(1, 2), new TSElement(11, 1), new TSElement(21, 1)),
+    assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(5, 1), new TSElement(25, 1)),
       values);
   }
 

--- a/src/test/resources/env/.env.v8.10
+++ b/src/test/resources/env/.env.v8.10
@@ -1,0 +1,8 @@
+REDIS_VERSION=8.10-m01-int
+REDIS_STACK_VERSION=8.10-m01-int
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test
+REDIS_ENV_CONF_DIR=./
+REDIS_MODULES_DIR=/tmp
+REDIS_ENV_WORK_DIR=/tmp/redis-env-work
+
+ENABLE_MODULE_COMMAND_DIRECTIVE=--enable-module-command yes


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to CI/Makefile env wiring and test expectations; no production client API or runtime behavior is modified.
> 
> **Overview**
> Adds **Redis 8.10** to the Docker CI matrix, `Makefile` supported test versions, and a new `src/test/resources/env/.env.v8.10` profile (`8.10-m01-int`) so the client libs test image can run against the 8.10 preview stack.
> 
> **TimeSeries `TS.RANGE` ALIGN coverage** is updated: `align()` now uses a non-keyword key (`ts:align`) and asserts distinct bucket timestamps for default alignment, `ALIGN start`, `ALIGN end`, and numeric `ALIGN 5`. A new `alignKeyNotConsumedAsOption()` test (gated with `@SinceRedisVersion("8.10.0")`) uses the key `"align"` to lock in the RedisTimeSeries option-parsing fix (PR #2052), where the series key must not be mistaken for the `ALIGN` option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 021c5dc9d687128e9a8e64271170d343ac0eeec7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->