### PR TITLE
Split RTS align test so ALIGN coverage runs on all versions

### DIFF
--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis.commands.unified.timeseries;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -519,40 +520,85 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
             .duplicatePolicy(DuplicatePolicy.MAX).ignore(50, 12.5).labels(labels)));
   }
 
+  /**
+   * Verify ALIGN modes. Non-keyword key: ALIGN option parsing is unaffected
+   * @see #alignKeyNotConsumedAsOption()
+   */
   @Test
-  @SinceRedisVersion(value = "8.10.0", message = "Requires the RedisTimeSeries TS.RANGE option-parsing fix "
-      + "(RedisTimeSeries PR #2052). Before it, a series key named like an option keyword "
-      + "(here \"align\") was matched as the ALIGN option, so the alignment was silently "
-      + "taken from the fromTimestamp and every ALIGN mode returned the same buckets.")
   public void align() {
-    // The series key is intentionally named "align" to guard against the option-keyword
-    // shadowing regression fixed in RedisTimeSeries PR #2052: option parsing must start after
-    // the key, so the key name must NOT be consumed as the ALIGN option.
-    jedis.tsAdd("align", 1, 10d);
-    jedis.tsAdd("align", 3, 5d);
-    jedis.tsAdd("align", 11, 10d);
-    jedis.tsAdd("align", 25, 11d);
+
+    final String key = "ts:align";
+
+    jedis.tsAdd(key, 1, 10d);
+    jedis.tsAdd(key, 3, 5d);
+    jedis.tsAdd(key, 11, 10d);
+    jedis.tsAdd(key, 25, 11d);
 
     // No ALIGN -> default alignment is 0 (epoch): buckets start at 0, 10, 20.
-    List<TSElement> values = jedis.tsRange("align",
+    List<TSElement> values = jedis.tsRange(key,
       TSRangeParams.rangeParams(1L, 30L).aggregation(AggregationType.COUNT, 10));
     assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(10, 1), new TSElement(20, 1)),
       values);
 
     // ALIGN start -> align to fromTimestamp (1): buckets start at 1, 11, 21.
-    values = jedis.tsRange("align",
+    values = jedis.tsRange(key,
       TSRangeParams.rangeParams(1L, 30L).alignStart().aggregation(AggregationType.COUNT, 10));
     assertEquals(Arrays.asList(new TSElement(1, 2), new TSElement(11, 1), new TSElement(21, 1)),
       values);
 
     // ALIGN end -> align to toTimestamp (30 ≡ 0 mod 10): buckets start at 0, 10, 20.
-    values = jedis.tsRange("align",
+    values = jedis.tsRange(key,
       TSRangeParams.rangeParams(1L, 30L).alignEnd().aggregation(AggregationType.COUNT, 10));
     assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(10, 1), new TSElement(20, 1)),
       values);
 
     // ALIGN 5 -> align to timestamp 5: buckets start at 0 (clamped), 5, 25.
-    values = jedis.tsRange("align",
+    values = jedis.tsRange(key,
+      TSRangeParams.rangeParams(1L, 30L).align(5).aggregation(AggregationType.COUNT, 10));
+    assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(5, 1), new TSElement(25, 1)),
+      values);
+  }
+
+  /**
+   * Verify that the series key is not consumed as the ALIGN option. See RedisTimeSeries #2052.
+   * @see #align()
+   */
+  @Test
+  @SinceRedisVersion(value = "8.10.0", message = "Requires the RedisTimeSeries TS.RANGE option-parsing fix "
+      + "(RedisTimeSeries PR #2052). Before it, a series key named like an option keyword "
+      + "(here \"align\") was matched as the ALIGN option, so the alignment was silently "
+      + "taken from the fromTimestamp and every ALIGN mode returned the same buckets.")
+  public void alignKeyNotConsumedAsOption() {
+    // The series key is intentionally named "align" to guard against the option-keyword
+    // shadowing regression fixed in RedisTimeSeries PR #2052: option parsing must start after
+    // the key, so the key name must NOT be consumed as the ALIGN option.
+    final String key = "align";
+
+    jedis.tsAdd(key, 1, 10d);
+    jedis.tsAdd(key, 3, 5d);
+    jedis.tsAdd(key, 11, 10d);
+    jedis.tsAdd(key, 25, 11d);
+
+    // No ALIGN -> default alignment is 0 (epoch): buckets start at 0, 10, 20.
+    List<TSElement> values = jedis.tsRange(key,
+      TSRangeParams.rangeParams(1L, 30L).aggregation(AggregationType.COUNT, 10));
+    assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(10, 1), new TSElement(20, 1)),
+      values);
+
+    // ALIGN start -> align to fromTimestamp (1): buckets start at 1, 11, 21.
+    values = jedis.tsRange(key,
+      TSRangeParams.rangeParams(1L, 30L).alignStart().aggregation(AggregationType.COUNT, 10));
+    assertEquals(Arrays.asList(new TSElement(1, 2), new TSElement(11, 1), new TSElement(21, 1)),
+      values);
+
+    // ALIGN end -> align to toTimestamp (30 ≡ 0 mod 10): buckets start at 0, 10, 20.
+    values = jedis.tsRange(key,
+      TSRangeParams.rangeParams(1L, 30L).alignEnd().aggregation(AggregationType.COUNT, 10));
+    assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(10, 1), new TSElement(20, 1)),
+      values);
+
+    // ALIGN 5 -> align to timestamp 5: buckets start at 0 (clamped), 5, 25.
+    values = jedis.tsRange(key,
       TSRangeParams.rangeParams(1L, 30L).align(5).aggregation(AggregationType.COUNT, 10));
     assertEquals(Arrays.asList(new TSElement(0, 2), new TSElement(5, 1), new TSElement(25, 1)),
       values);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only refactor in Time Series command tests; no production or client API changes.
> 
> **Overview**
> Splits **TS.RANGE `ALIGN`** coverage so general behavior is exercised on every supported Redis version, while the **RedisTimeSeries #2052** keyword-shadowing case stays version-gated.
> 
> A new unversioned **`align()`** test uses key `ts:align` and asserts default alignment plus **`alignStart`**, **`alignEnd`**, and numeric **`align(5)`** bucket boundaries. The former combined test is renamed **`alignKeyNotConsumedAsOption()`**, still **`@SinceRedisVersion("8.10.0")`**, and keeps a series key literally named **`align`** to ensure the key is not parsed as the ALIGN option. Cross-references were added between the two tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ade175b132f5cb31708301a9ea510c044af75484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->