### PR TITLE
Backport #4593 to 7.5.x: use Locale.ENGLISH for ASCII case conversion in ClientType and TSInfo

### DIFF
--- a/src/main/java/redis/clients/jedis/args/ClientType.java
+++ b/src/main/java/redis/clients/jedis/args/ClientType.java
@@ -1,5 +1,7 @@
 package redis.clients.jedis.args;
 
+import java.util.Locale;
+
 import redis.clients.jedis.util.SafeEncoder;
 
 public enum ClientType implements Rawable {
@@ -9,7 +11,7 @@ public enum ClientType implements Rawable {
   private final byte[] raw;
 
   private ClientType() {
-    raw = SafeEncoder.encode(name().toLowerCase());
+    raw = SafeEncoder.encode(name().toLowerCase(Locale.ENGLISH));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/timeseries/TSInfo.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSInfo.java
@@ -3,6 +3,7 @@ package redis.clients.jedis.timeseries;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -117,7 +118,7 @@ public class TSInfo {
           value = SafeEncoder.encode((byte[]) value);
           if (DUPLICATE_POLICY_PROPERTY.equals(prop)) {
             try {
-              value = DuplicatePolicy.valueOf(((String) value).toUpperCase());
+              value = DuplicatePolicy.valueOf(((String) value).toUpperCase(Locale.ENGLISH));
             } catch (Exception e) { }
           }
         }
@@ -179,7 +180,7 @@ public class TSInfo {
           value = BuilderFactory.STRING.build(value);
           if (DUPLICATE_POLICY_PROPERTY.equals(prop)) {
             try {
-              value = DuplicatePolicy.valueOf(((String) value).toUpperCase());
+              value = DuplicatePolicy.valueOf(((String) value).toUpperCase(Locale.ENGLISH));
             } catch (Exception e) { }
           }
         }

--- a/src/test/java/redis/clients/jedis/timeseries/TSInfoLocaleTest.java
+++ b/src/test/java/redis/clients/jedis/timeseries/TSInfoLocaleTest.java
@@ -1,0 +1,56 @@
+package redis.clients.jedis.timeseries;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.util.KeyValue;
+import redis.clients.jedis.util.SafeEncoder;
+
+/**
+ * Under a Turkish/Azeri default locale, {@code "first".toUpperCase()} yields the dotted
+ * {@code "FİRST"}, so {@code DuplicatePolicy.valueOf(...)} throws and the parsed policy is silently
+ * dropped. Parsing the TS.INFO reply must not depend on the JVM default locale.
+ * <p>
+ * Mutates the JVM default locale; must not run concurrently with other tests.
+ */
+public class TSInfoLocaleTest {
+
+  private Locale previousLocale;
+
+  @BeforeEach
+  public void setTurkishLocale() {
+    previousLocale = Locale.getDefault();
+    Locale.setDefault(new Locale("tr", "TR"));
+  }
+
+  @AfterEach
+  public void restoreLocale() {
+    Locale.setDefault(previousLocale);
+  }
+
+  @Test
+  public void duplicatePolicyParsingIsLocaleIndependent() {
+    List<Object> reply = new ArrayList<>();
+    reply.add(SafeEncoder.encode("duplicatePolicy"));
+    reply.add(SafeEncoder.encode("first"));
+
+    TSInfo info = TSInfo.TIMESERIES_INFO.build(reply);
+    assertEquals(DuplicatePolicy.FIRST, info.getProperty("duplicatePolicy"));
+  }
+
+  @Test
+  public void duplicatePolicyParsingIsLocaleIndependentResp3() {
+    List<KeyValue> reply = new ArrayList<>();
+    reply.add(new KeyValue(SafeEncoder.encode("duplicatePolicy"), SafeEncoder.encode("first")));
+
+    TSInfo info = TSInfo.TIMESERIES_INFO_RESP3.build(reply);
+    assertEquals(DuplicatePolicy.FIRST, info.getProperty("duplicatePolicy"));
+  }
+}


### PR DESCRIPTION
Backport of #4593 to `7.5.x`. Fixes https://github.com/redis/jedis/issues/4595 for the 7.5 line.

## Problem

`ClientType` and `TSInfo` case-convert under the JVM default locale. On a Turkish/Azeri locale (`tr_TR`, `az_AZ`), `i`/`I` convert to the dotted/dotless variants:

- `ClientType` builds its wire token with `name().toLowerCase()`, so `REPLICA` becomes `replıca` — `CLIENT KILL/LIST TYPE replica` sends an invalid token and fails with a server error.
- `TSInfo` parses `duplicatePolicy` with `toUpperCase()` before `DuplicatePolicy.valueOf(...)`, so `first`/`min` become `FİRST`/`MİN` — `valueOf` throws, the exception is swallowed, and the parsed policy silently remains a `String`.

## Fix

Pin both conversions to `Locale.ENGLISH`, matching the sibling enums `GeoUnit` and `Protocol.ResponseKeyword` (same defect class as #1319).

## Testing

`TSInfoLocaleTest` asserts `duplicatePolicy` parses correctly under `tr_TR` through both the RESP2 (`TIMESERIES_INFO`) and RESP3 (`TIMESERIES_INFO_RESP3`) builders.

Cherry-picked from master: 81caef76 (#4593 squash commit; clean, no conflicts).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted locale fixes aligned with existing `GeoUnit`/`Protocol` patterns; behavior change only for JVMs with Turkish/Azeri default locales.
> 
> **Overview**
> Backport of the locale-safety fix for wire tokens and TS.INFO parsing on the **7.5.x** line.
> 
> **`ClientType`** now builds Redis wire bytes with `name().toLowerCase(Locale.ENGLISH)` instead of the JVM default locale, so values like `REPLICA` stay `replica` rather than Turkish `replıca` on `tr_TR`/`az_AZ` (which broke `CLIENT KILL`/`LIST TYPE`).
> 
> **`TSInfo`** uses `toUpperCase(Locale.ENGLISH)` when mapping `duplicatePolicy` to `DuplicatePolicy` in both RESP2 and RESP3 builders, so policies like `first` parse correctly instead of failing `valueOf` and leaving a raw `String`.
> 
> Adds **`TSInfoLocaleTest`**, which sets `tr_TR` as the default locale and asserts `duplicatePolicy` resolves to `DuplicatePolicy.FIRST` for both builders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 148232a0ee929a26e20d39b8f6e4d1d710580442. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->