### PR TITLE
Use Locale.ENGLISH for ASCII case conversion in ClientType and TSInfo (#4595)

### DIFF
--- a/src/main/java/redis/clients/jedis/args/ClientType.java
+++ b/src/main/java/redis/clients/jedis/args/ClientType.java
@@ -1,5 +1,7 @@
 package redis.clients.jedis.args;
 
+import java.util.Locale;
+
 import redis.clients.jedis.util.SafeEncoder;
 
 public enum ClientType implements Rawable {
@@ -9,7 +11,7 @@ public enum ClientType implements Rawable {
   private final byte[] raw;
 
   private ClientType() {
-    raw = SafeEncoder.encode(name().toLowerCase());
+    raw = SafeEncoder.encode(name().toLowerCase(Locale.ENGLISH));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/timeseries/TSInfo.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSInfo.java
@@ -3,6 +3,7 @@ package redis.clients.jedis.timeseries;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -117,7 +118,7 @@ public class TSInfo {
           value = SafeEncoder.encode((byte[]) value);
           if (DUPLICATE_POLICY_PROPERTY.equals(prop)) {
             try {
-              value = DuplicatePolicy.valueOf(((String) value).toUpperCase());
+              value = DuplicatePolicy.valueOf(((String) value).toUpperCase(Locale.ENGLISH));
             } catch (Exception e) { }
           }
         }
@@ -179,7 +180,7 @@ public class TSInfo {
           value = BuilderFactory.STRING.build(value);
           if (DUPLICATE_POLICY_PROPERTY.equals(prop)) {
             try {
-              value = DuplicatePolicy.valueOf(((String) value).toUpperCase());
+              value = DuplicatePolicy.valueOf(((String) value).toUpperCase(Locale.ENGLISH));
             } catch (Exception e) { }
           }
         }

--- a/src/test/java/redis/clients/jedis/timeseries/TSInfoLocaleTest.java
+++ b/src/test/java/redis/clients/jedis/timeseries/TSInfoLocaleTest.java
@@ -6,31 +6,51 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import redis.clients.jedis.util.KeyValue;
 import redis.clients.jedis.util.SafeEncoder;
 
+/**
+ * Under a Turkish/Azeri default locale, {@code "first".toUpperCase()} yields the dotted
+ * {@code "FİRST"}, so {@code DuplicatePolicy.valueOf(...)} throws and the parsed policy is silently
+ * dropped. Parsing the TS.INFO reply must not depend on the JVM default locale.
+ * <p>
+ * Mutates the JVM default locale; must not run concurrently with other tests.
+ */
 public class TSInfoLocaleTest {
 
-  /**
-   * Under a Turkish/Azeri default locale, {@code "first".toUpperCase()} yields the dotted
-   * {@code "FİRST"}, so {@code DuplicatePolicy.valueOf(...)} throws and the parsed policy is
-   * silently dropped. Parsing the TS.INFO reply must not depend on the JVM default locale.
-   */
+  private Locale previousLocale;
+
+  @BeforeEach
+  public void setTurkishLocale() {
+    previousLocale = Locale.getDefault();
+    Locale.setDefault(new Locale("tr", "TR"));
+  }
+
+  @AfterEach
+  public void restoreLocale() {
+    Locale.setDefault(previousLocale);
+  }
+
   @Test
-  public void duplicatePolicyParsedUnderTurkishLocale() {
-    Locale previous = Locale.getDefault();
-    try {
-      Locale.setDefault(new Locale("tr", "TR"));
+  public void duplicatePolicyParsingIsLocaleIndependent() {
+    List<Object> reply = new ArrayList<>();
+    reply.add(SafeEncoder.encode("duplicatePolicy"));
+    reply.add(SafeEncoder.encode("first"));
 
-      List<Object> reply = new ArrayList<>();
-      reply.add(SafeEncoder.encode("duplicatePolicy"));
-      reply.add(SafeEncoder.encode("first"));
+    TSInfo info = TSInfo.TIMESERIES_INFO.build(reply);
+    assertEquals(DuplicatePolicy.FIRST, info.getProperty("duplicatePolicy"));
+  }
 
-      TSInfo info = TSInfo.TIMESERIES_INFO.build(reply);
-      assertEquals(DuplicatePolicy.FIRST, info.getProperty("duplicatePolicy"));
-    } finally {
-      Locale.setDefault(previous);
-    }
+  @Test
+  public void duplicatePolicyParsingIsLocaleIndependentResp3() {
+    List<KeyValue> reply = new ArrayList<>();
+    reply.add(new KeyValue(SafeEncoder.encode("duplicatePolicy"), SafeEncoder.encode("first")));
+
+    TSInfo info = TSInfo.TIMESERIES_INFO_RESP3.build(reply);
+    assertEquals(DuplicatePolicy.FIRST, info.getProperty("duplicatePolicy"));
   }
 }

--- a/src/test/java/redis/clients/jedis/timeseries/TSInfoLocaleTest.java
+++ b/src/test/java/redis/clients/jedis/timeseries/TSInfoLocaleTest.java
@@ -1,0 +1,36 @@
+package redis.clients.jedis.timeseries;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.util.SafeEncoder;
+
+public class TSInfoLocaleTest {
+
+  /**
+   * Under a Turkish/Azeri default locale, {@code "first".toUpperCase()} yields the dotted
+   * {@code "FİRST"}, so {@code DuplicatePolicy.valueOf(...)} throws and the parsed policy is
+   * silently dropped. Parsing the TS.INFO reply must not depend on the JVM default locale.
+   */
+  @Test
+  public void duplicatePolicyParsedUnderTurkishLocale() {
+    Locale previous = Locale.getDefault();
+    try {
+      Locale.setDefault(new Locale("tr", "TR"));
+
+      List<Object> reply = new ArrayList<>();
+      reply.add(SafeEncoder.encode("duplicatePolicy"));
+      reply.add(SafeEncoder.encode("first"));
+
+      TSInfo info = TSInfo.TIMESERIES_INFO.build(reply);
+      assertEquals(DuplicatePolicy.FIRST, info.getProperty("duplicatePolicy"));
+    } finally {
+      Locale.setDefault(previous);
+    }
+  }
+}


### PR DESCRIPTION
  ## Problem                                                                                                                                                                            
                                                                                                                                                                                        
  `ClientType` and `TSInfo` case-convert under the JVM default locale. On a Turkish/Azeri locale (`tr_TR`, `az_AZ`), `i`/`I` convert to the dotted/dotless variants:                    
                                                                                                                                                                                        
  - `ClientType` builds its wire token with `name().toLowerCase()`, so `REPLICA` becomes `replıca` — `CLIENT KILL/LIST TYPE replica` sends an invalid token and fails with a server     
  error.                                                                                                                                                                                
  - `TSInfo` parses `duplicatePolicy` with `toUpperCase()` before `DuplicatePolicy.valueOf(...)`, so `first`/`min` become `FİRST`/`MİN` — `valueOf` throws, the exception is swallowed, 
  and the parsed policy silently remains a `String`.
  
    ## Fix                                                                                                                                                                                
                                                                                                                                                                                        
  Pin both conversions to `Locale.ENGLISH`, keeping the ASCII tokens intact. This matches the sibling enums `GeoUnit` and `Protocol.ResponseKeyword`, which already do this (see #1319  
  for the same defect class fixed previously)

Fixes #4595
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized string-case fixes aligned with existing enum patterns; new unit tests only mutate JVM locale in isolation.
> 
> **Overview**
> Fixes **locale-sensitive** `toLowerCase()` / `toUpperCase()` so Redis wire tokens and TS.INFO parsing stay correct when the JVM default locale is Turkish or Azeri (e.g. `REPLICA` → `replıca`, `first` → dotted uppercase that breaks `DuplicatePolicy.valueOf`).
> 
> **`ClientType`** now lowercases enum names with `Locale.ENGLISH` when building raw bytes, consistent with **`GeoUnit`** and **`Protocol.ResponseKeyword`**.
> 
> **`TSInfo`** uses `Locale.ENGLISH` for `duplicatePolicy` parsing in both the RESP2 and RESP3 builders.
> 
> Adds **`TSInfoLocaleTest`**, which sets `tr_TR` as the default locale and asserts `duplicatePolicy` still resolves to `DuplicatePolicy.FIRST`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8c6521728ff92af002ffb8af5c91f8ff07ab32d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->