### PR TITLE
Backport #4575 to 7.5.x: fix FT.HYBRID COMBINE arg count for YIELD_SCORE_AS

### DIFF
--- a/src/main/java/redis/clients/jedis/search/Combiner.java
+++ b/src/main/java/redis/clients/jedis/search/Combiner.java
@@ -44,7 +44,10 @@ public abstract class Combiner implements IParams {
     args.add(name);
 
     List<Object> ownArgs = getOwnArgs();
-    args.add(ownArgs.size());
+
+    int argCount = ownArgs.size() + (scoreAlias != null ? 2 : 0);
+    args.add(argCount);
+
     ownArgs.forEach(args::add);
 
     if (scoreAlias != null) {

--- a/src/test/java/redis/clients/jedis/commands/unified/search/FTHybridCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/search/FTHybridCommandsTestBase.java
@@ -42,6 +42,7 @@ import redis.clients.jedis.search.aggr.Reducers;
 import redis.clients.jedis.search.aggr.SortedField;
 import redis.clients.jedis.search.Apply;
 import redis.clients.jedis.search.Filter;
+import redis.clients.jedis.search.Combiner;
 import redis.clients.jedis.search.Combiners;
 import redis.clients.jedis.search.hybrid.FTHybridParams;
 import redis.clients.jedis.search.hybrid.FTHybridPostProcessingParams;
@@ -480,6 +481,37 @@ public abstract class FTHybridCommandsTestBase extends UnifiedJedisCommandsTestB
     Document firstResult = reply.getDocuments().get(0);
     assertThat(firstResult.hasProperty("title"), equalTo(true));
     assertThat(firstResult.hasProperty("price"), equalTo(true));
+  }
+
+  static Stream<Arguments> yieldScoreAsCombiners() {
+    return Stream.of(
+      Arguments.of("LINEAR-all-params",
+        Combiners.linear().alpha(0.5).beta(0.5).as("combined_score")),
+      Arguments.of("RRF-all-params", Combiners.rrf().window(20).constant(60).as("combined_score")),
+      Arguments.of("LINEAR-default-with-alias", Combiners.linear().as("combined_score")),
+      Arguments.of("RRF-default-with-alias", Combiners.rrf().as("combined_score")));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("yieldScoreAsCombiners")
+  public void testCombineWithYieldScoreAs(String name, Combiner combiner) {
+    // Combiner.as(...) emits YIELD_SCORE_AS; it must be counted inside the COMBINE clause or the
+    // server rejects it as an unknown argument (see #4574). The combined score is returned under
+    // the alias for both LINEAR and RRF.
+    FTHybridParams hybridArgs = FTHybridParams.builder()
+        .search(FTHybridSearchParams.builder().query("@id:1").build())
+        .vectorSearch(FTHybridVectorParams.builder().filter("@id:1").field("@image_embedding")
+            .vector("vector").method(FTHybridVectorParams.Knn.of(5)).build())
+        .combine(combiner).param("vector", queryVector).build();
+
+    HybridResult reply = jedis.ftHybrid(INDEX_NAME, hybridArgs);
+
+    assertThat(reply, notNullValue());
+    assertThat(reply.getTotalResults(), equalTo(1L));
+
+    Document doc = reply.getDocuments().get(0);
+    assertThat(doc.hasProperty("combined_score"), equalTo(true));
+    assertThat(Double.parseDouble(doc.getString("combined_score")), greaterThanOrEqualTo(0.0));
   }
 
   // ========== Scorer Tests ==========

--- a/src/test/java/redis/clients/jedis/search/hybrid/CombinersTest.java
+++ b/src/test/java/redis/clients/jedis/search/hybrid/CombinersTest.java
@@ -1,0 +1,198 @@
+package redis.clients.jedis.search.hybrid;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static redis.clients.jedis.search.SearchProtocol.SearchKeyword.ALPHA;
+import static redis.clients.jedis.search.SearchProtocol.SearchKeyword.BETA;
+import static redis.clients.jedis.search.SearchProtocol.SearchKeyword.CONSTANT;
+import static redis.clients.jedis.search.SearchProtocol.SearchKeyword.WINDOW;
+import static redis.clients.jedis.search.SearchProtocol.SearchKeyword.YIELD_SCORE_AS;
+import static redis.clients.jedis.util.CommandArgumentsMatchers.hasArgumentCount;
+import static redis.clients.jedis.util.CommandArgumentsMatchers.hasArguments;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.args.RawableFactory;
+import redis.clients.jedis.search.Combiner;
+import redis.clients.jedis.search.Combiners;
+import redis.clients.jedis.search.SearchProtocol.SearchCommand;
+
+/**
+ * Serialization tests for the FT.HYBRID score {@link Combiner}s built via {@link Combiners}.
+ * <p>
+ * Each combiner is serialized in isolation into a {@link CommandArguments} seeded with the HYBRID
+ * command; the assertions cover only the combiner's own clause ({@code <method> <count> ...}).
+ * </p>
+ */
+public class CombinersTest {
+
+  private static CommandArguments combineArgs(Combiner combiner) {
+    CommandArguments args = new CommandArguments(SearchCommand.HYBRID);
+    combiner.addParams(args);
+    return args;
+  }
+
+  @Nested
+  class RrfTests {
+
+    @Test
+    public void rrfWithNoParamsWritesZeroCount() {
+      CommandArguments args = combineArgs(Combiners.rrf());
+
+      // Expected: RRF 0
+      assertThat(args, hasArgumentCount(3));
+      assertThat(args,
+        hasArguments(SearchCommand.HYBRID, RawableFactory.from("RRF"), RawableFactory.from(0)));
+    }
+
+    @Test
+    public void rrfWithWindowOnly() {
+      CommandArguments args = combineArgs(Combiners.rrf().window(20));
+
+      // Expected: RRF 2 WINDOW 20
+      assertThat(args, hasArgumentCount(5));
+      assertThat(args, hasArguments(SearchCommand.HYBRID, RawableFactory.from("RRF"),
+        RawableFactory.from(2), WINDOW, RawableFactory.from(20)));
+    }
+
+    @Test
+    public void rrfWithConstantOnly() {
+      CommandArguments args = combineArgs(Combiners.rrf().constant(60));
+
+      // Expected: RRF 2 CONSTANT 60
+      assertThat(args, hasArgumentCount(5));
+      assertThat(args, hasArguments(SearchCommand.HYBRID, RawableFactory.from("RRF"),
+        RawableFactory.from(2), CONSTANT, RawableFactory.from(60.0)));
+    }
+
+    @Test
+    public void rrfWithWindowAndConstant() {
+      CommandArguments args = combineArgs(Combiners.rrf().window(20).constant(60));
+
+      // Expected: RRF 4 WINDOW 20 CONSTANT 60
+      assertThat(args, hasArgumentCount(7));
+      assertThat(args,
+        hasArguments(SearchCommand.HYBRID, RawableFactory.from("RRF"), RawableFactory.from(4),
+          WINDOW, RawableFactory.from(20), CONSTANT, RawableFactory.from(60.0)));
+    }
+  }
+
+  @Nested
+  class LinearTests {
+
+    @Test
+    public void linearWithNoParamsWritesZeroCount() {
+      CommandArguments args = combineArgs(Combiners.linear());
+
+      // Expected: LINEAR 0
+      assertThat(args, hasArgumentCount(3));
+      assertThat(args,
+        hasArguments(SearchCommand.HYBRID, RawableFactory.from("LINEAR"), RawableFactory.from(0)));
+    }
+
+    @Test
+    public void linearWithAlphaOnly() {
+      CommandArguments args = combineArgs(Combiners.linear().alpha(0.7));
+
+      // Expected: LINEAR 2 ALPHA 0.7
+      assertThat(args, hasArgumentCount(5));
+      assertThat(args, hasArguments(SearchCommand.HYBRID, RawableFactory.from("LINEAR"),
+        RawableFactory.from(2), ALPHA, RawableFactory.from(0.7)));
+    }
+
+    @Test
+    public void linearWithBetaOnly() {
+      CommandArguments args = combineArgs(Combiners.linear().beta(0.3));
+
+      // Expected: LINEAR 2 BETA 0.3
+      assertThat(args, hasArgumentCount(5));
+      assertThat(args, hasArguments(SearchCommand.HYBRID, RawableFactory.from("LINEAR"),
+        RawableFactory.from(2), BETA, RawableFactory.from(0.3)));
+    }
+
+    @Test
+    public void linearWithWindowOnly() {
+      CommandArguments args = combineArgs(Combiners.linear().window(25));
+
+      // Expected: LINEAR 2 WINDOW 25
+      assertThat(args, hasArgumentCount(5));
+      assertThat(args, hasArguments(SearchCommand.HYBRID, RawableFactory.from("LINEAR"),
+        RawableFactory.from(2), WINDOW, RawableFactory.from(25)));
+    }
+
+    @Test
+    public void linearWithAlphaAndBeta() {
+      CommandArguments args = combineArgs(Combiners.linear().alpha(0.7).beta(0.3));
+
+      // Expected: LINEAR 4 ALPHA 0.7 BETA 0.3
+      assertThat(args, hasArgumentCount(7));
+      assertThat(args, hasArguments(SearchCommand.HYBRID, RawableFactory.from("LINEAR"),
+        RawableFactory.from(4), ALPHA, RawableFactory.from(0.7), BETA, RawableFactory.from(0.3)));
+    }
+
+    @Test
+    public void linearWithAllParamsKeepsAlphaBetaWindowOrder() {
+      CommandArguments args = combineArgs(Combiners.linear().alpha(0.7).beta(0.3).window(25));
+
+      // Expected: LINEAR 6 ALPHA 0.7 BETA 0.3 WINDOW 25
+      assertThat(args, hasArgumentCount(9));
+      assertThat(args,
+        hasArguments(SearchCommand.HYBRID, RawableFactory.from("LINEAR"), RawableFactory.from(6),
+          ALPHA, RawableFactory.from(0.7), BETA, RawableFactory.from(0.3), WINDOW,
+          RawableFactory.from(25)));
+    }
+  }
+
+  /**
+   * The combined-score alias is appended as {@code YIELD_SCORE_AS <alias>} and must be included in
+   * the clause count. Regression coverage for the off-by-two count bug where the two alias tokens
+   * fell outside the count and Redis rejected them as an unknown argument.
+   */
+  @Nested
+  class YieldScoreAsTests {
+
+    @Test
+    public void rrfWithParamsAndAliasCountsAliasTokens() {
+      CommandArguments args = combineArgs(Combiners.rrf().window(20).constant(60).as("score"));
+
+      // Expected: RRF 6 WINDOW 20 CONSTANT 60 YIELD_SCORE_AS score
+      assertThat(args, hasArgumentCount(9));
+      assertThat(args,
+        hasArguments(SearchCommand.HYBRID, RawableFactory.from("RRF"), RawableFactory.from(6),
+          WINDOW, RawableFactory.from(20), CONSTANT, RawableFactory.from(60.0), YIELD_SCORE_AS,
+          RawableFactory.from("score")));
+    }
+
+    @Test
+    public void rrfWithOnlyAliasCountsAliasTokens() {
+      CommandArguments args = combineArgs(Combiners.rrf().as("score"));
+
+      // Expected: RRF 2 YIELD_SCORE_AS score
+      assertThat(args, hasArgumentCount(5));
+      assertThat(args, hasArguments(SearchCommand.HYBRID, RawableFactory.from("RRF"),
+        RawableFactory.from(2), YIELD_SCORE_AS, RawableFactory.from("score")));
+    }
+
+    @Test
+    public void linearWithParamsAndAliasCountsAliasTokens() {
+      CommandArguments args = combineArgs(Combiners.linear().alpha(0.7).beta(0.3).as("score"));
+
+      // Expected: LINEAR 6 ALPHA 0.7 BETA 0.3 YIELD_SCORE_AS score
+      assertThat(args, hasArgumentCount(9));
+      assertThat(args,
+        hasArguments(SearchCommand.HYBRID, RawableFactory.from("LINEAR"), RawableFactory.from(6),
+          ALPHA, RawableFactory.from(0.7), BETA, RawableFactory.from(0.3), YIELD_SCORE_AS,
+          RawableFactory.from("score")));
+    }
+
+    @Test
+    public void linearWithOnlyAliasCountsAliasTokens() {
+      CommandArguments args = combineArgs(Combiners.linear().as("score"));
+
+      // Expected: LINEAR 2 YIELD_SCORE_AS score
+      assertThat(args, hasArgumentCount(5));
+      assertThat(args, hasArguments(SearchCommand.HYBRID, RawableFactory.from("LINEAR"),
+        RawableFactory.from(2), YIELD_SCORE_AS, RawableFactory.from("score")));
+    }
+  }
+}


### PR DESCRIPTION
Backport of #4575 to `7.5.x`.

Cherry-picked commit `7fdb4e4f`. Includes the `COMBINE` arg-count fix plus `CombinersTest` and the FT.HYBRID `YIELD_SCORE_AS` integration tests (RRF and LINEAR).

Fixes #4574 on the 7.5.x line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow protocol-serialization fix in experimental FT.HYBRID combiners, with unit and integration tests; no auth or data-path changes.
> 
> **Overview**
> Fixes **FT.HYBRID** failures when a score combiner uses **`Combiner.as(...)`** to alias the combined score (#4574).
> 
> `Combiner.addParams` now sets the COMBINE clause argument count to **`ownArgs.size()` plus two** when a score alias is present, so **`YIELD_SCORE_AS`** and the alias name are counted inside the clause instead of being treated as stray arguments Redis rejects.
> 
> Adds **`CombinersTest`** for LINEAR/RRF serialization (including alias regression cases) and a parameterized integration test on **`FTHybridCommandsTestBase`** that asserts the combined score is returned under the alias for LINEAR and RRF.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41ba16f009c4b6eba1114fe13776ef2310bcc9d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->