### PR TITLE
Fix 'MultiDbClient' compatibility with client-side cache-enabled configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -625,6 +625,8 @@
 						<include>**/*MockTest.java</include>
 						<include>**/*Increx*.java</include>
 						<include>src/test/jmh/**/*.java</include>
+						<include>**/RedisMultiDbClientSideCacheTest.java</include>
+						<include>**/MultiDbCSCTest.java</include>
 					</includes>
 				</configuration>
 				<executions>

--- a/src/main/java/redis/clients/jedis/builders/MultiDbClientBuilder.java
+++ b/src/main/java/redis/clients/jedis/builders/MultiDbClientBuilder.java
@@ -117,7 +117,7 @@ public abstract class MultiDbClientBuilder<C>
     }
 
     // Create the multi-database connection provider
-    MultiDbConnectionProvider provider = new MultiDbConnectionProvider(multiDbConfig);
+    MultiDbConnectionProvider provider = new MultiDbConnectionProvider(multiDbConfig, cache);
 
     // Set database switch listener if provided
     if (this.databaseSwitchListener != null) {

--- a/src/main/java/redis/clients/jedis/mcf/MultiDbConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/mcf/MultiDbConnectionProvider.java
@@ -110,7 +110,7 @@ public class MultiDbConnectionProvider implements ConnectionProvider {
   private final AtomicInteger failoverAttemptCount = new AtomicInteger(0);
   private final Cache cache;
 
-  /*
+  /**
    * Constructor for MultiDbConnectionProvider. For the case where client side cache is not used.
    * Check other constructor where client side cache is demanded.
    * @param multiDbConfig the multi-database configuration

--- a/src/main/java/redis/clients/jedis/mcf/MultiDbConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/mcf/MultiDbConnectionProvider.java
@@ -36,6 +36,7 @@ import redis.clients.jedis.*;
 import redis.clients.jedis.MultiDbConfig.DatabaseConfig;
 import redis.clients.jedis.annots.Experimental;
 import redis.clients.jedis.annots.VisibleForTesting;
+import redis.clients.jedis.csc.Cache;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.exceptions.JedisValidationException;
@@ -107,13 +108,29 @@ public class MultiDbConnectionProvider implements ConnectionProvider {
 
   private final AtomicLong failoverFreezeUntil = new AtomicLong(0);
   private final AtomicInteger failoverAttemptCount = new AtomicInteger(0);
+  private final Cache cache;
 
+  /*
+   * Constructor for MultiDbConnectionProvider. For the case where client side cache is not used.
+   * Check other constructor where client side cache is demanded.
+   * @param multiDbConfig the multi-database configuration
+   */
   public MultiDbConnectionProvider(MultiDbConfig multiDbConfig) {
+    this(multiDbConfig, null);
+  }
+
+  /**
+   * Constructor for MultiDbConnectionProvider. For the case where client side cache is used.
+   * @param multiDbConfig the multi-database configuration
+   * @param cache the client-side cache
+   */
+  public MultiDbConnectionProvider(MultiDbConfig multiDbConfig, Cache cache) {
 
     if (multiDbConfig == null) throw new JedisValidationException(
         "MultiDbConfig must not be NULL for MultiDbConnectionProvider");
 
     this.multiDbConfig = multiDbConfig;
+    this.cache = cache;
 
     ////////////// Configure Retry ////////////////////
     MultiDbConfig.RetryConfig commandRetry = multiDbConfig.getCommandRetry();
@@ -326,7 +343,7 @@ public class MultiDbConnectionProvider implements ConnectionProvider {
 
     TrackingConnectionPool pool = TrackingConnectionPool.builder()
         .hostAndPort(hostPort(config.getEndpoint())).clientConfig(config.getJedisClientConfig())
-        .poolConfig(config.getConnectionPoolConfig()).build();
+        .poolConfig(config.getConnectionPoolConfig()).cache(cache).build();
 
     Database database;
     StrategySupplier strategySupplier = config.getHealthCheckStrategySupplier();

--- a/src/main/java/redis/clients/jedis/mcf/TrackingConnectionPool.java
+++ b/src/main/java/redis/clients/jedis/mcf/TrackingConnectionPool.java
@@ -16,6 +16,7 @@ import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.DefaultJedisSocketFactory;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
+import redis.clients.jedis.csc.Cache;
 import redis.clients.jedis.csc.CacheConnection;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
@@ -89,6 +90,7 @@ public class TrackingConnectionPool extends ConnectionPool {
     private HostAndPort hostAndPort;
     private JedisClientConfig clientConfig;
     private GenericObjectPoolConfig<Connection> poolConfig;
+    private Cache cache;
 
     public Builder hostAndPort(HostAndPort hostAndPort) {
       this.hostAndPort = hostAndPort;
@@ -102,6 +104,11 @@ public class TrackingConnectionPool extends ConnectionPool {
 
     public Builder poolConfig(GenericObjectPoolConfig<Connection> poolConfig) {
       this.poolConfig = poolConfig;
+      return this;
+    }
+
+    public Builder cache(Cache cache) {
+      this.cache = cache;
       return this;
     }
 
@@ -125,6 +132,7 @@ public class TrackingConnectionPool extends ConnectionPool {
   private final HostAndPort hostAndPort;
   private final JedisClientConfig clientConfig;
   private final GenericObjectPoolConfig<Connection> poolConfig;
+  private final Cache cache;
   private final AtomicInteger numWaiters = new AtomicInteger();
   private final Set<Connection> poolTrackedObjects = ConcurrentHashMap.newKeySet();
 
@@ -139,19 +147,22 @@ public class TrackingConnectionPool extends ConnectionPool {
     this.hostAndPort = builder.hostAndPort;
     this.clientConfig = builder.clientConfig;
     this.poolConfig = builder.poolConfig;
+    this.cache = builder.cache;
     this.attachAuthenticationListener(builder.clientConfig.getAuthXManager());
   }
 
   private static FailFastConnectionFactory createfailFastFactory(Builder poolBuilder) {
     ConnectionFactory.Builder factoryBuilder = ConnectionFactory.builder()
-        .clientConfig(poolBuilder.clientConfig).socketFactory(
-          new DefaultJedisSocketFactory(poolBuilder.hostAndPort, poolBuilder.clientConfig));
+        .clientConfig(poolBuilder.clientConfig)
+        .socketFactory(
+          new DefaultJedisSocketFactory(poolBuilder.hostAndPort, poolBuilder.clientConfig))
+        .cache(poolBuilder.cache);
     return new FailFastConnectionFactory(factoryBuilder, poolBuilder.clientConfig);
   }
 
   public static TrackingConnectionPool from(TrackingConnectionPool existing) {
     return builder().hostAndPort(existing.hostAndPort).clientConfig(existing.clientConfig)
-        .poolConfig(existing.poolConfig).build();
+        .poolConfig(existing.poolConfig).cache(existing.cache).build();
   }
 
   @Override

--- a/src/test/java/redis/clients/jedis/MultiDbClientTest.java
+++ b/src/test/java/redis/clients/jedis/MultiDbClientTest.java
@@ -67,9 +67,14 @@ public class MultiDbClientTest {
   @BeforeEach
   void setUp() {
     // Create a simple resilient client with mock endpoints for testing
+    // Disable health checks for faster test execution
     MultiDbConfig clientConfig = MultiDbConfig.builder()
-        .database(endpoint1.getHostAndPort(), 100.0f, endpoint1.getClientConfigBuilder().build())
-        .database(endpoint2.getHostAndPort(), 50.0f, endpoint2.getClientConfigBuilder().build())
+        .database(DatabaseConfig
+            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build())
+            .weight(100.0f).healthCheckEnabled(false).build())
+        .database(DatabaseConfig
+            .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().build())
+            .weight(50.0f).healthCheckEnabled(false).build())
         .build();
 
     client = MultiDbClient.builder().multiDbConfig(clientConfig).build();
@@ -117,11 +122,10 @@ public class MultiDbClientTest {
   void testSetActiveDatabase() {
     Endpoint endpoint = client.getActiveDatabaseEndpoint();
 
-    awaitIsHealthy(endpoint1.getHostAndPort());
-    awaitIsHealthy(endpoint2.getHostAndPort());
-    // Ensure we have a healthy endpoint to switch to
+    // With healthCheckEnabled=false, all endpoints are always considered healthy
+    // Find a different endpoint to switch to
     Endpoint newEndpoint = client.getDatabaseEndpoints().stream()
-        .filter(e -> e.equals(endpoint) && client.isHealthy(e)).findFirst().orElse(null);
+        .filter(e -> !e.equals(endpoint)).findFirst().orElse(null);
     assertNotNull(newEndpoint);
 
     // Switch to the new endpoint
@@ -150,14 +154,13 @@ public class MultiDbClientTest {
   public void testForceActiveDatabase() {
     Endpoint endpoint = client.getActiveDatabaseEndpoint();
 
-    // Ensure we have a healthy endpoint to switch to
-    awaitIsHealthy(endpoint1.getHostAndPort());
-    awaitIsHealthy(endpoint2.getHostAndPort());
+    // With healthCheckEnabled=false, endpoints are always considered healthy
+    // Find an endpoint that is not the current one
     Endpoint newEndpoint = client.getDatabaseEndpoints().stream()
-        .filter(e -> e.equals(endpoint) && client.isHealthy(e)).findFirst().orElse(null);
+        .filter(e -> !e.equals(endpoint)).findFirst().orElse(null);
     assertNotNull(newEndpoint);
 
-    // Force switch to the new endpoint for 10 seconds
+    // Force switch to the new endpoint for 100ms
     client.forceActiveDatabase(newEndpoint, Duration.ofMillis(100).toMillis());
 
     // Verify the active endpoint has changed
@@ -166,9 +169,20 @@ public class MultiDbClientTest {
 
   @Test
   public void testForceActiveDatabaseWithNonHealthyEndpoint() {
+    // This test needs health checks enabled to detect an unhealthy endpoint
     Endpoint newEndpoint = new HostAndPort("unavailable", 6381);
-    client.addDatabase(newEndpoint, 25.0f, DefaultJedisClientConfig.builder().build());
+    DatabaseConfig config = DatabaseConfig
+        .builder(newEndpoint, DefaultJedisClientConfig.builder().build())
+        .weight(25.0f)
+        .healthCheckEnabled(true)  // Enable health check to detect unavailable endpoint
+        .build();
+    client.addDatabase(config);
 
+    // Wait for health check to mark it as unhealthy (unavailable endpoint will fail health check)
+    await().atMost(Duration.ofSeconds(3))
+        .until(() -> !client.isHealthy(newEndpoint));
+
+    // Now attempting to force switch to an unhealthy endpoint should throw exception
     assertThrows(JedisValidationException.class,
       () -> client.forceActiveDatabase(newEndpoint, Duration.ofMillis(100).toMillis()));
   }
@@ -186,10 +200,10 @@ public class MultiDbClientTest {
     MultiDbConfig endpointsConfig = MultiDbConfig.builder()
         .database(DatabaseConfig
             .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build())
-            .weight(100.0f).build())
+            .weight(100.0f).healthCheckEnabled(false).build())
         .database(DatabaseConfig
             .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().build())
-            .weight(50.0f).build())
+            .weight(50.0f).healthCheckEnabled(false).build())
         .build();
 
     Consumer<DatabaseSwitchEvent> eventConsumer;
@@ -201,7 +215,7 @@ public class MultiDbClientTest {
 
       assertThat(events.size(), equalTo(0));
 
-      awaitIsHealthy(endpoint2.getHostAndPort());
+      // With healthCheckEnabled=false, no need to wait
       testClient.setActiveDatabase(endpoint2.getHostAndPort());
 
       assertThat(events.size(), equalTo(1));
@@ -298,8 +312,172 @@ public class MultiDbClientTest {
     }
   }
 
-  private void awaitIsHealthy(HostAndPort hostAndPort) {
-    await().atMost(Duration.ofSeconds(1)).until(() -> client.isHealthy(hostAndPort));
+  @Test
+  void testCacheWithMultiDbClientPoolRecreation() {
+    // Create MultiDbClient with cache enabled and fast failover enabled
+    // This tests the scenario where TrackingConnectionPool.from() is called
+    // when switching back to a database whose pool was closed during manual switch
+    MultiDbConfig clientConfig = MultiDbConfig.builder()
+        .database(DatabaseConfig
+            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build())
+            .weight(100.0f).healthCheckEnabled(false).build())
+        .database(DatabaseConfig
+            .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().build())
+            .weight(50.0f).healthCheckEnabled(false).build())
+        .fastFailover(true) // Close pools when switching databases
+        .build();
+
+    try (MultiDbClient cachedClient = MultiDbClient.builder().multiDbConfig(clientConfig)
+        .cacheConfig(CacheConfig.builder().build()).build()) {
+
+      // Verify cache is available
+      Cache cache = cachedClient.getCache();
+      assertNotNull(cache, "Cache should be available");
+      assertEquals(0, cache.getSize(), "Cache should be empty initially");
+
+      // Determine the two endpoints
+      Endpoint firstEndpoint = endpoint1.getHostAndPort();
+      Endpoint secondEndpoint = endpoint2.getHostAndPort();
+
+      // Make sure we start on the first endpoint
+      cachedClient.setActiveDatabase(firstEndpoint);
+      assertEquals(firstEndpoint, cachedClient.getActiveDatabaseEndpoint());
+
+      // Set some values and cache them on first endpoint
+      cachedClient.set("poolrec1", "value1");
+      cachedClient.set("poolrec2", "value2");
+      assertEquals("value1", cachedClient.get("poolrec1"));
+      assertEquals("value2", cachedClient.get("poolrec2"));
+      assertEquals(2, cache.getSize(), "Cache should contain 2 entries");
+
+      // Manually switch to the second endpoint
+      // With fastFailover=true, this closes the first endpoint's pool
+      cachedClient.setActiveDatabase(secondEndpoint);
+      assertEquals(secondEndpoint, cachedClient.getActiveDatabaseEndpoint());
+
+      // Perform operations on the second endpoint
+      cachedClient.set("poolrec3", "value3");
+      assertEquals("value3", cachedClient.get("poolrec3"));
+
+      // Cache should still be functional
+      assertSame(cache, cachedClient.getCache(), "Cache instance should be preserved");
+
+      // Now switch back to the first endpoint
+      // This triggers TrackingConnectionPool.from() because the pool was closed
+      cachedClient.setActiveDatabase(firstEndpoint);
+      assertEquals(firstEndpoint, cachedClient.getActiveDatabaseEndpoint());
+
+      // Verify cache continues to work after pool recreation
+      // This is the key test - the TrackingConnectionPool.from() code path
+      cachedClient.set("poolrec4", "value4");
+      assertEquals("value4", cachedClient.get("poolrec4"));
+
+      // Verify cache is still the same instance and functional
+      assertSame(cache, cachedClient.getCache(), "Cache instance should still be preserved");
+      assertTrue(cachedClient.getCache().getSize() > 0, "Cache should have entries");
+    }
+  }
+
+  @Test
+  void testCacheWithDynamicDatabaseAddition() {
+    // Create MultiDbClient with cache enabled - start with just one database
+    MultiDbConfig clientConfig = MultiDbConfig.builder()
+        .database(DatabaseConfig
+            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build())
+            .weight(100.0f).healthCheckEnabled(false).build())
+        .build();
+
+    try (MultiDbClient cachedClient = MultiDbClient.builder().multiDbConfig(clientConfig)
+        .cacheConfig(CacheConfig.builder().build()).build()) {
+
+      Cache cache = cachedClient.getCache();
+      assertNotNull(cache, "Cache should be available");
+
+      // Set and cache some values on the first endpoint
+      cachedClient.set("dynamic1", "value1");
+      assertEquals("value1", cachedClient.get("dynamic1"));
+      assertTrue(cache.getSize() > 0, "Cache should have entries");
+
+      // Dynamically add a second database with the same cache
+      cachedClient.addDatabase(DatabaseConfig
+          .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().build())
+          .weight(50.0f).healthCheckEnabled(false).build());
+
+      // No need to wait for health check since healthCheckEnabled=false
+
+      // Verify both endpoints are available
+      assertEquals(2, cachedClient.getDatabaseEndpoints().size());
+
+      // Continue operations - cache should work across database additions
+      cachedClient.set("dynamic2", "value2");
+      assertEquals("value2", cachedClient.get("dynamic2"));
+
+      // Switch to the newly added database
+      cachedClient.setActiveDatabase(endpoint2.getHostAndPort());
+      assertEquals(endpoint2.getHostAndPort(), cachedClient.getActiveDatabaseEndpoint());
+
+      // Cache should still be functional after switching
+      cachedClient.set("dynamic3", "value3");
+      assertEquals("value3", cachedClient.get("dynamic3"));
+
+      assertNotNull(cachedClient.getCache(),
+        "Cache should still be available after database switch");
+    }
+  }
+
+  @Test
+  void testCachePreservedAcrossDatabaseSwitches() {
+    // Test that cache instance is shared across database switches
+    MultiDbConfig clientConfig = MultiDbConfig.builder()
+        .database(DatabaseConfig
+            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build())
+            .weight(100.0f).healthCheckEnabled(false).build())
+        .database(DatabaseConfig
+            .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().build())
+            .weight(50.0f).healthCheckEnabled(false).build())
+        .build();
+
+    try (MultiDbClient cachedClient = MultiDbClient.builder().multiDbConfig(clientConfig)
+        .cacheConfig(CacheConfig.builder().maxSize(100).build()).build()) {
+
+      Cache cache = cachedClient.getCache();
+      assertNotNull(cache);
+
+      Endpoint firstEndpoint = cachedClient.getActiveDatabaseEndpoint();
+      // No need to wait for health checks since healthCheckEnabled=false
+
+      Endpoint secondEndpoint = cachedClient.getDatabaseEndpoints().stream()
+          .filter(e -> !e.equals(firstEndpoint)).findFirst().orElse(null);
+      assertNotNull(secondEndpoint, "Should have a second endpoint");
+
+      // Set data on first endpoint
+      cachedClient.set("shared1", "value1");
+      assertEquals("value1", cachedClient.get("shared1"));
+
+      // Switch to second endpoint
+      cachedClient.setActiveDatabase(secondEndpoint);
+      assertEquals(secondEndpoint, cachedClient.getActiveDatabaseEndpoint());
+
+      // Verify cache is the same instance
+      assertSame(cache, cachedClient.getCache(),
+        "Cache instance should be preserved across switches");
+
+      // Set data on second endpoint
+      cachedClient.set("shared2", "value2");
+      assertEquals("value2", cachedClient.get("shared2"));
+
+      // Switch back to first endpoint
+      cachedClient.setActiveDatabase(firstEndpoint);
+      assertEquals(firstEndpoint, cachedClient.getActiveDatabaseEndpoint());
+
+      // Cache should still be the same instance
+      assertSame(cache, cachedClient.getCache(),
+        "Cache instance should be the same after switching back");
+
+      // Verify operations still work
+      cachedClient.set("shared3", "value3");
+      assertEquals("value3", cachedClient.get("shared3"));
+    }
   }
 
 }

--- a/src/test/java/redis/clients/jedis/MultiDbClientTest.java
+++ b/src/test/java/redis/clients/jedis/MultiDbClientTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -15,6 +17,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import redis.clients.jedis.MultiDbConfig.DatabaseConfig;
 import redis.clients.jedis.csc.Cache;
@@ -30,10 +33,15 @@ import java.util.List;
 import java.util.function.Consumer;
 
 /**
- * Basic tests for MultiDbClient functionality.
+ * Basic tests for MultiDbClient functionality. Tests are parameterized to run against both RESP2
+ * and RESP3 protocols. Cache-related tests only run on RESP3 as client-side caching requires RESP3.
  */
+@ParameterizedClass
+@MethodSource("redis.clients.jedis.commands.CommandsTestsParameters#respVersions")
 @Tag("integration")
 public class MultiDbClientTest {
+
+  protected final RedisProtocol protocol;
 
   private MultiDbClient client;
   private static EndpointConfig endpoint1;
@@ -42,6 +50,10 @@ public class MultiDbClientTest {
   private static final ToxiproxyClient tp = new ToxiproxyClient("localhost", 8474);
   private static Proxy redisProxy1;
   private static Proxy redisProxy2;
+
+  public MultiDbClientTest(RedisProtocol protocol) {
+    this.protocol = protocol;
+  }
 
   @BeforeAll
   public static void setupAdminClients() throws IOException {
@@ -70,10 +82,12 @@ public class MultiDbClientTest {
     // Disable health checks for faster test execution
     MultiDbConfig clientConfig = MultiDbConfig.builder()
         .database(DatabaseConfig
-            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build())
+            .builder(endpoint1.getHostAndPort(),
+              endpoint1.getClientConfigBuilder().protocol(protocol).build())
             .weight(100.0f).healthCheckEnabled(false).build())
         .database(DatabaseConfig
-            .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().build())
+            .builder(endpoint2.getHostAndPort(),
+              endpoint2.getClientConfigBuilder().protocol(protocol).build())
             .weight(50.0f).healthCheckEnabled(false).build())
         .build();
 
@@ -91,8 +105,8 @@ public class MultiDbClientTest {
   void testAddRemoveDatabaseWithEndpointInterface() {
     Endpoint newEndpoint = new HostAndPort("unavailable", 6381);
 
-    assertDoesNotThrow(
-      () -> client.addDatabase(newEndpoint, 25.0f, DefaultJedisClientConfig.builder().build()));
+    assertDoesNotThrow(() -> client.addDatabase(newEndpoint, 25.0f,
+      endpoint1.getClientConfigBuilder().protocol(protocol).build()));
 
     assertThat(client.getDatabaseEndpoints(), hasItems(newEndpoint));
 
@@ -107,7 +121,8 @@ public class MultiDbClientTest {
     HostAndPort newEndpoint = new HostAndPort("unavailable", 6381);
 
     DatabaseConfig newConfig = DatabaseConfig
-        .builder(newEndpoint, DefaultJedisClientConfig.builder().build()).weight(25.0f).build();
+        .builder(newEndpoint, endpoint1.getClientConfigBuilder().protocol(protocol).build())
+        .weight(25.0f).build();
 
     assertDoesNotThrow(() -> client.addDatabase(newConfig));
 
@@ -138,10 +153,13 @@ public class MultiDbClientTest {
   @Test
   void testBuilderWithMultipleEndpointTypes() {
     MultiDbConfig clientConfig = MultiDbConfig.builder()
-        .database(endpoint1.getHostAndPort(), 100.0f, DefaultJedisClientConfig.builder().build())
-        .database(DatabaseConfig
-            .builder(endpoint2.getHostAndPort(), DefaultJedisClientConfig.builder().build())
-            .weight(50.0f).build())
+        .database(endpoint1.getHostAndPort(), 100.0f,
+          endpoint1.getClientConfigBuilder().protocol(protocol).build())
+        .database(
+          DatabaseConfig
+              .builder(endpoint2.getHostAndPort(),
+                endpoint2.getClientConfigBuilder().protocol(protocol).build())
+              .weight(50.0f).build())
         .build();
 
     try (MultiDbClient testClient = MultiDbClient.builder().multiDbConfig(clientConfig).build()) {
@@ -175,8 +193,9 @@ public class MultiDbClientTest {
     // This test needs health checks enabled to detect an unhealthy endpoint
     Endpoint newEndpoint = new HostAndPort("unavailable", 6381);
     DatabaseConfig config = DatabaseConfig
-        .builder(newEndpoint, DefaultJedisClientConfig.builder().build()).weight(25.0f)
-        .healthCheckEnabled(true) // Enable health check to detect unavailable endpoint
+        .builder(newEndpoint, endpoint1.getClientConfigBuilder().protocol(protocol).build())
+        .weight(25.0f).healthCheckEnabled(true) // Enable health check to detect unavailable
+                                                // endpoint
         .build();
     client.addDatabase(config);
 
@@ -200,10 +219,12 @@ public class MultiDbClientTest {
 
     MultiDbConfig endpointsConfig = MultiDbConfig.builder()
         .database(DatabaseConfig
-            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build())
+            .builder(endpoint1.getHostAndPort(),
+              endpoint1.getClientConfigBuilder().protocol(protocol).build())
             .weight(100.0f).healthCheckEnabled(false).build())
         .database(DatabaseConfig
-            .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().build())
+            .builder(endpoint2.getHostAndPort(),
+              endpoint2.getClientConfigBuilder().protocol(protocol).build())
             .weight(50.0f).healthCheckEnabled(false).build())
         .build();
 
@@ -272,13 +293,17 @@ public class MultiDbClientTest {
 
   @Test
   void testCacheWithMultiDbClient() {
+    // Client-side caching requires RESP3
+    assumeTrue(protocol == null || protocol == RedisProtocol.RESP3,
+      "Client-side caching is only supported with RESP3");
+
     // Create MultiDbClient with cache enabled
     MultiDbConfig clientConfig = MultiDbConfig.builder()
         .database(DatabaseConfig
-            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build())
+            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().resp3().build())
             .weight(100.0f).healthCheckEnabled(false).build())
         .database(DatabaseConfig
-            .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().build())
+            .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().resp3().build())
             .weight(50.0f).healthCheckEnabled(false).build())
         .build();
 
@@ -319,15 +344,19 @@ public class MultiDbClientTest {
 
   @Test
   void testCacheWithMultiDbClientPoolRecreation() {
+    // Client-side caching requires RESP3
+    assumeTrue(protocol == null || protocol == RedisProtocol.RESP3,
+      "Client-side caching is only supported with RESP3");
+
     // Create MultiDbClient with cache enabled and fast failover enabled
     // This tests the scenario where TrackingConnectionPool.from() is called
     // when switching back to a database whose pool was closed during manual switch
     MultiDbConfig clientConfig = MultiDbConfig.builder()
         .database(DatabaseConfig
-            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build())
+            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().resp3().build())
             .weight(100.0f).healthCheckEnabled(false).build())
         .database(DatabaseConfig
-            .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().build())
+            .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().resp3().build())
             .weight(50.0f).healthCheckEnabled(false).build())
         .fastFailover(true) // Close pools when switching databases
         .build();
@@ -385,10 +414,14 @@ public class MultiDbClientTest {
 
   @Test
   void testCacheWithDynamicDatabaseAddition() {
+    // Client-side caching requires RESP3
+    assumeTrue(protocol == null || protocol == RedisProtocol.RESP3,
+      "Client-side caching is only supported with RESP3");
+
     // Create MultiDbClient with cache enabled - start with just one database
     MultiDbConfig clientConfig = MultiDbConfig.builder()
         .database(DatabaseConfig
-            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build())
+            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().resp3().build())
             .weight(100.0f).healthCheckEnabled(false).build())
         .build();
 
@@ -405,7 +438,7 @@ public class MultiDbClientTest {
 
       // Dynamically add a second database with the same cache
       cachedClient.addDatabase(DatabaseConfig
-          .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().build())
+          .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().resp3().build())
           .weight(50.0f).healthCheckEnabled(false).build());
 
       // No need to wait for health check since healthCheckEnabled=false
@@ -432,13 +465,17 @@ public class MultiDbClientTest {
 
   @Test
   void testCachePreservedAcrossDatabaseSwitches() {
+    // Client-side caching requires RESP3
+    assumeTrue(protocol == null || protocol == RedisProtocol.RESP3,
+      "Client-side caching is only supported with RESP3");
+
     // Test that cache instance is shared across database switches
     MultiDbConfig clientConfig = MultiDbConfig.builder()
         .database(DatabaseConfig
-            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build())
+            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().resp3().build())
             .weight(100.0f).healthCheckEnabled(false).build())
         .database(DatabaseConfig
-            .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().build())
+            .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().resp3().build())
             .weight(50.0f).healthCheckEnabled(false).build())
         .build();
 

--- a/src/test/java/redis/clients/jedis/MultiDbClientTest.java
+++ b/src/test/java/redis/clients/jedis/MultiDbClientTest.java
@@ -122,10 +122,11 @@ public class MultiDbClientTest {
   void testSetActiveDatabase() {
     Endpoint endpoint = client.getActiveDatabaseEndpoint();
 
-    // With healthCheckEnabled=false, all endpoints are always considered healthy
+    awaitIsHealthy(endpoint1.getHostAndPort());
+    awaitIsHealthy(endpoint2.getHostAndPort());
     // Find a different endpoint to switch to
-    Endpoint newEndpoint = client.getDatabaseEndpoints().stream()
-        .filter(e -> !e.equals(endpoint)).findFirst().orElse(null);
+    Endpoint newEndpoint = client.getDatabaseEndpoints().stream().filter(e -> !e.equals(endpoint))
+        .findFirst().orElse(null);
     assertNotNull(newEndpoint);
 
     // Switch to the new endpoint
@@ -154,10 +155,12 @@ public class MultiDbClientTest {
   public void testForceActiveDatabase() {
     Endpoint endpoint = client.getActiveDatabaseEndpoint();
 
-    // With healthCheckEnabled=false, endpoints are always considered healthy
+    // Ensure we have a healthy endpoint to switch to
+    awaitIsHealthy(endpoint1.getHostAndPort());
+    awaitIsHealthy(endpoint2.getHostAndPort());
     // Find an endpoint that is not the current one
-    Endpoint newEndpoint = client.getDatabaseEndpoints().stream()
-        .filter(e -> !e.equals(endpoint)).findFirst().orElse(null);
+    Endpoint newEndpoint = client.getDatabaseEndpoints().stream().filter(e -> !e.equals(endpoint))
+        .findFirst().orElse(null);
     assertNotNull(newEndpoint);
 
     // Force switch to the new endpoint for 100ms
@@ -172,15 +175,13 @@ public class MultiDbClientTest {
     // This test needs health checks enabled to detect an unhealthy endpoint
     Endpoint newEndpoint = new HostAndPort("unavailable", 6381);
     DatabaseConfig config = DatabaseConfig
-        .builder(newEndpoint, DefaultJedisClientConfig.builder().build())
-        .weight(25.0f)
-        .healthCheckEnabled(true)  // Enable health check to detect unavailable endpoint
+        .builder(newEndpoint, DefaultJedisClientConfig.builder().build()).weight(25.0f)
+        .healthCheckEnabled(true) // Enable health check to detect unavailable endpoint
         .build();
     client.addDatabase(config);
 
     // Wait for health check to mark it as unhealthy (unavailable endpoint will fail health check)
-    await().atMost(Duration.ofSeconds(3))
-        .until(() -> !client.isHealthy(newEndpoint));
+    await().atMost(Duration.ofSeconds(3)).until(() -> !client.isHealthy(newEndpoint));
 
     // Now attempting to force switch to an unhealthy endpoint should throw exception
     assertThrows(JedisValidationException.class,
@@ -273,8 +274,12 @@ public class MultiDbClientTest {
   void testCacheWithMultiDbClient() {
     // Create MultiDbClient with cache enabled
     MultiDbConfig clientConfig = MultiDbConfig.builder()
-        .database(endpoint1.getHostAndPort(), 100.0f, endpoint1.getClientConfigBuilder().build())
-        .database(endpoint2.getHostAndPort(), 50.0f, endpoint2.getClientConfigBuilder().build())
+        .database(DatabaseConfig
+            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build())
+            .weight(100.0f).healthCheckEnabled(false).build())
+        .database(DatabaseConfig
+            .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().build())
+            .weight(50.0f).healthCheckEnabled(false).build())
         .build();
 
     try (MultiDbClient cachedClient = MultiDbClient.builder().multiDbConfig(clientConfig)
@@ -478,6 +483,10 @@ public class MultiDbClientTest {
       cachedClient.set("shared3", "value3");
       assertEquals("value3", cachedClient.get("shared3"));
     }
+  }
+
+  private void awaitIsHealthy(HostAndPort hostAndPort) {
+    await().atMost(Duration.ofSeconds(1)).until(() -> client.isHealthy(hostAndPort));
   }
 
 }

--- a/src/test/java/redis/clients/jedis/MultiDbClientTest.java
+++ b/src/test/java/redis/clients/jedis/MultiDbClientTest.java
@@ -2,12 +2,15 @@ package redis.clients.jedis;
 
 import eu.rekawek.toxiproxy.Proxy;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
+import io.redis.test.annotations.SinceRedisVersion;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -25,6 +28,7 @@ import redis.clients.jedis.csc.CacheConfig;
 import redis.clients.jedis.exceptions.JedisValidationException;
 import redis.clients.jedis.mcf.DatabaseSwitchEvent;
 import redis.clients.jedis.mcf.SwitchReason;
+import redis.clients.jedis.util.RedisVersionCondition;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -50,6 +54,9 @@ public class MultiDbClientTest {
   private static final ToxiproxyClient tp = new ToxiproxyClient("localhost", 8474);
   private static Proxy redisProxy1;
   private static Proxy redisProxy2;
+
+  @RegisterExtension
+  public RedisVersionCondition versionCondition = new RedisVersionCondition(() -> endpoint1);
 
   public MultiDbClientTest(RedisProtocol protocol) {
     this.protocol = protocol;
@@ -292,6 +299,7 @@ public class MultiDbClientTest {
   }
 
   @Test
+  @SinceRedisVersion(value = "7.4.0", message = "Jedis client-side caching is only supported with Redis 7.4 or later.")
   void testCacheWithMultiDbClient() {
     // Client-side caching requires RESP3
     assumeTrue(protocol == null || protocol == RedisProtocol.RESP3,
@@ -343,6 +351,7 @@ public class MultiDbClientTest {
   }
 
   @Test
+  @SinceRedisVersion(value = "7.4.0", message = "Jedis client-side caching is only supported with Redis 7.4 or later.")
   void testCacheWithMultiDbClientPoolRecreation() {
     // Client-side caching requires RESP3
     assumeTrue(protocol == null || protocol == RedisProtocol.RESP3,
@@ -413,6 +422,7 @@ public class MultiDbClientTest {
   }
 
   @Test
+  @SinceRedisVersion(value = "7.4.0", message = "Jedis client-side caching is only supported with Redis 7.4 or later.")
   void testCacheWithDynamicDatabaseAddition() {
     // Client-side caching requires RESP3
     assumeTrue(protocol == null || protocol == RedisProtocol.RESP3,
@@ -464,6 +474,7 @@ public class MultiDbClientTest {
   }
 
   @Test
+  @SinceRedisVersion(value = "7.4.0", message = "Jedis client-side caching is only supported with Redis 7.4 or later.")
   void testCachePreservedAcrossDatabaseSwitches() {
     // Client-side caching requires RESP3
     assumeTrue(protocol == null || protocol == RedisProtocol.RESP3,

--- a/src/test/java/redis/clients/jedis/MultiDbClientTest.java
+++ b/src/test/java/redis/clients/jedis/MultiDbClientTest.java
@@ -17,6 +17,8 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.*;
 
 import redis.clients.jedis.MultiDbConfig.DatabaseConfig;
+import redis.clients.jedis.csc.Cache;
+import redis.clients.jedis.csc.CacheConfig;
 import redis.clients.jedis.exceptions.JedisValidationException;
 import redis.clients.jedis.mcf.DatabaseSwitchEvent;
 import redis.clients.jedis.mcf.SwitchReason;
@@ -251,6 +253,49 @@ public class MultiDbClientTest {
 
     client.setWeight(endpoint, 1.0f);
     assertEquals(1.0f, client.getWeight(endpoint));
+  }
+
+  @Test
+  void testCacheWithMultiDbClient() {
+    // Create MultiDbClient with cache enabled
+    MultiDbConfig clientConfig = MultiDbConfig.builder()
+        .database(endpoint1.getHostAndPort(), 100.0f, endpoint1.getClientConfigBuilder().build())
+        .database(endpoint2.getHostAndPort(), 50.0f, endpoint2.getClientConfigBuilder().build())
+        .build();
+
+    try (MultiDbClient cachedClient = MultiDbClient.builder().multiDbConfig(clientConfig)
+        .cacheConfig(CacheConfig.builder().build()).build()) {
+
+      // Verify cache is available
+      Cache cache = cachedClient.getCache();
+      assertNotNull(cache, "Cache should be available");
+      assertEquals(0, cache.getSize(), "Cache should be empty initially");
+
+      // Set some values
+      cachedClient.set("key1", "value1");
+      cachedClient.set("key2", "value2");
+      cachedClient.set("key3", "value3");
+
+      // First read - should cache the values
+      assertEquals("value1", cachedClient.get("key1"));
+      assertEquals("value2", cachedClient.get("key2"));
+      assertEquals("value3", cachedClient.get("key3"));
+
+      // Verify cache has entries
+      assertEquals(3, cache.getSize(), "Cache should contain 3 entries");
+
+      // Second read - should hit the cache
+      assertEquals("value1", cachedClient.get("key1"));
+      assertEquals("value2", cachedClient.get("key2"));
+
+      // Flush the cache
+      cache.flush();
+      assertEquals(0, cache.getSize(), "Cache should be empty after flush");
+
+      // Read again - should populate cache again
+      assertEquals("value1", cachedClient.get("key1"));
+      assertEquals(1, cache.getSize(), "Cache should contain 1 entry after reading");
+    }
   }
 
   private void awaitIsHealthy(HostAndPort hostAndPort) {

--- a/src/test/java/redis/clients/jedis/csc/RedisClientSideCacheTestBase.java
+++ b/src/test/java/redis/clients/jedis/csc/RedisClientSideCacheTestBase.java
@@ -9,6 +9,7 @@ import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.params.ClientKillParams;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class RedisClientSideCacheTestBase extends UnifiedJedisClientSideCacheTestBase {
 
@@ -52,11 +53,8 @@ public abstract class RedisClientSideCacheTestBase extends UnifiedJedisClientSid
         killer.clientKill(ClientKillParams.clientKillParams().type(ClientType.NORMAL).skipMe(ClientKillParams.SkipMe.YES));
       }
 
-      try {
-        jedis.get("foo");
-      } catch (JedisConnectionException jce) {
-        // expected
-      }
+      assertThrows(JedisConnectionException.class, () -> jedis.get("foo"));
+
       assertEquals(0, cache.getSize());
     }
   }

--- a/src/test/java/redis/clients/jedis/csc/RedisMultiDbClientSideCacheTest.java
+++ b/src/test/java/redis/clients/jedis/csc/RedisMultiDbClientSideCacheTest.java
@@ -7,16 +7,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import redis.clients.jedis.*;
 import redis.clients.jedis.MultiDbConfig.DatabaseConfig;
 import redis.clients.jedis.args.ClientType;
 import redis.clients.jedis.params.ClientKillParams;
+import redis.clients.jedis.util.RedisVersionCondition;
 
 @SinceRedisVersion(value = "7.4.0", message = "Jedis client-side caching is only supported with Redis 7.4 or later.")
 @Tag("integration")
 public class RedisMultiDbClientSideCacheTest extends UnifiedJedisClientSideCacheTestBase {
 
   protected static EndpointConfig endpoint;
+
+  @RegisterExtension
+  public static RedisVersionCondition versionCondition = new RedisVersionCondition(
+      () -> Endpoints.getRedisEndpoint("standalone0"));
 
   @BeforeAll
   public static void prepare() {

--- a/src/test/java/redis/clients/jedis/csc/RedisMultiDbClientSideCacheTest.java
+++ b/src/test/java/redis/clients/jedis/csc/RedisMultiDbClientSideCacheTest.java
@@ -1,0 +1,69 @@
+package redis.clients.jedis.csc;
+
+import io.redis.test.annotations.SinceRedisVersion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.*;
+import redis.clients.jedis.MultiDbConfig.DatabaseConfig;
+import redis.clients.jedis.args.ClientType;
+import redis.clients.jedis.params.ClientKillParams;
+
+@SinceRedisVersion(value = "7.4.0", message = "Jedis client-side caching is only supported with Redis 7.4 or later.")
+@Tag("integration")
+public class RedisMultiDbClientSideCacheTest extends UnifiedJedisClientSideCacheTestBase {
+
+  protected static EndpointConfig endpoint;
+
+  @BeforeAll
+  public static void prepare() {
+    endpoint = Endpoints.getRedisEndpoint("standalone0");
+  }
+
+  @Override
+  protected UnifiedJedis createRegularJedis() {
+    return RedisClient.builder().hostAndPort(endpoint.getHostAndPort())
+        .clientConfig(endpoint.getClientConfigBuilder().build()).build();
+  }
+
+  @Override
+  protected MultiDbClient createCachedJedis(CacheConfig cacheConfig) {
+    DatabaseConfig dbConfig = DatabaseConfig
+        .builder(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder().build()).build();
+
+    MultiDbConfig multiDbConfig = MultiDbConfig.builder().database(dbConfig).build();
+
+    return MultiDbClient.builder().multiDbConfig(multiDbConfig)
+        .clientConfig(endpoint.getClientConfigBuilder().build()).cacheConfig(cacheConfig).build();
+  }
+
+  @Test
+  public void clearIfOneDiesTest() {
+    try (MultiDbClient jedis = createCachedJedis(CacheConfig.builder().build())) {
+      Cache cache = jedis.getCache();
+      // Create 100 keys
+      for (int i = 0; i < 100; i++) {
+        jedis.set("key" + i, "value" + i);
+      }
+      assertEquals(0, cache.getSize());
+
+      // Get 100 keys into the cache
+      for (int i = 0; i < 100; i++) {
+        jedis.get("key" + i);
+      }
+      assertEquals(100, cache.getSize());
+
+      try (Jedis killer = new Jedis(endpoint.getHostAndPort(),
+          endpoint.getClientConfigBuilder().serverDefaultProtocol().build())) {
+        killer.clientKill(ClientKillParams.clientKillParams().type(ClientType.NORMAL)
+            .skipMe(ClientKillParams.SkipMe.YES));
+      }
+      jedis.get("foo");
+
+      assertEquals(1, cache.getSize());
+    }
+  }
+}

--- a/src/test/java/redis/clients/jedis/mcf/MultiDbCSCTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiDbCSCTest.java
@@ -1,0 +1,139 @@
+package redis.clients.jedis.mcf;
+
+import org.junit.jupiter.api.*;
+import redis.clients.jedis.*;
+import redis.clients.jedis.MultiDbConfig.DatabaseConfig;
+import redis.clients.jedis.csc.Cache;
+import redis.clients.jedis.csc.CacheConfig;
+import redis.clients.jedis.csc.CacheFactory;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.mcf.MultiDbConnectionProvider.Database;
+import redis.clients.jedis.util.SafeEncoder;
+import redis.clients.jedis.util.server.TcpMockServer;
+import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class MultiDbCSCTest {
+
+  TcpMockServer server;
+  TcpMockServer server2;
+  Cache cache;
+  HostAndPort active;
+  HostAndPort standby;
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    cache = spy(CacheFactory.getCache(CacheConfig.builder().build()));
+    server = new TcpMockServer();
+    server2 = new TcpMockServer();
+    server.start();
+    server2.start();
+    active = new HostAndPort("localhost", server.getPort());
+    standby = new HostAndPort("localhost", server2.getPort());
+  }
+
+  @AfterEach
+  public void tearDown() throws IOException {
+    server.stop();
+    server2.stop();
+  }
+
+  @Test
+  public void databaseSwitch_flushesClientSideCache() throws IOException {
+    // SET is not cacheable, so it goes straight to the server; answer it so the pre-MULTI command
+    // completes and the cached connection is returned to the pool (idle) before the switch.
+    server.setCommandHandler(
+      (args, clientId) -> "SET".equals(SafeEncoder.encode(args.getCommand().getRaw())) ? "+OK\r\n"
+          : null);
+
+    MultiDbConnectionProvider p = twoDbProvider(active, standby, true, cache);
+    MultiDbClient client = MultiDbClient.builder().connectionProvider(p).build();
+    try {
+      Database standbyDb = p.getDatabase(standby);
+
+      client.set("foo", "bar");
+
+      // Ignore any cache interactions during warm-up; only care about the flush on switch.
+      reset(cache);
+
+      // Switching away from the active database force-disconnects its pool and flushes the cache.
+      p.setActiveDatabase(standby);
+
+      assertEquals(standbyDb, p.getDatabase(), "active database should have switched");
+      verify(cache, atLeastOnce()).flush();
+    } finally {
+      p.close();
+
+    }
+  }
+
+  @Test
+  public void connectionClose_flushesClientSideCache() throws IOException {
+    server.setCommandHandler((args, clientId) -> {
+      return null; // ( anything unhandled) -> server closes the connection
+    });
+
+    HostAndPort standby = new HostAndPort("fake-standby", 6379);
+
+    MultiDbConnectionProvider p = twoDbProvider(active, standby, false, cache);
+    MultiDbClient client = MultiDbClient.builder().connectionProvider(p).build();
+
+    try {
+      reset(cache);
+      assertThrows(JedisConnectionException.class, () -> client.set("foo", "bar"));
+
+      // Destroying the broken CacheConnection disconnects it and flushes the client-side cache.
+      verify(cache, atLeastOnce()).flush();
+    } finally {
+      p.close();
+    }
+  }
+
+  @Test
+  public void databaseSwitch_notFlushesClientSideCache() throws IOException {
+    // SET is not cacheable, so it goes straight to the server; answer it so the pre-MULTI command
+    // completes and the cached connection is returned to the pool (idle) before the switch.
+    server.setCommandHandler(
+      (args, clientId) -> "SET".equals(SafeEncoder.encode(args.getCommand().getRaw())) ? "+OK\r\n"
+          : null);
+
+    MultiDbConnectionProvider p = twoDbProvider(active, standby, false, cache);
+    MultiDbClient client = MultiDbClient.builder().connectionProvider(p).build();
+    try {
+      Database standbyDb = p.getDatabase(standby);
+      client.set("foo", "bar");
+
+      // Ignore any cache interactions during warm-up; only care about the flush on switch.
+      reset(cache);
+
+      // Switching away from the active database force-disconnects its pool and flushes the cache.
+      p.setActiveDatabase(standby);
+
+      assertEquals(standbyDb, p.getDatabase(), "active database should have switched");
+      verify(cache, never()).flush();
+    } finally {
+      p.close();
+    }
+  }
+
+  private static MultiDbConnectionProvider twoDbProvider(HostAndPort active, HostAndPort standby,
+      boolean fastFailover, Cache cache) {
+    JedisClientConfig clientConfig = DefaultJedisClientConfig.builder()
+        .protocol(RedisProtocol.RESP3).build();
+
+    DatabaseConfig activeDb = DatabaseConfig.builder(active, clientConfig).healthCheckEnabled(false)
+        .weight(100.0f).build();
+    DatabaseConfig standbyDb = DatabaseConfig.builder(standby, clientConfig)
+        .healthCheckEnabled(false).weight(1.0f).build();
+    MultiDbConfig cfg = MultiDbConfig.builder(new DatabaseConfig[] { activeDb, standbyDb })
+        .commandRetry(MultiDbConfig.RetryConfig.builder().maxAttempts(1).build())
+        .fastFailover(fastFailover).build();
+    return cache == null ? new MultiDbConnectionProvider(cfg)
+        : new MultiDbConnectionProvider(cfg, cache);
+  }
+}

--- a/src/test/java/redis/clients/jedis/mcf/MultiDbTransactionIT.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiDbTransactionIT.java
@@ -13,21 +13,17 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-
 import redis.clients.jedis.BuilderFactory;
 import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.CommandObject;
 import redis.clients.jedis.ConnectionPool;
 import redis.clients.jedis.EndpointConfig;
 import redis.clients.jedis.Endpoints;
-import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.MultiDbClient;
 import redis.clients.jedis.MultiDbConfig;
 import redis.clients.jedis.MultiDbConfig.DatabaseConfig;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.Response;
-import redis.clients.jedis.csc.CacheConfig;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.util.ClientTestUtil;
@@ -218,8 +214,7 @@ public class MultiDbTransactionIT {
 
     MultiDbConfig config = MultiDbConfig.builder(new DatabaseConfig[] { db1, db2 }).build();
 
-    MultiDbClient twoDbClient = MultiDbClient.builder().cacheConfig(CacheConfig.builder().build())
-        .multiDbConfig(config).build();
+    MultiDbClient twoDbClient = MultiDbClient.builder().multiDbConfig(config).build();
 
     try {
       try (MultiDbTransaction tx = twoDbClient.transaction(false)) {

--- a/src/test/java/redis/clients/jedis/mcf/MultiDbTransactionIT.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiDbTransactionIT.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import redis.clients.jedis.BuilderFactory;
 import redis.clients.jedis.CommandArguments;
@@ -20,12 +21,15 @@ import redis.clients.jedis.CommandObject;
 import redis.clients.jedis.ConnectionPool;
 import redis.clients.jedis.EndpointConfig;
 import redis.clients.jedis.Endpoints;
+import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.MultiDbClient;
 import redis.clients.jedis.MultiDbConfig;
 import redis.clients.jedis.MultiDbConfig.DatabaseConfig;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.Response;
+import redis.clients.jedis.csc.CacheConfig;
 import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.util.ClientTestUtil;
 
 /**
@@ -38,11 +42,13 @@ import redis.clients.jedis.util.ClientTestUtil;
 public class MultiDbTransactionIT {
 
   private static EndpointConfig endpoint;
+  private static EndpointConfig endpoint2;
   private MultiDbClient client;
 
   @BeforeAll
   public static void prepareEndpoints() {
     endpoint = Endpoints.getRedisEndpoint("standalone0");
+    endpoint2 = Endpoints.getRedisEndpoint("standalone1");
   }
 
   @BeforeEach
@@ -195,4 +201,47 @@ public class MultiDbTransactionIT {
     assertEquals("OK", client.set("x", "y"));
     assertEquals("y", client.get("x"));
   }
+
+  /**
+   * When the active database changes while a transaction is open, {@link MultiDbTransaction#exec()}
+   * must detect the switch, roll back and refuse to run the buffered commands against the new
+   * database.
+   */
+  @Test
+  public void exec_whenActiveDatabaseChangesMidTransaction_throws() {
+    DatabaseConfig db1 = DatabaseConfig
+        .builder(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder().build())
+        .weight(100.0f).healthCheckEnabled(false).build();
+    DatabaseConfig db2 = DatabaseConfig
+        .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().build())
+        .weight(1.0f).healthCheckEnabled(false).build();
+
+    MultiDbConfig config = MultiDbConfig.builder(new DatabaseConfig[] { db1, db2 }).build();
+
+    MultiDbClient twoDbClient = MultiDbClient.builder().cacheConfig(CacheConfig.builder().build())
+        .multiDbConfig(config).build();
+
+    try {
+      try (MultiDbTransaction tx = twoDbClient.transaction(false)) {
+        // WATCH borrows a connection and pins the initial database without committing anything.
+        assertEquals("OK", tx.watch("a"));
+        tx.multi();
+        tx.set("a", "1");
+
+        // Switch the active database while the transaction is open. Without fast failover the
+        // already-borrowed connection stays usable, so exec() reaches its own switch check.
+        twoDbClient.setActiveDatabase(endpoint2.getHostAndPort());
+
+        JedisException ex = assertThrows(JedisException.class, tx::exec);
+        assertTrue(ex.getMessage().contains("Active database has changed"),
+          "expected active-database-changed error, got: " + ex.getMessage());
+      }
+
+      // The transaction was aborted, so nothing was committed on the new database.
+      assertNull(twoDbClient.get("a"));
+    } finally {
+      twoDbClient.close();
+    }
+  }
+
 }

--- a/src/test/java/redis/clients/jedis/mcf/MultiDbTransactionUnitTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiDbTransactionUnitTest.java
@@ -8,8 +8,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,12 +28,14 @@ import redis.clients.jedis.CommandObjects;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.MultiDbConfig;
 import redis.clients.jedis.MultiDbConfig.DatabaseConfig;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.Response;
 import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.mcf.MultiDbConnectionProvider.Database;
 import redis.clients.jedis.util.ReflectionTestUtil;
 
@@ -213,4 +217,59 @@ public class MultiDbTransactionUnitTest {
     // no command was issued, so the supplier was never touched
     verify(poolMock, never()).getResource();
   }
+
+  @Test
+  public void exec_whenActiveDatabaseChangesMidTransaction_throws() {
+    HostAndPort active = fakeEndpoint;
+    HostAndPort standby = new HostAndPort("fake-standby", 6379);
+
+    JedisClientConfig clientConfig = DefaultJedisClientConfig.builder()
+        .protocol(RedisProtocol.RESP3).build();
+
+    DatabaseConfig activeDb = DatabaseConfig.builder(active, clientConfig).healthCheckEnabled(false)
+        .weight(100.0f).build();
+    DatabaseConfig standbyDb = DatabaseConfig.builder(standby, clientConfig)
+        .healthCheckEnabled(false).weight(1.0f).build();
+    MultiDbConfig cfg = MultiDbConfig.builder(new DatabaseConfig[] { activeDb, standbyDb })
+        .commandRetry(MultiDbConfig.RetryConfig.builder().maxAttempts(1).build()).build();
+    MultiDbConnectionProvider p = new MultiDbConnectionProvider(cfg);
+
+    try {
+      Connection conn = mock(Connection.class);
+      when(conn.executeCommand(any(CommandObject.class))).thenReturn("OK".getBytes());
+
+      Database initial = p.getDatabase();
+      Database other = p.getDatabase(standby);
+      initial = spy(initial);
+      doReturn(conn).when(initial).getConnection();
+      other = spy(other);
+      doReturn(conn).when(other).getConnection();
+
+      p = spy(p);
+      // 1 - initial: for acquiring the conn
+      // 2 - initial: for the pre-MULTI command
+      // 3 - other: for the database switch check during exec()
+      when(p.getDatabase()).thenReturn(initial).thenReturn(initial).thenReturn(other);
+
+      // doMulti=false: the pre-MULTI command borrows a connection and pins the initial database.
+      MultiDbTransaction tx = new MultiDbTransaction(p, false,
+          new CommandObjects(RedisProtocol.RESP3));
+      tx.set("k", "v");
+      tx.multi();
+      tx.set("k", "v2");
+
+      // Simulate a database switch happening between MULTI buffering and exec().
+      ReflectionTestUtil.setField(p, "activeDatabase", other);
+
+      JedisException ex = assertThrows(JedisException.class, tx::exec);
+      assertTrue(ex.getMessage().contains("Active database has changed"),
+        "expected active-database-changed error, got: " + ex.getMessage());
+
+      verify(conn, times(1)).executeCommand(any(CommandArguments.class));
+      verify(conn, atLeastOnce()).close();
+    } finally {
+      p.close();
+    }
+  }
+
 }


### PR DESCRIPTION
## Summary
This PR fixes client-side caching support with `MultiDbConnectionProvider` by threading the `Cache` instance through the connection provider and pool layers.

## Changes

### Core Implementation
- **`MultiDbConnectionProvider`**: Added new constructor accepting `Cache` parameter and updated pool creation to pass cache to `TrackingConnectionPool`
- **`TrackingConnectionPool`**: Extended builder pattern to accept and propagate `Cache` through connection factory and pool recreation
- **`MultiDbClientBuilder`**: Updated to pass cache instance when constructing `MultiDbConnectionProvider`

### Key Features
- Cache instance is shared across all database connections in a multi-database setup
- Cache is preserved during database switches and pool recreations
- Backward compatibility maintained with no-arg constructor for non-cached scenarios

### Testing
Added comprehensive test coverage including:
- Basic cache functionality with `MultiDbClient`
- Cache preservation during pool recreation (fast failover scenario)
- Cache behavior with dynamic database additions
- Cache persistence across database switches

### Test Improvements
- Disabled health checks in most tests for faster execution
- Updated test assertions to work with health check disabled mode
- Added proper health check configuration for tests that need it

## Files Changed
- `MultiDbConnectionProvider.java` - Added cache support with dual constructors
- `TrackingConnectionPool.java` - Enhanced builder to accept and propagate cache
- `MultiDbClientBuilder.java` - Updated provider instantiation to include cache
- `MultiDbClientTest.java` - Added 4 new cache-related tests and improved existing tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect multi-database connection pooling and cache invalidation on failover/switch; incorrect cache sharing could serve stale data across endpoints, though behavior is heavily tested.
> 
> **Overview**
> **MultiDbClient** can now use **client-side caching (CSC)** by passing the builder’s `Cache` into `MultiDbConnectionProvider`, through `TrackingConnectionPool` / `ConnectionFactory`, so pooled connections become `CacheConnection` when a cache is configured. The same cache instance is reused when pools are rebuilt via `TrackingConnectionPool.from()` (e.g. after **fast failover** closes the old pool).
> 
> `MultiDbClientBuilder` constructs the provider with `cache`; the original single-arg provider constructor remains for non-cached setups.
> 
> Tests add RESP2/RESP3 parameterization for `MultiDbClientTest`, CSC integration scenarios (switches, dynamic DB add, pool recreation), `RedisMultiDbClientSideCacheTest`, mock-server `MultiDbCSCTest` (flush on fast-failover switch vs no flush otherwise), and coverage for **mid-transaction active-database switches** on `MultiDbTransaction`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fc551898f7b1681fa9a06c9c8bdb0883229be0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->