### PR TITLE
Backport #4571 and #4573 to 7.5.x: stabilize XINFO STREAM tests

### DIFF
--- a/src/test/java/redis/clients/jedis/commands/jedis/StreamsCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/StreamsCommandsTest.java
@@ -1261,8 +1261,6 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     // Stream info test
     assertEquals(2L, streamInfo.getStreamInfo().get(StreamInfo.LENGTH));
-    assertEquals(1L, streamInfo.getStreamInfo().get(StreamInfo.RADIX_TREE_KEYS));
-    assertEquals(2L, streamInfo.getStreamInfo().get(StreamInfo.RADIX_TREE_NODES));
     assertEquals(0L, streamInfo.getStreamInfo().get(StreamInfo.GROUPS));
     assertEquals(V1, ((StreamEntry) streamInfo.getStreamInfo().get(StreamInfo.FIRST_ENTRY)).getFields().get(F1));
     assertEquals(V2, ((StreamEntry) streamInfo.getStreamInfo().get(StreamInfo.LAST_ENTRY)).getFields().get(F1));
@@ -1270,8 +1268,6 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     // Using getters
     assertEquals(2, streamInfo.getLength());
-    assertEquals(1, streamInfo.getRadixTreeKeys());
-    assertEquals(2, streamInfo.getRadixTreeNodes());
     assertEquals(0, streamInfo.getGroups());
     assertEquals(V1, streamInfo.getFirstEntry().getFields().get(F1));
     assertEquals(V2, streamInfo.getLastEntry().getFields().get(F1));
@@ -1339,8 +1335,6 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     assertEquals(2, streamInfoFull.getEntries().size());
     assertEquals(2, streamInfoFull.getGroups().size());
     assertEquals(2, streamInfoFull.getLength());
-    assertEquals(1, streamInfoFull.getRadixTreeKeys());
-    assertEquals(2, streamInfoFull.getRadixTreeNodes());
     assertEquals(0, streamInfo.getGroups());
     assertEquals(G1, streamInfoFull.getGroups().get(0).getName());
     assertEquals(G2, streamInfoFull.getGroups().get(1).getName());

--- a/src/test/java/redis/clients/jedis/commands/jedis/StreamsCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/StreamsCommandsTest.java
@@ -1261,6 +1261,9 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     // Stream info test
     assertEquals(2L, streamInfo.getStreamInfo().get(StreamInfo.LENGTH));
+    // radix-tree-* are internal debugging fields; only assert they are parsed, not their values
+    assertThat((Long) streamInfo.getStreamInfo().get(StreamInfo.RADIX_TREE_KEYS), Matchers.any(Long.class));
+    assertThat((Long) streamInfo.getStreamInfo().get(StreamInfo.RADIX_TREE_NODES), Matchers.any(Long.class));
     assertEquals(0L, streamInfo.getStreamInfo().get(StreamInfo.GROUPS));
     assertEquals(V1, ((StreamEntry) streamInfo.getStreamInfo().get(StreamInfo.FIRST_ENTRY)).getFields().get(F1));
     assertEquals(V2, ((StreamEntry) streamInfo.getStreamInfo().get(StreamInfo.LAST_ENTRY)).getFields().get(F1));
@@ -1268,6 +1271,8 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     // Using getters
     assertEquals(2, streamInfo.getLength());
+    assertThat(streamInfo.getRadixTreeKeys(), Matchers.any(Long.class));
+    assertThat(streamInfo.getRadixTreeNodes(), Matchers.any(Long.class));
     assertEquals(0, streamInfo.getGroups());
     assertEquals(V1, streamInfo.getFirstEntry().getFields().get(F1));
     assertEquals(V2, streamInfo.getLastEntry().getFields().get(F1));
@@ -1335,6 +1340,8 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     assertEquals(2, streamInfoFull.getEntries().size());
     assertEquals(2, streamInfoFull.getGroups().size());
     assertEquals(2, streamInfoFull.getLength());
+    assertThat(streamInfoFull.getRadixTreeKeys(), Matchers.any(Long.class));
+    assertThat(streamInfoFull.getRadixTreeNodes(), Matchers.any(Long.class));
     assertEquals(0, streamInfo.getGroups());
     assertEquals(G1, streamInfoFull.getGroups().get(0).getName());
     assertEquals(G2, streamInfoFull.getGroups().get(1).getName());

--- a/src/test/java/redis/clients/jedis/commands/unified/pipeline/StreamsPipelineCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/pipeline/StreamsPipelineCommandsTest.java
@@ -1177,6 +1177,9 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
     StreamInfo streamInfo = streamInfoResponse.get();
 
     assertEquals(2L, streamInfo.getStreamInfo().get(StreamInfo.LENGTH));
