### PR TITLE
Backport #4511 test changes to 7.5.x: accept new Search error message

### DIFF
--- a/src/test/java/redis/clients/jedis/modules/search/SearchTest.java
+++ b/src/test/java/redis/clients/jedis/modules/search/SearchTest.java
@@ -1,7 +1,9 @@
 package redis.clients.jedis.modules.search;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -211,11 +213,7 @@ public class SearchTest extends RedisModuleCommandsTestBase {
     assertEquals(99, res.getTotalResults());
 
     assertEquals("OK", client.ftDropIndex(index));
-    try {
-      client.ftSearch(index, new Query("hello world"));
-      fail();
-    } catch (JedisDataException e) {
-    }
+    assertThrows(JedisDataException.class, () -> client.ftSearch(index, new Query("hello world")));
   }
 
   @Test
@@ -579,8 +577,10 @@ public class SearchTest extends RedisModuleCommandsTestBase {
       client.ftSearch(index, new Query("hello world"));
       fail("Index should not exist.");
     } catch (JedisDataException de) {
-      // error message updated to "No such index" with Redis 8.0.0
-      assertTrue(de.getMessage().toLowerCase().contains("no such index"));
+      assertThat(de.getMessage(), anyOf(containsStringIgnoringCase("no such index"), // Redis Search
+        // <v8.7.90
+        containsString("SEARCH_INDEX_NOT_FOUND") // Redis Search v8.7.90+
+      ));
     }
     assertEquals(100, client.dbSize());
   }

--- a/src/test/java/redis/clients/jedis/modules/search/SearchWithParamsTest.java
+++ b/src/test/java/redis/clients/jedis/modules/search/SearchWithParamsTest.java
@@ -1,6 +1,9 @@
 package redis.clients.jedis.modules.search;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -226,11 +229,7 @@ public class SearchWithParamsTest extends RedisModuleCommandsTestBase {
     assertEquals(99, result.getTotalResults());
 
     assertEquals("OK", client.ftDropIndex(index));
-    try {
-      client.ftSearch(index, "hello world");
-      fail();
-    } catch (JedisDataException e) {
-    }
+    assertThrows(JedisDataException.class, () -> client.ftSearch(index, "hello world"));
   }
 
   @Test
@@ -745,8 +744,10 @@ public class SearchWithParamsTest extends RedisModuleCommandsTestBase {
       client.ftSearch(index, "hello world");
       fail("Index should not exist.");
     } catch (JedisDataException de) {
-      // toLowerCase - Error message updated to "No such index" with Redis 8.0.0
-      assertTrue(de.getMessage().toLowerCase().contains("no such index"));
+      assertThat(de.getMessage(), anyOf(containsStringIgnoringCase("no such index"), // Redis Search
+        // <v8.7.90
+        containsString("SEARCH_INDEX_NOT_FOUND") // Redis Search v8.7.90+
+      ));
     }
     assertEquals(100, client.dbSize());
   }


### PR DESCRIPTION
## What
Backports the #4511 test changes missed by #4578, fixing `dropIndex` test failures on 7.5.x against Redis 8.8.

## Why
#4578 added Redis 8.8 GA to the 7.5.x test matrix but did not include the test fixes from #4511. Redis Search v8.7.90+ returns `SEARCH_INDEX_NOT_FOUND` instead of `no such index` when querying a dropped index, so `SearchTest.dropIndex` and `SearchWithParamsTest.dropIndex` fail against Redis 8.8. On master these tests live in `SearchWithParamsCommandsTestBase`; on 7.5.x they live in `SearchTest` and `SearchWithParamsTest`.

## Changes
- `SearchTest.dropIndex()` / `SearchWithParamsTest.dropIndex()`: accept either `no such index` (Redis Search < v8.7.90) or `SEARCH_INDEX_NOT_FOUND` (v8.7.90+) in the error message assertion
- `SearchTest.search()` / `SearchWithParamsTest.search()`: replace try/fail/catch with `assertThrows` (matching #4511)

Verified locally against Redis 8.8.0: all four tests pass across RESP2/RESP3 variants.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion updates; no production library or runtime behavior changes.
> 
> **Overview**
> Backports **#4511** test fixes onto **7.5.x** so Redis Search integration tests pass against **Redis 8.8** (Search v8.7.90+), where a search on a dropped index returns **`SEARCH_INDEX_NOT_FOUND`** instead of **`no such index`**.
> 
> In **`SearchTest`** and **`SearchWithParamsTest`**, **`dropIndex()`** now asserts the **`JedisDataException`** message matches either legacy text (case-insensitive **`no such index`**) or **`SEARCH_INDEX_NOT_FOUND`**, using Hamcrest **`anyOf`**. **`search()`** in both classes replaces manual try/fail/catch with **`assertThrows`** when searching after **`ftDropIndex`**, matching the master change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b82b74b15bb3f901fdb98c3e6e6dacd3d9991de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->