### PR TITLE
Remove unusable aclLogBinary() methods

### DIFF
--- a/docs/migration-guides/v7-to-v8.md
+++ b/docs/migration-guides/v7-to-v8.md
@@ -14,6 +14,7 @@ This guide helps you migrate from Jedis 7.5.0 to Jedis 8.0.0. Version 8.0.0 intr
   - [`CommandObjects` Protocol is Now Immutable](#commandobjects-protocol-is-now-immutable)
   - [`broadcastCommand` and `JedisBroadcastAndRoundRobinConfig` Removed](#broadcastcommand-and-jedisbroadcastandroundrobinconfig-removed)
   - [Removed Sharding Utility Classes](#removed-sharding-utility-classes)
+  - [`aclLogBinary()` Removed](#acllogbinary-removed)
   - [`commons-pool2` Upgraded to 2.13.1](#commons-pool2-upgraded-to-2131)
 - [Deprecations](#deprecations)
   - [`JedisCluster` Deprecation](#jediscluster-deprecation)
@@ -324,6 +325,18 @@ The following utility classes — leftovers from the `JedisSharding` feature rem
 - `redis.clients.jedis.util.MurmurHash`
 
 If you happened to use these utility classes for application-level hashing, copy them into your own codebase or switch to an equivalent library (Guava's `Hashing.murmur3_*`, etc.).
+
+### `aclLogBinary()` Removed
+
+`Jedis.aclLogBinary()` and `aclLogBinary(int)` (declared on `AccessControlLogBinaryCommands`) have been **removed**. Their declared return type `List<byte[]>` could not represent the `ACL LOG` reply, which is a nested array (a list of entries, each a flattened list of key/value pairs). Reading any element threw `ClassCastException`, so the methods were never usable.
+
+#### Migration Path
+
+Use `aclLog()` / `aclLog(int)`, which return structured `AccessControlLogEntry` objects for the same data:
+
+```java
+List<AccessControlLogEntry> log = jedis.aclLog();
+```
 
 ### `commons-pool2` Upgraded to 2.13.1
 

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -4342,20 +4342,6 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   }
 
   @Override
-  public List<byte[]> aclLogBinary() {
-    checkIsInMultiOrPipeline();
-    connection.sendCommand(ACL, LOG);
-    return connection.getBinaryMultiBulkReply();
-  }
-
-  @Override
-  public List<byte[]> aclLogBinary(int limit) {
-    checkIsInMultiOrPipeline();
-    connection.sendCommand(ACL, LOG.getRaw(), toByteArray(limit));
-    return connection.getBinaryMultiBulkReply();
-  }
-
-  @Override
   public String aclLogReset() {
     checkIsInMultiOrPipeline();
     connection.sendCommand(ACL, LOG.getRaw(), Keyword.RESET.getRaw());

--- a/src/main/java/redis/clients/jedis/commands/AccessControlLogBinaryCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/AccessControlLogBinaryCommands.java
@@ -107,23 +107,6 @@ public interface AccessControlLogBinaryCommands {
   List<byte[]> aclCat(byte[] category);
 
   /**
-   * Shows the recent ACL security events.
-   *
-   * @see <a href="https://redis.io/commands/acl-log">ACL LOG</a>
-   * @return The list of recent security events
-   */
-  List<byte[]> aclLogBinary();
-
-  /**
-   * Shows the recent limit ACL security events.
-   *
-   * @param limit The number of results to return
-   * @see <a href="https://redis.io/commands/acl-log">ACL LOG</a>
-   * @return The list of recent security events
-   */
-  List<byte[]> aclLogBinary(int limit);
-
-  /**
    * Reset the script event log
    *
    * @see <a href="https://redis.io/commands/acl-log">ACL LOG</a>

--- a/src/test/java/redis/clients/jedis/commands/jedis/AccessControlListCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/AccessControlListCommandsTest.java
@@ -12,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static redis.clients.jedis.util.ACLTestUtil.filterBinaryByClientId;
 import static redis.clients.jedis.util.ACLTestUtil.filterByClientId;
 import static redis.clients.jedis.util.RedisVersionUtil.getRedisVersion;
 
@@ -471,10 +470,6 @@ public class AccessControlListCommandsTest extends JedisCommandsTestBase {
     jedis.auth(endpoint.getUsername(), endpoint.getPassword());
     assertEquals( 3, filterByClientId(jedis.aclLog(), jedis.clientId()).size(), "Number of log messages ");
     assertEquals( 2, jedis.aclLog(2).size(), "Number of log messages ");
-
-    // Binary tests
-    assertEquals( 3, filterBinaryByClientId(jedis.aclLogBinary(), jedis.clientId()).size(), "Number of log messages ");
-    assertEquals( 2, jedis.aclLogBinary(2).size(), "Number of log messages ");
 
     // RESET
     String status = jedis.aclLogReset();

--- a/src/test/java/redis/clients/jedis/util/ACLTestUtil.java
+++ b/src/test/java/redis/clients/jedis/util/ACLTestUtil.java
@@ -1,10 +1,8 @@
 package redis.clients.jedis.util;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import redis.clients.jedis.BuilderFactory;
 import redis.clients.jedis.resps.AccessControlLogEntry;
 
 /**
@@ -29,45 +27,5 @@ public final class ACLTestUtil {
       Map<String, String> clientInfo = entry.getClientInfo();
       return clientInfo != null && clientIdStr.equals(clientInfo.get("id"));
     }).collect(Collectors.toList());
-  }
-
-  /**
-   * Filters a list of binary ACL log entries by client ID.
-   * <p>
-   * This method converts the binary ACL log entries to AccessControlLogEntry objects, filters them
-   * by client ID, and returns the filtered binary entries.
-   * @param binaryEntries the list of binary ACL log entries to filter (raw Redis response)
-   * @param clientId the client ID to filter by
-   * @return a new list containing only binary entries matching the specified client ID
-   */
-  public static List<byte[]> filterBinaryByClientId(List<byte[]> binaryEntries, long clientId) {
-    if (binaryEntries == null || binaryEntries.isEmpty()) {
-      return new ArrayList<>();
-    }
-
-    // Build the structured entries from binary data
-    List<AccessControlLogEntry> entries = BuilderFactory.ACCESS_CONTROL_LOG_ENTRY_LIST
-        .build(binaryEntries);
-    if (entries == null || entries.isEmpty()) {
-      return new ArrayList<>();
-    }
-
-    // Filter by client ID
-    String clientIdStr = String.valueOf(clientId);
-    List<Integer> matchingIndices = new ArrayList<>();
-    for (int i = 0; i < entries.size(); i++) {
-      AccessControlLogEntry entry = entries.get(i);
-      Map<String, String> clientInfo = entry.getClientInfo();
-      if (clientInfo != null && clientIdStr.equals(clientInfo.get("id"))) {
-        matchingIndices.add(i);
-      }
-    }
-
-    // Return the corresponding binary entries
-    List<byte[]> result = new ArrayList<>();
-    for (Integer index : matchingIndices) {
-      result.add(binaryEntries.get(index));
-    }
-    return result;
   }
 }


### PR DESCRIPTION
## Problem

`Jedis.aclLogBinary()` / `aclLogBinary(int)` (declared on `AccessControlLogBinaryCommands`) declare `List<byte[]>`, but the `ACL LOG` reply is a nested array (`Array<Array<...>>`) — a list of entries, each itself a flattened list of key/value pairs. `getBinaryMultiBulkReply()` only does an unchecked `(List<byte[]>)` cast, so the elements are actually nested lists. Reading any element throws `ClassCastException: java.util.ArrayList cannot be cast to [B`. The methods have never been usable.

Fixes #4579.

## Change

- Remove `aclLogBinary()` and `aclLogBinary(int)` from `Jedis` and `AccessControlLogBinaryCommands`.
- Drop the test-only `ACLTestUtil.filterBinaryByClientId` and its usage in `AccessControlListCommandsTest`.
- Document the removal in the v7→v8 migration guide.

## Migration

Use `aclLog()` / `aclLog(int)`, which return structured `AccessControlLogEntry` objects for the same data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API deletion of methods that were never usable; migration path to existing `aclLog()` APIs is straightforward.
> 
> **Overview**
> Removes **`aclLogBinary()`** and **`aclLogBinary(int)`** from `Jedis` and `AccessControlLogBinaryCommands`. Those APIs claimed `List<byte[]>` but could not parse the nested `ACL LOG` reply, so they threw `ClassCastException` at runtime.
> 
> Callers should use **`aclLog()`** / **`aclLog(int)`**, which return `AccessControlLogEntry` objects. The v7→v8 migration guide adds a breaking-change section for this removal. Tests drop binary ACL log coverage and the test-only **`ACLTestUtil.filterBinaryByClientId`** helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c190541a32c4410872d4b22bfb223ef5e331eac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->