+    // radix-tree-* are internal debugging fields; only assert they are parsed, not their values
+    assertThat((Long) streamInfo.getStreamInfo().get(StreamInfo.RADIX_TREE_KEYS), Matchers.any(Long.class));
+    assertThat((Long) streamInfo.getStreamInfo().get(StreamInfo.RADIX_TREE_NODES), Matchers.any(Long.class));
     assertEquals(0L, streamInfo.getStreamInfo().get(StreamInfo.GROUPS));
     assertEquals(V1, ((StreamEntry) streamInfo.getStreamInfo().get(StreamInfo.FIRST_ENTRY)).getFields().get(F1));
     assertEquals(V2, ((StreamEntry) streamInfo.getStreamInfo().get(StreamInfo.LAST_ENTRY)).getFields().get(F1));
@@ -1184,6 +1187,8 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
 
     // Using getters
     assertEquals(2, streamInfo.getLength());
+    assertThat(streamInfo.getRadixTreeKeys(), Matchers.any(Long.class));
+    assertThat(streamInfo.getRadixTreeNodes(), Matchers.any(Long.class));
     assertEquals(0, streamInfo.getGroups());
     assertEquals(V1, streamInfo.getFirstEntry().getFields().get(F1));
     assertEquals(V2, streamInfo.getLastEntry().getFields().get(F1));
@@ -1264,6 +1269,8 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
     assertEquals(2, streamInfoFull.getEntries().size());
     assertEquals(2, streamInfoFull.getGroups().size());
     assertEquals(2, streamInfoFull.getLength());
+    assertThat(streamInfoFull.getRadixTreeKeys(), Matchers.any(Long.class));
+    assertThat(streamInfoFull.getRadixTreeNodes(), Matchers.any(Long.class));
     assertEquals(0, streamInfo.getGroups());
     assertEquals(G1, streamInfoFull.getGroups().get(0).getName());
     assertEquals(G2, streamInfoFull.getGroups().get(1).getName());

--- a/src/test/java/redis/clients/jedis/commands/unified/pipeline/StreamsPipelineCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/pipeline/StreamsPipelineCommandsTest.java
@@ -1177,8 +1177,6 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
     StreamInfo streamInfo = streamInfoResponse.get();
 
     assertEquals(2L, streamInfo.getStreamInfo().get(StreamInfo.LENGTH));
-    assertEquals(1L, streamInfo.getStreamInfo().get(StreamInfo.RADIX_TREE_KEYS));
-    assertEquals(2L, streamInfo.getStreamInfo().get(StreamInfo.RADIX_TREE_NODES));
     assertEquals(0L, streamInfo.getStreamInfo().get(StreamInfo.GROUPS));
     assertEquals(V1, ((StreamEntry) streamInfo.getStreamInfo().get(StreamInfo.FIRST_ENTRY)).getFields().get(F1));
     assertEquals(V2, ((StreamEntry) streamInfo.getStreamInfo().get(StreamInfo.LAST_ENTRY)).getFields().get(F1));
@@ -1186,8 +1184,6 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
 
     // Using getters
     assertEquals(2, streamInfo.getLength());
-    assertEquals(1, streamInfo.getRadixTreeKeys());
-    assertEquals(2, streamInfo.getRadixTreeNodes());
     assertEquals(0, streamInfo.getGroups());
     assertEquals(V1, streamInfo.getFirstEntry().getFields().get(F1));
     assertEquals(V2, streamInfo.getLastEntry().getFields().get(F1));
@@ -1268,8 +1264,6 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
     assertEquals(2, streamInfoFull.getEntries().size());
     assertEquals(2, streamInfoFull.getGroups().size());
     assertEquals(2, streamInfoFull.getLength());
-    assertEquals(1, streamInfoFull.getRadixTreeKeys());
-    assertEquals(2, streamInfoFull.getRadixTreeNodes());
     assertEquals(0, streamInfo.getGroups());
     assertEquals(G1, streamInfoFull.getGroups().get(0).getName());
     assertEquals(G2, streamInfoFull.getGroups().get(1).getName());


### PR DESCRIPTION
Backports two test-only fixes to `7.5.x` that stabilize the XINFO STREAM assertions in `StreamsCommandsTest` and `StreamsPipelineCommandsTest`.

## Commits
- #4571 — Do not assert on internal field of XINFO command (`c72f02c`)
- #4573 — Verify that `RADIX_TREE_KEYS` and `RADIX_TREE_NODES` were parsed (`f46de70`)

## Why
`radix-tree-keys` / `radix-tree-nodes` are internal Redis debugging fields whose exact values are not stable across versions. Asserting on their values made the stream tests brittle. The combined change drops the value assertions and instead verifies the fields are present and parsed as `Long`.

Cherry-picked with `-x` (provenance preserved). Test-only; no production code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to integration test assertions; no library or runtime behavior is modified.
> 
> **Overview**
> **Test-only backport** that relaxes XINFO STREAM / XINFO STREAM FULL checks in `StreamsCommandsTest` and `StreamsPipelineCommandsTest`.
> 
> Instead of asserting fixed values for **`radix-tree-keys`** and **`radix-tree-nodes`**, tests now only verify those fields are **parsed as `Long`** (Hamcrest `Matchers.any(Long.class)`), with a comment that they are internal Redis debugging fields. All other stream metadata assertions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af275957a15704c70111dcb0d650e3d77c3b7e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->