### PR TITLE
[maintenance events] Wire maintenance config/controller into multidb components 

### DIFF
--- a/src/main/java/redis/clients/jedis/ConnectionFactory.java
+++ b/src/main/java/redis/clients/jedis/ConnectionFactory.java
@@ -83,6 +83,10 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
 
     public ConnectionFactory build() {
       withDefaults();
+      return create();
+    }
+
+    protected ConnectionFactory create() {
       return new ConnectionFactory(this);
     }
 

--- a/src/main/java/redis/clients/jedis/ConnectionPool.java
+++ b/src/main/java/redis/clients/jedis/ConnectionPool.java
@@ -60,12 +60,12 @@ public class ConnectionPool extends Pool<Connection> {
     attachAuthenticationListener(clientConfig.getAuthXManager());
   }
 
-
   @Experimental
   public ConnectionPool(HostAndPort hostAndPort, JedisClientConfig clientConfig,
       Cache clientSideCache, GenericObjectPoolConfig<Connection> poolConfig,
       MaintenanceNotificationsConfig maintConfig) {
-    this(controllerFor(maintConfig), hostAndPort, clientConfig, clientSideCache, poolConfig);
+    this(ConnectionFactory.builder().hostAndPort(hostAndPort).clientConfig(clientConfig)
+        .cache(clientSideCache), poolConfig, maintConfig);
   }
 
   private static MaintenanceEventController controllerFor(MaintenanceNotificationsConfig config) {
@@ -73,13 +73,17 @@ public class ConnectionPool extends Pool<Connection> {
         : null;
   }
 
-  private ConnectionPool(MaintenanceEventController controller, HostAndPort hostAndPort,
-      JedisClientConfig clientConfig, Cache clientSideCache,
-      GenericObjectPoolConfig<Connection> poolConfig) {
-    this(ConnectionFactory.builder().hostAndPort(hostAndPort).clientConfig(clientConfig)
-        .cache(clientSideCache).maintenanceController(controller).build(), poolConfig);
+  @Experimental
+  public ConnectionPool(ConnectionFactory.Builder factoryBuilder,
+      GenericObjectPoolConfig<Connection> poolConfig, MaintenanceNotificationsConfig maintConfig) {
+    this(factoryBuilder, poolConfig, controllerFor(maintConfig));
+  }
+
+  private ConnectionPool(ConnectionFactory.Builder factoryBuilder,
+      GenericObjectPoolConfig<Connection> poolConfig, MaintenanceEventController controller) {
+    this(factoryBuilder.maintenanceController(controller).build(), poolConfig);
     this.maintenanceController = controller;
-    attachAuthenticationListener(clientConfig.getAuthXManager());
+    attachAuthenticationListener(factoryBuilder.getClientConfig().getAuthXManager());
     if (controller != null) {
       setEvictionPolicy(new RebindAwareEvictionPolicy(controller, getEvictionPolicy()));
       controller.addHandoffHook(handoff -> evictQuietly());

--- a/src/main/java/redis/clients/jedis/MultiDbConfig.java
+++ b/src/main/java/redis/clients/jedis/MultiDbConfig.java
@@ -862,6 +862,9 @@ public final class MultiDbConfig {
     /** Jedis client configuration containing connection settings and authentication. */
     private final JedisClientConfig jedisClientConfig;
 
+    /** Maintenance notifications configuration for this database. */
+    private final MaintenanceNotificationsConfig maintenanceNotificationsConfig;
+
     /** Optional connection pool configuration for managing connections to this database. */
     private GenericObjectPoolConfig<Connection> connectionPoolConfig;
 
@@ -894,6 +897,7 @@ public final class MultiDbConfig {
     public DatabaseConfig(Endpoint endpoint, JedisClientConfig clientConfig) {
       this.endpoint = endpoint;
       this.jedisClientConfig = clientConfig;
+      this.maintenanceNotificationsConfig = null;
     }
 
     /**
@@ -907,6 +911,7 @@ public final class MultiDbConfig {
       this.weight = builder.weight;
       this.healthCheckEnabled = builder.healthCheckEnabled;
       this.healthCheckStrategySupplier = builder.healthCheckStrategySupplier;
+      this.maintenanceNotificationsConfig = builder.maintenanceNotificationsConfig;
     }
 
     /**
@@ -935,6 +940,14 @@ public final class MultiDbConfig {
      */
     public JedisClientConfig getJedisClientConfig() {
       return jedisClientConfig;
+    }
+
+    /**
+     * Returns the maintenance notifications configuration for this database.
+     * @return the maintenance notifications configuration, may be null if not specified
+     */
+    public MaintenanceNotificationsConfig getMaintenanceNotificationsConfig() {
+      return maintenanceNotificationsConfig;
     }
 
     /**
@@ -1017,6 +1030,9 @@ public final class MultiDbConfig {
       /** Health check strategy supplier. Default: PingStrategy.DEFAULT */
       private StrategySupplier healthCheckStrategySupplier = PingStrategy.DEFAULT;
 
+      /** Maintenance notifications configuration. */
+      public MaintenanceNotificationsConfig maintenanceNotificationsConfig = null;
+
       /**
        * Constructs a new Builder with required endpoint and client configuration.
        * @param endpoint the Redis endpoint (host and port)
@@ -1040,6 +1056,17 @@ public final class MultiDbConfig {
       public Builder connectionPoolConfig(
           GenericObjectPoolConfig<Connection> connectionPoolConfig) {
         this.connectionPoolConfig = connectionPoolConfig;
+        return this;
+      }
+
+      /**
+       * Sets the maintenance notifications configuration for this database.
+       * @param maintenanceNotificationsConfig the maintenance notifications configuration
+       * @return this builder instance for method chaining
+       */
+      public Builder maintenanceNotificationsConfig(
+          MaintenanceNotificationsConfig maintenanceNotificationsConfig) {
+        this.maintenanceNotificationsConfig = maintenanceNotificationsConfig;
         return this;
       }
 

--- a/src/main/java/redis/clients/jedis/mcf/MultiDbConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/mcf/MultiDbConnectionProvider.java
@@ -326,6 +326,7 @@ public class MultiDbConnectionProvider implements ConnectionProvider {
 
     TrackingConnectionPool pool = TrackingConnectionPool.builder()
         .hostAndPort(hostPort(config.getEndpoint())).clientConfig(config.getJedisClientConfig())
+        .maintenanceNotificationsConfig(config.getMaintenanceNotificationsConfig())
         .poolConfig(config.getConnectionPoolConfig()).build();
 
     Database database;

--- a/src/main/java/redis/clients/jedis/mcf/TrackingConnectionPool.java
+++ b/src/main/java/redis/clients/jedis/mcf/TrackingConnectionPool.java
@@ -16,7 +16,7 @@ import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.DefaultJedisSocketFactory;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
-import redis.clients.jedis.csc.CacheConnection;
+import redis.clients.jedis.MaintenanceNotificationsConfig;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
 public class TrackingConnectionPool extends ConnectionPool {
@@ -25,19 +25,16 @@ public class TrackingConnectionPool extends ConnectionPool {
     private volatile boolean failFast = false;
     private final Set<Connection> factoryTrackedObjects = ConcurrentHashMap.newKeySet();
 
-    public FailFastConnectionFactory(ConnectionFactory.Builder factoryBuilder,
-        JedisClientConfig clientConfig) {
-      super(factoryBuilder
-          .connectionBuilder(createCustomConnectionBuilder(factoryBuilder, clientConfig)));
+    private static class FailFastFactoryBuilder extends ConnectionFactory.Builder {
+
+      @Override
+      protected ConnectionFactory create() {
+        return new FailFastConnectionFactory(this);
+      }
     }
 
-    private static Connection.Builder createCustomConnectionBuilder(
-        ConnectionFactory.Builder factoryBuilder, JedisClientConfig clientConfig) {
-      Connection.Builder connBuilder = factoryBuilder.getCache() == null ? Connection.builder()
-          : CacheConnection.builder(factoryBuilder.getCache());
-
-      return connBuilder.socketFactory(factoryBuilder.getJedisSocketFactory())
-          .clientConfig(clientConfig);
+    public FailFastConnectionFactory(Builder factoryBuilder) {
+      super(factoryBuilder);
     }
 
     @Override
@@ -89,6 +86,7 @@ public class TrackingConnectionPool extends ConnectionPool {
     private HostAndPort hostAndPort;
     private JedisClientConfig clientConfig;
     private GenericObjectPoolConfig<Connection> poolConfig;
+    private MaintenanceNotificationsConfig maintenanceNotificationsConfig;
 
     public Builder hostAndPort(HostAndPort hostAndPort) {
       this.hostAndPort = hostAndPort;
@@ -102,6 +100,12 @@ public class TrackingConnectionPool extends ConnectionPool {
 
     public Builder poolConfig(GenericObjectPoolConfig<Connection> poolConfig) {
       this.poolConfig = poolConfig;
+      return this;
+    }
+
+    public Builder maintenanceNotificationsConfig(
+        MaintenanceNotificationsConfig maintenanceNotificationsConfig) {
+      this.maintenanceNotificationsConfig = maintenanceNotificationsConfig;
       return this;
     }
 
@@ -133,8 +137,9 @@ public class TrackingConnectionPool extends ConnectionPool {
   }
 
   private TrackingConnectionPool(Builder builder) {
-    super(createfailFastFactory(builder),
-        builder.poolConfig != null ? builder.poolConfig : new GenericObjectPoolConfig<>());
+    super(createFailFastFactoryBuilder(builder),
+        builder.poolConfig != null ? builder.poolConfig : new GenericObjectPoolConfig<>(),
+        builder.maintenanceNotificationsConfig);
 
     this.hostAndPort = builder.hostAndPort;
     this.clientConfig = builder.clientConfig;
@@ -142,11 +147,10 @@ public class TrackingConnectionPool extends ConnectionPool {
     this.attachAuthenticationListener(builder.clientConfig.getAuthXManager());
   }
 
-  private static FailFastConnectionFactory createfailFastFactory(Builder poolBuilder) {
-    ConnectionFactory.Builder factoryBuilder = ConnectionFactory.builder()
+  private static ConnectionFactory.Builder createFailFastFactoryBuilder(Builder poolBuilder) {
+    return new FailFastConnectionFactory.FailFastFactoryBuilder()
         .clientConfig(poolBuilder.clientConfig).socketFactory(
           new DefaultJedisSocketFactory(poolBuilder.hostAndPort, poolBuilder.clientConfig));
-    return new FailFastConnectionFactory(factoryBuilder, poolBuilder.clientConfig);
   }
 
   public static TrackingConnectionPool from(TrackingConnectionPool existing) {

--- a/src/test/java/redis/clients/jedis/mcf/MultiDbConnectionProviderInitializationTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiDbConnectionProviderInitializationTest.java
@@ -10,7 +10,6 @@ import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import redis.clients.jedis.Connection;
-import redis.clients.jedis.ConnectionPool;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
@@ -37,10 +36,10 @@ public class MultiDbConnectionProviderInitializationTest {
     clientConfig = DefaultJedisClientConfig.builder().build();
   }
 
-  private MockedConstruction<ConnectionPool> mockPool() {
+  private MockedConstruction<TrackingConnectionPool> mockPool() {
     Connection mockConnection = mock(Connection.class);
     lenient().when(mockConnection.ping()).thenReturn(true);
-    return mockConstruction(ConnectionPool.class, (mock, context) -> {
+    return mockConstruction(TrackingConnectionPool.class, (mock, context) -> {
       when(mock.getResource()).thenReturn(mockConnection);
       doNothing().when(mock).close();
     });
@@ -48,7 +47,7 @@ public class MultiDbConnectionProviderInitializationTest {
 
   @Test
   void testInitializationWithMixedHealthCheckConfiguration() {
-    try (MockedConstruction<ConnectionPool> mockedPool = mockPool()) {
+    try (MockedConstruction<TrackingConnectionPool> mockedPool = mockPool()) {
       // Create databases with mixed health check configuration
       DatabaseConfig db1 = DatabaseConfig.builder(endpoint1, clientConfig).weight(1.0f)
           .healthCheckEnabled(false) // No health
@@ -78,7 +77,7 @@ public class MultiDbConnectionProviderInitializationTest {
 
   @Test
   void testInitializationWithAllHealthChecksDisabled() {
-    try (MockedConstruction<ConnectionPool> mockedPool = mockPool()) {
+    try (MockedConstruction<TrackingConnectionPool> mockedPool = mockPool()) {
       // Create databases with no health checks
       DatabaseConfig db1 = DatabaseConfig.builder(endpoint1, clientConfig).weight(1.0f)
           .healthCheckEnabled(false).build();
@@ -98,7 +97,7 @@ public class MultiDbConnectionProviderInitializationTest {
 
   @Test
   void testInitializationWithSingleDatabase() {
-    try (MockedConstruction<ConnectionPool> mockedPool = mockPool()) {
+    try (MockedConstruction<TrackingConnectionPool> mockedPool = mockPool()) {
       DatabaseConfig db = DatabaseConfig.builder(endpoint1, clientConfig).weight(1.0f)
           .healthCheckEnabled(false).build();
 
@@ -141,7 +140,7 @@ public class MultiDbConnectionProviderInitializationTest {
 
   @Test
   void testInitializationWithOneAvailablePolicy() {
-    try (MockedConstruction<ConnectionPool> mockedPool = mockPool()) {
+    try (MockedConstruction<TrackingConnectionPool> mockedPool = mockPool()) {
       DatabaseConfig db1 = DatabaseConfig.builder(endpoint1, clientConfig).weight(1.0f)
           .healthCheckEnabled(false).build();
 
@@ -160,7 +159,7 @@ public class MultiDbConnectionProviderInitializationTest {
 
   @Test
   void testInitializationWithAllAvailablePolicy() {
-    try (MockedConstruction<ConnectionPool> mockedPool = mockPool()) {
+    try (MockedConstruction<TrackingConnectionPool> mockedPool = mockPool()) {
       DatabaseConfig db1 = DatabaseConfig.builder(endpoint1, clientConfig).weight(1.0f)
           .healthCheckEnabled(false).build();
 
@@ -180,7 +179,7 @@ public class MultiDbConnectionProviderInitializationTest {
 
   @Test
   void testInitializationWithMajorityAvailablePolicy() {
-    try (MockedConstruction<ConnectionPool> mockedPool = mockPool()) {
+    try (MockedConstruction<TrackingConnectionPool> mockedPool = mockPool()) {
       DatabaseConfig db1 = DatabaseConfig.builder(endpoint1, clientConfig).weight(1.0f)
           .healthCheckEnabled(false).build();
 

--- a/src/test/java/redis/clients/jedis/mcf/TrackingConnectionPoolInitTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/TrackingConnectionPoolInitTest.java
@@ -23,6 +23,7 @@ import redis.clients.jedis.Connection;
 import redis.clients.jedis.ConnectionTestHelper;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.MaintenanceNotificationsConfig;
 import redis.clients.jedis.PushConsumer;
 import redis.clients.jedis.PushConsumerChainImpl;
 import redis.clients.jedis.util.server.TcpMockServer;
@@ -58,7 +59,8 @@ public class TrackingConnectionPoolInitTest {
 
     try (
         TrackingConnectionPool pool = TrackingConnectionPool.builder().hostAndPort(hostAndPort)
-            .clientConfig(config).build();
+            .clientConfig(config)
+            .maintenanceNotificationsConfig(MaintenanceNotificationsConfig.DEFAULT).build();
         Connection conn = pool.getResource()) {
 
       List<PushConsumer> consumers = ConnectionTestHelper.getPushConsumers(conn);

--- a/src/test/java/redis/clients/jedis/providers/MultiDbProviderHealthStatusChangeTest.java
+++ b/src/test/java/redis/clients/jedis/providers/MultiDbProviderHealthStatusChangeTest.java
@@ -10,7 +10,6 @@ import org.mockito.MockedConstruction;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import redis.clients.jedis.Connection;
-import redis.clients.jedis.ConnectionPool;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
@@ -18,6 +17,7 @@ import redis.clients.jedis.MultiDbConfig;
 import redis.clients.jedis.mcf.HealthStatus;
 import redis.clients.jedis.mcf.MultiDbConnectionProvider;
 import redis.clients.jedis.mcf.MultiDbConnectionProviderHelper;
+import redis.clients.jedis.mcf.TrackingConnectionPool;
 
 /**
  * Tests for MultiDbConnectionProvider event handling behavior during initialization and throughout
@@ -39,10 +39,10 @@ public class MultiDbProviderHealthStatusChangeTest {
     clientConfig = DefaultJedisClientConfig.builder().build();
   }
 
-  private MockedConstruction<ConnectionPool> mockConnectionPool() {
+  private MockedConstruction<TrackingConnectionPool> mockConnectionPool() {
     Connection mockConnection = mock(Connection.class);
     lenient().when(mockConnection.ping()).thenReturn(true);
-    return mockConstruction(ConnectionPool.class, (mock, context) -> {
+    return mockConstruction(TrackingConnectionPool.class, (mock, context) -> {
       when(mock.getResource()).thenReturn(mockConnection);
       doNothing().when(mock).close();
     });
@@ -50,7 +50,7 @@ public class MultiDbProviderHealthStatusChangeTest {
 
   @Test
   void postInit_unhealthy_active_sets_grace_and_fails_over() throws Exception {
-    try (MockedConstruction<ConnectionPool> mockedPool = mockConnectionPool()) {
+    try (MockedConstruction<TrackingConnectionPool> mockedPool = mockConnectionPool()) {
       // Create databases without health checks
       MultiDbConfig.DatabaseConfig database1 = MultiDbConfig.DatabaseConfig
           .builder(endpoint1, clientConfig).weight(1.0f).healthCheckEnabled(false).build();
@@ -82,7 +82,7 @@ public class MultiDbProviderHealthStatusChangeTest {
 
   @Test
   void postInit_nonActive_changes_do_not_switch_active() throws Exception {
-    try (MockedConstruction<ConnectionPool> mockedPool = mockConnectionPool()) {
+    try (MockedConstruction<TrackingConnectionPool> mockedPool = mockConnectionPool()) {
       MultiDbConfig.DatabaseConfig database1 = MultiDbConfig.DatabaseConfig
           .builder(endpoint1, clientConfig).weight(1.0f).healthCheckEnabled(false).build();
       MultiDbConfig.DatabaseConfig database2 = MultiDbConfig.DatabaseConfig
@@ -128,7 +128,7 @@ public class MultiDbProviderHealthStatusChangeTest {
 
   @Test
   void init_selects_highest_weight_healthy_when_checks_disabled() throws Exception {
-    try (MockedConstruction<ConnectionPool> mockedPool = mockConnectionPool()) {
+    try (MockedConstruction<TrackingConnectionPool> mockedPool = mockConnectionPool()) {
       MultiDbConfig.DatabaseConfig database1 = MultiDbConfig.DatabaseConfig
           .builder(endpoint1, clientConfig).weight(1.0f).healthCheckEnabled(false).build();
 
@@ -154,7 +154,7 @@ public class MultiDbProviderHealthStatusChangeTest {
 
   @Test
   void init_single_database_initializes_and_is_healthy() throws Exception {
-    try (MockedConstruction<ConnectionPool> mockedPool = mockConnectionPool()) {
+    try (MockedConstruction<TrackingConnectionPool> mockedPool = mockConnectionPool()) {
       MultiDbConfig.DatabaseConfig database1 = MultiDbConfig.DatabaseConfig
           .builder(endpoint1, clientConfig).weight(1.0f).healthCheckEnabled(false).build();
 
@@ -178,7 +178,7 @@ public class MultiDbProviderHealthStatusChangeTest {
 
   @Test
   void postInit_two_hop_failover_chain_respected() throws Exception {
-    try (MockedConstruction<ConnectionPool> mockedPool = mockConnectionPool()) {
+    try (MockedConstruction<TrackingConnectionPool> mockedPool = mockConnectionPool()) {
       MultiDbConfig.DatabaseConfig database1 = MultiDbConfig.DatabaseConfig
           .builder(endpoint1, clientConfig).weight(1.0f).healthCheckEnabled(false).build();
 
@@ -221,7 +221,7 @@ public class MultiDbProviderHealthStatusChangeTest {
 
   @Test
   void postInit_rapid_events_respect_grace_and_keep_active_stable() throws Exception {
-    try (MockedConstruction<ConnectionPool> mockedPool = mockConnectionPool()) {
+    try (MockedConstruction<TrackingConnectionPool> mockedPool = mockConnectionPool()) {
       MultiDbConfig.DatabaseConfig database1 = MultiDbConfig.DatabaseConfig
           .builder(endpoint1, clientConfig).weight(1.0f).healthCheckEnabled(false).build();
 

--- a/src/test/java/redis/clients/jedis/sch/RebindMockTest.java
+++ b/src/test/java/redis/clients/jedis/sch/RebindMockTest.java
@@ -151,7 +151,7 @@ public class RebindMockTest {
       assertEquals(0, pool.getNumActive());
 
       // 5. Wait for connection to be closed on server1
-      await().pollDelay(Duration.ofMillis(1)).timeout(Duration.ofMillis(10))
+      await().atMost(Duration.ofSeconds(1)).pollInterval(Duration.ofMillis(20))
           .until(() -> mockServer1.getConnectedClientCount() == 0);
       assertEquals(0, mockServer1.getConnectedClientCount());
       assertEquals(1, mockServer2.getConnectedClientCount());
@@ -198,7 +198,7 @@ public class RebindMockTest {
       assertEquals(1, pool.getNumActive());
 
       // 5. Wait for connection to be closed on server1
-      await().pollDelay(Duration.ofMillis(1)).timeout(Duration.ofMillis(10))
+      await().atMost(Duration.ofSeconds(1)).pollInterval(Duration.ofMillis(20))
           .until(() -> mockServer1.getConnectedClientCount() == 1);
       assertEquals(1, mockServer1.getConnectedClientCount());
       assertEquals(0, mockServer2.getConnectedClientCount());


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes connection factory construction and pool maintenance wiring on the multi-db failover path; misconfiguration could affect rebind/eviction during MOVING events, though behavior is largely delegated to existing `ConnectionPool` logic.
> 
> **Overview**
> **Per-database maintenance notifications** can now be set on `MultiDbConfig.DatabaseConfig` and flow into each `TrackingConnectionPool` used by `MultiDbConnectionProvider`, so MOVING/rebind behavior matches single-pool `ConnectionPool` when maintenance is enabled.
> 
> `ConnectionPool` gains a builder-based constructor that applies `MaintenanceNotificationsConfig` (controller, rebind-aware eviction, handoff evict). `ConnectionFactory.Builder` exposes a protected `create()` hook so `TrackingConnectionPool`’s fail-fast factory subclasses the builder instead of manually rebuilding connection builders.
> 
> Tests mock `TrackingConnectionPool` where pools are constructed, assert maintenance push consumers when maintenance config is set, and relax `RebindMockTest` await timeouts for flaky async disconnect checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b691c89bca62c4c71fc7103cef3a77e013c2a6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->