### PR TITLE
Handle Pub/Sub PONG replies for Jedis ping

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -435,6 +435,35 @@ public class Connection implements Closeable {
     }
   }
 
+  String getPongReply() {
+    final byte[] resp = getBinaryPongReply(false);
+    return resp == null ? null : encode(resp);
+  }
+
+  String getPongReply(final boolean hasArgument) {
+    final byte[] resp = getBinaryPongReply(hasArgument);
+    return resp == null ? null : encode(resp);
+  }
+
+  @SuppressWarnings("unchecked")
+  byte[] getBinaryPongReply(final boolean hasArgument) {
+    flush();
+    final Object resp = readProtocolWithCheckingBroken();
+    if (resp instanceof List) {
+      return getPubSubPongReply((List<Object>) resp, hasArgument);
+    }
+    return (byte[]) resp;
+  }
+
+  private static byte[] getPubSubPongReply(final List<Object> reply, final boolean hasArgument) {
+    if (reply.size() != 2 || !(reply.get(0) instanceof byte[])
+        || !Arrays.equals(Protocol.ResponseKeyword.PONG.getRaw(), (byte[]) reply.get(0))
+        || !(reply.get(1) instanceof byte[])) {
+      throw new JedisException("Unexpected PING reply: " + reply);
+    }
+    return hasArgument ? (byte[]) reply.get(1) : encode("PONG");
+  }
+
   public String getBulkReply() {
     final byte[] result = getBinaryBulkReply();
     if (null != result) {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -447,7 +447,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   public String ping() {
     checkIsInMultiOrPipeline();
     connection.sendCommand(Command.PING);
-    return connection.getStatusCodeReply();
+    return connection.getPongReply();
   }
 
   /**
@@ -458,7 +458,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   public byte[] ping(final byte[] message) {
     checkIsInMultiOrPipeline();
     connection.sendCommand(Command.PING, message);
-    return connection.getBinaryBulkReply();
+    return connection.getBinaryPongReply(true);
   }
 
   /**
@@ -5414,7 +5414,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   public String ping(final String message) {
     checkIsInMultiOrPipeline();
     connection.sendCommand(Command.PING, message);
-    return connection.getBulkReply();
+    return connection.getPongReply(true);
   }
 
   /**

--- a/src/test/java/redis/clients/jedis/JedisMockTest.java
+++ b/src/test/java/redis/clients/jedis/JedisMockTest.java
@@ -1,0 +1,82 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static redis.clients.jedis.Protocol.Command.PING;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.util.SafeEncoder;
+import redis.clients.jedis.util.server.RespResponse;
+import redis.clients.jedis.util.server.TcpMockServer;
+
+public class JedisMockTest {
+
+  private TcpMockServer mockServer;
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    mockServer = new TcpMockServer();
+    mockServer.start();
+  }
+
+  @AfterEach
+  public void tearDown() throws IOException {
+    if (mockServer != null) {
+      mockServer.stop();
+    }
+  }
+
+  @Test
+  public void pingHandlesPubSubStylePongReply() {
+    mockServer.setCommandHandler((commandArgs, clientId) -> {
+      if (!PING.equals(commandArgs.getCommand())) {
+        return null;
+      }
+      return RespResponse.array(RespResponse.bulkString("pong"), RespResponse.bulkString(""));
+    });
+
+    try (Jedis jedis = createJedis()) {
+      assertEquals("PONG", jedis.ping());
+    }
+  }
+
+  @Test
+  public void pingWithStringArgumentHandlesPubSubStylePongReply() {
+    mockServer.setCommandHandler((commandArgs, clientId) -> {
+      if (!PING.equals(commandArgs.getCommand())) {
+        return null;
+      }
+      return RespResponse.array(RespResponse.bulkString("pong"),
+        RespResponse.bulkString(commandArgs.get(1).getRaw()));
+    });
+
+    try (Jedis jedis = createJedis()) {
+      assertEquals("hello", jedis.ping("hello"));
+    }
+  }
+
+  @Test
+  public void pingWithBinaryArgumentHandlesPubSubStylePongReply() {
+    mockServer.setCommandHandler((commandArgs, clientId) -> {
+      if (!PING.equals(commandArgs.getCommand())) {
+        return null;
+      }
+      return RespResponse.array(RespResponse.bulkString("pong"),
+        RespResponse.bulkString(commandArgs.get(1).getRaw()));
+    });
+
+    try (Jedis jedis = createJedis()) {
+      assertArrayEquals(SafeEncoder.encode("hello"), jedis.ping(SafeEncoder.encode("hello")));
+    }
+  }
+
+  private Jedis createJedis() {
+    return new Jedis("localhost", mockServer.getPort(),
+      DefaultJedisClientConfig.builder().protocol(RedisProtocol.RESP2).autoNegotiateProtocol(false).build());
+  }
+}


### PR DESCRIPTION
Fixes #4162.

This handles Redis PING while a connection is in subscribed mode, where Redis replies with a Pub/Sub-style PONG array instead of the normal status/bulk-string reply. Jedis#ping now accepts that PONG array path while preserving normal standalone PING behavior.

Changed files:
- src/main/java/redis/clients/jedis/Connection.java
- src/main/java/redis/clients/jedis/Jedis.java
- src/test/java/redis/clients/jedis/JedisMockTest.java

Validation:
- git diff --check
- diff-only debug/focused-test marker scan
- mvn "-Dformatter.skip=true" "-Dtest=JedisMockTest" "-DforkCount=0" test
- mvn "-Dformatter.skip=true" "-Dnet.bytebuddy.experimental=true" "-Dtest=JedisMockTest,JedisPubSubBaseTest" "-DforkCount=0" test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes low-level RESP reply handling on a core connection path used by health checks; scope is narrow and covered by new tests, but mis-parsing could affect any code calling ping on a subscribed connection.
> 
> **Overview**
> Fixes **PING** on connections that are already in **pub/sub subscribed mode**, where Redis returns a two-element array (`pong` + payload) instead of a simple status or bulk string.
> 
> `Connection` gains **`getPongReply` / `getBinaryPongReply`**, which read the next protocol object and, when it is a list, validate and normalize the pub/sub PONG shape (returning `"PONG"` or the echoed argument). **`Jedis#ping()`** and its string/binary overloads now use these helpers instead of **`getStatusCodeReply`** / **`getBulkReply`**, so standalone PING behavior is unchanged while subscribed-mode PING no longer fails parsing.
> 
> Adds **`JedisMockTest`** with a TCP mock server to assert all three PING variants against pub/sub-style replies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53550fe21a9b725a955966359e3b86bbc43a77f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->