### PR TITLE
[maintenance events] Fix accessors with connection

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -19,8 +19,6 @@ import java.util.function.Supplier;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Protocol.Command;
 import redis.clients.jedis.Protocol.Keyword;
 import redis.clients.jedis.TimeoutSource.TimeoutInfo;
@@ -36,7 +34,6 @@ import redis.clients.jedis.util.RedisInputStream;
 import redis.clients.jedis.util.RedisOutputStream;
 
 public class Connection implements Closeable {
-  public static Logger logger = LoggerFactory.getLogger(Connection.class);
 
   public static class Builder {
     private JedisSocketFactory socketFactory;
@@ -324,7 +321,7 @@ public class Connection implements Closeable {
    * @return the configured timeout in milliseconds for blocking operations
    * @see MaintenanceNotificationsConfig#getRelaxedBlockingTimeout()
    */
-  public int getBlockingSoTimeout() {
+  int getBlockingSoTimeout() {
     return defaultTimeoutSource.getDefaults().blockingTimeout;
   }
 
@@ -1067,8 +1064,7 @@ public class Connection implements Closeable {
     this.pushConsumers.add(consumer);
   }
 
-  @Internal
-  protected void removePushConsumer(PushConsumer consumer) {
+  void removePushConsumer(PushConsumer consumer) {
     this.pushConsumers.remove(consumer);
   }
 

--- a/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
@@ -14,7 +14,7 @@ import redis.clients.jedis.util.JedisAsserts;
 
 public class MaintenanceAwareVisitor implements InitVisitor {
 
-  private static Logger logger = LoggerFactory.getLogger(MaintenanceAwareVisitor.class);
+  private static final Logger logger = LoggerFactory.getLogger(MaintenanceAwareVisitor.class);
 
   private final Connection.Builder builder;
   private final MaintenanceEventController controller;

--- a/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
@@ -3,6 +3,7 @@ package redis.clients.jedis;
 import java.util.Set;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import redis.clients.jedis.Protocol.Command;
 import redis.clients.jedis.TimeoutSource.TimeoutInfo;
@@ -12,6 +13,8 @@ import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.util.JedisAsserts;
 
 public class MaintenanceAwareVisitor implements InitVisitor {
+
+  private static Logger logger = LoggerFactory.getLogger(MaintenanceAwareVisitor.class);
 
   private final Connection.Builder builder;
   private final MaintenanceEventController controller;
@@ -26,7 +29,6 @@ public class MaintenanceAwareVisitor implements InitVisitor {
 
   @Override
   public void visit(Connection connection) {
-    Logger logger = Connection.logger;
     RedisProtocol protocol = connection.getRedisProtocol();
     Set<MaintenanceEventListener> maintenanceEventListeners = connection
         .getMaintenanceEventListeners();

--- a/src/test/java/redis/clients/jedis/ConnectionTestHelper.java
+++ b/src/test/java/redis/clients/jedis/ConnectionTestHelper.java
@@ -100,6 +100,10 @@ public class ConnectionTestHelper {
     NanoClock.INSTANCE = System::nanoTime;
   }
 
+  public static int getBlockingSoTimeout(Connection connection) {
+    return connection.getBlockingSoTimeout();
+  }
+
   private ConnectionTestHelper() {
     // Utility class - prevent instantiation
   }

--- a/src/test/java/redis/clients/jedis/sch/AbstractRelaxedTimeoutBehaviorTest.java
+++ b/src/test/java/redis/clients/jedis/sch/AbstractRelaxedTimeoutBehaviorTest.java
@@ -160,7 +160,7 @@ public abstract class AbstractRelaxedTimeoutBehaviorTest {
     try {
       // Baseline (non-relaxed) timeouts are read from the default source.
       assertEquals(SO_TIMEOUT_MS, connection.getSoTimeout());
-      assertEquals(0, connection.getBlockingSoTimeout());
+      assertEquals(0, ConnectionTestHelper.getBlockingSoTimeout(connection));
 
       ConnectionTestHelper.relaxTimeouts(connection, Durations.FIVE_SECONDS);
       // Configured relaxed timeouts are read from the relaxed source, independent of whether a
@@ -172,7 +172,8 @@ public abstract class AbstractRelaxedTimeoutBehaviorTest {
       // be
       // observable rather than masked by equal values.
       assertNotEquals(connection.getSoTimeout(), getRelaxedSoTimeout(connection));
-      assertNotEquals(connection.getBlockingSoTimeout(), getRelaxedBlockingSoTimeout(connection));
+      assertNotEquals(ConnectionTestHelper.getBlockingSoTimeout(connection),
+        getRelaxedBlockingSoTimeout(connection));
 
       // The relaxed source is plugged into the default source as its override, but the window is
       // not


### PR DESCRIPTION
Closes #4608
This piece of change remains limited to decreasing the accessibility of connection internals while initial intent was to address #4608 purely.
the requirement around the issue is fixed previously in the [commit](https://github.com/redis/jedis/commit/6d23922cf6bda48a63ccdcc04c41f6f27b648a49) .
Another change to pay attention is `initPushConsumers` which was protected(not sure why) before is now private;
```java
private void initPushConsumers(JedisClientConfig config)

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visibility and logging refactors only; maintenance behavior is unchanged and tests still reach internals through package-private helpers.
> 
> **Overview**
> Narrows **`Connection`** surface area used by maintenance-event wiring: removes the **public static `logger`**, makes **`getBlockingSoTimeout()`** and **`removePushConsumer()`** package-private (dropping `@Internal` on the latter), and stops exposing logging through the connection type.
> 
> **`MaintenanceAwareVisitor`** now owns a **class-local SLF4J logger** instead of **`Connection.logger`**.
> 
> Tests outside the package read blocking timeout via **`ConnectionTestHelper.getBlockingSoTimeout`**, including updates in **`AbstractRelaxedTimeoutBehaviorTest`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83cf9e117ecba512785cb79a5233136861dad51c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->