### PR TITLE
Add Redis 8.8 GA to test matrix on 7.5.x

### DIFF
--- a/.github/workflows/test-on-docker.yml
+++ b/.github/workflows/test-on-docker.yml
@@ -40,6 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         redis_version:
+          - "8.8"
           - "8.6"
           - "8.4"
           - "8.2"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 PATH := ./redis-git/src:${PATH}
 
 # Supported test env versions
-SUPPORTED_TEST_ENV_VERSIONS := 8.6 8.4 8.2 8.0 7.4 7.2 6.2
-DEFAULT_TEST_ENV_VERSION := 8.6
+SUPPORTED_TEST_ENV_VERSIONS := 8.8 8.6 8.4 8.2 8.0 7.4 7.2 6.2
+DEFAULT_TEST_ENV_VERSION := 8.8
 REDIS_ENV_WORK_DIR := $(or ${REDIS_ENV_WORK_DIR},/tmp/redis-env-work)
 TOXIPROXY_IMAGE := ghcr.io/shopify/toxiproxy:2.8.0
 

--- a/src/test/resources/env/.env.v8.8
+++ b/src/test/resources/env/.env.v8.8
@@ -1,0 +1,8 @@
+REDIS_VERSION=8.8.0
+REDIS_STACK_VERSION=8.8.0
+CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test
+REDIS_ENV_CONF_DIR=./
+REDIS_MODULES_DIR=/tmp
+REDIS_ENV_WORK_DIR=/tmp/redis-env-work
+
+ENABLE_MODULE_COMMAND_DIRECTIVE=--enable-module-command yes


### PR DESCRIPTION
Introduces Redis **8.8 (GA, 8.8.0)** to the 7.5.x test infrastructure.

## Changes
- `.github/workflows/test-on-docker.yml` — add `8.8` to the `redis_version` matrix
- `Makefile` — add `8.8` to `SUPPORTED_TEST_ENV_VERSIONS`, set `DEFAULT_TEST_ENV_VERSION := 8.8`
- `src/test/resources/env/.env.v8.8` — new env file pinned to `8.8.0`

## Provenance
This is the net end-state of the upstream chain on `master`:
- #4493 — add 8.8 to test matrix
- #4511 / #4528 / #4536 — image bumps (m03 → rc1 → custom-debian)
- #4542 — bump to 8.8 GA

Applied as a single commit because the intermediate bumps are pure version churn. The unrelated `topic/**` push-trigger removal that #4493 also carried is **omitted** — 7.5.x's workflow triggers differ.

CI/test-only; no production code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and test-configuration only; no production or library runtime code changes.
> 
> **Overview**
> Adds **Redis 8.8 (8.8.0 GA)** to the client-libs test infrastructure and makes it the default local/Docker test version.
> 
> The GitHub Actions `test-on-docker` workflow now includes **`8.8`** at the top of the `redis_version` matrix. The **Makefile** prepends `8.8` to `SUPPORTED_TEST_ENV_VERSIONS` and sets **`DEFAULT_TEST_ENV_VERSION`** to `8.8`, so `make start` / `make test` without a version pick 8.8. A new **`src/test/resources/env/.env.v8.8`** pins `REDIS_VERSION` and `REDIS_STACK_VERSION` to `8.8.0` and matches the existing env pattern (client-libs image, work dirs, `--enable-module-command yes`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9f77ffed2b8d743cfa1206b181ab1c718714d8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->