### PR TITLE
Hash-tag TS.CREATERULE/TS.DELETERULE key pairs so they don't CROSSSLOT on clustered deployments

### DIFF
--- a/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsTimeSeriesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsTimeSeriesCommandsTest.java
@@ -416,8 +416,10 @@ public class CommandObjectsTimeSeriesCommandsTest extends CommandObjectsModulesT
 
   @Test
   public void testTsCreateRule() {
-    String sourceKey = "tsSourceKey";
-    String destKey = "tsDestKey";
+    // Hash-tag the rule key pair so TS.CREATERULE's two keys hash to the same slot on a
+    // clustered deployment (otherwise the server rejects it with CROSSSLOT).
+    String sourceKey = "{tsCreateRule}tsSourceKey";
+    String destKey = "{tsCreateRule}tsDestKey";
 
     AggregationType aggregationType = AggregationType.AVG;
 
@@ -460,8 +462,9 @@ public class CommandObjectsTimeSeriesCommandsTest extends CommandObjectsModulesT
 
   @Test
   public void testTsCreateRuleWithAlign() {
-    String sourceKey = "tsSourceKey";
-    String destKey = "tsDestKey";
+    // Hash-tag the rule key pair so the two keys collocate on one slot (avoid CROSSSLOT).
+    String sourceKey = "{tsCreateRuleAlign}tsSourceKey";
+    String destKey = "{tsCreateRuleAlign}tsDestKey";
 
     AggregationType aggregationType = AggregationType.AVG;
 
@@ -502,8 +505,9 @@ public class CommandObjectsTimeSeriesCommandsTest extends CommandObjectsModulesT
 
   @Test
   public void testTsDeleteRule() {
-    String sourceKey = "tsSourceKeyForDeletionWithData";
-    String destKey = "tsDestKeyForDeletionWithData";
+    // Hash-tag the rule key pair so TS.DELETERULE's two keys collocate on one slot (avoid CROSSSLOT).
+    String sourceKey = "{tsDeleteRule}tsSourceKeyForDeletionWithData";
+    String destKey = "{tsDeleteRule}tsDestKeyForDeletionWithData";
 
     AggregationType aggregationType = AggregationType.SUM;
 


### PR DESCRIPTION
## Summary

`CommandObjectsTimeSeriesCommandsTest` exercises `TS.CREATERULE` / `TS.DELETERULE`, which are multi-key commands (source + destination key). The source and destination keys were plain, un-tagged strings (`tsSourceKey` / `tsDestKey`), so on a clustered deployment they hash to different slots and the server rejects the command with:

```
CROSSSLOT Keys in request don't hash to the same slot (command='ts.createrule', first-key='tsSourceKey', violating-key='tsDestKey')
```

This makes `testTsCreateRule`, `testTsCreateRuleWithAlign`, and `testTsDeleteRule` fail whenever the tests run against a sharded/cluster database, while passing on a single-slot server.

## What changed

Hash-tag each rule's key pair with a shared tag so the two keys always land on the same slot, e.g. `{tsCreateRule}tsSourceKey` / `{tsCreateRule}tsDestKey`. This keeps the test intent identical (create/delete a compaction rule between two keys) while making it slot-safe on both standalone and clustered topologies.

## Testing

Ran the affected tests against a sharded Redis database:
- Before: `testTsCreateRule`, `testTsCreateRuleWithAlign`, `testTsDeleteRule` fail with `CROSSSLOT`.
- After: all three pass (16 tests per RESP protocol, 0 failures).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only key renames with comments; no library or runtime behavior changes.
> 
> **Overview**
> Updates **Time Series integration tests** so `TS.CREATERULE` and `TS.DELETERULE` work on **clustered Redis**, where source and destination keys must hash to the same slot.
> 
> In `testTsCreateRule`, `testTsCreateRuleWithAlign`, and `testTsDeleteRule`, source/dest keys now use a **shared hash tag** (e.g. `{tsCreateRule}tsSourceKey` / `{tsCreateRule}tsDestKey`) instead of plain names. Short comments document why. Test behavior is unchanged; only key naming is slot-safe so runs no longer hit **CROSSSLOT** on sharded deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7430133d0eb2c3539c6319b18ad4738250725f1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->