### PR TITLE
[maintenance events] Relaxed maintenance timeouts only loosen, never tighten the deadline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -638,7 +638,7 @@
 						<include>**/*Handler.java</include>
 						<include>**/InitVisitor.java</include>
 						<include>**/NanoClock.java</include>
-						<include>**/*TimeoutSource.java</include>
+						<include>**/*TimeoutSource*.java</include>
 						<include>**/RebindAwareEvictionPolicy.java</include>
 						<include>**/Maintenance*.java</include>
 					</includes>

--- a/src/main/java/redis/clients/jedis/ChainedTimeoutSource.java
+++ b/src/main/java/redis/clients/jedis/ChainedTimeoutSource.java
@@ -16,14 +16,14 @@ class ChainedTimeoutSource implements TimeoutSource {
 
   @Override
   public TimeoutInfo get() {
+    TimeoutInfo fromOverride = getOverrideInfo();
+    return fromOverride != null ? fromOverride : getOwnInfo();
+  }
+
+  /** The deepest valid override's timeouts, or {@code null} when no override has an opinion. */
+  protected final TimeoutInfo getOverrideInfo() {
     ChainedTimeoutSource o = override;
-    if (o != null) {
-      TimeoutInfo fromOverride = o.get();
-      if (fromOverride != null) {
-        return fromOverride;
-      }
-    }
-    return getOwnInfo();
+    return o != null ? o.get() : null;
   }
 
   protected TimeoutInfo getOwnInfo() {

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -335,8 +335,9 @@ public class Connection implements Closeable {
    * is already established. Otherwise, it will be applied when the socket is created.</p>
    *
    * <p>If the connection is currently in a <em>relaxed timeout</em> state (see {@link MaintenanceNotificationsConfig}),
-   * the relaxed value remains in effect on the socket; the value configured here takes effect
-   * once the relaxation window closes.</p>
+   * the looser of the value configured here and the relaxed value is in effect on the socket,
+   * {@code 0} (infinite) being the loosest; the configured value alone takes effect once the
+   * relaxation window closes.</p>
    *
    * @param millis the timeout value in milliseconds; a value of {@code 0} means infinite timeout
    * @throws JedisConnectionException if the underlying socket fails to apply the timeout
@@ -368,8 +369,9 @@ public class Connection implements Closeable {
    *
    * <p>The effective timeout applied depends on the current connection state:</p>
    * <ul>
-   *   <li>If relaxed timeout mode is active, the relaxed blocking timeout is used.</li>
-   *   <li>Otherwise, the configured infinite blocking timeout is applied.</li>
+   *   <li>If relaxed timeout mode is active, the looser of the configured blocking timeout and
+   *   the relaxed blocking timeout is used, {@code 0} (infinite) being the loosest.</li>
+   *   <li>Otherwise, the configured blocking timeout is applied.</li>
    * </ul>
    *
    * <p>This is typically used for blocking Redis commands (e.g. BLPOP, BRPOP) where
@@ -395,7 +397,8 @@ public class Connection implements Closeable {
    *
    * <p>The restored timeout depends on the current connection state:</p>
    * <ul>
-   *   <li>{@link MaintenanceNotificationsConfig#getRelaxedTimeout()} if relaxed timeout mode is active</li>
+   *   <li>The looser of {@link #getSoTimeout()} and {@link MaintenanceNotificationsConfig#getRelaxedTimeout()},
+   *   {@code 0} (infinite) being the loosest, if relaxed timeout mode is active</li>
    *   <li>{@link #getSoTimeout()} otherwise</li>
    * </ul>
    *
@@ -1094,9 +1097,11 @@ public class Connection implements Closeable {
 
   /**
    * Switches this connection to relaxed timeouts for at most {@code period}. While the window is
-   * open, commands use {@link MaintenanceNotificationsConfig#getRelaxedTimeout()} and {@link MaintenanceNotificationsConfig#getRelaxedBlockingTimeout()}
-   * instead of the configured values, giving in-flight commands extra headroom across a server-side
-   * maintenance event (MIGRATING / FAILING_OVER / MOVING-receiver). The original timeouts return
+   * open, commands use the looser of the configured value and {@link MaintenanceNotificationsConfig#getRelaxedTimeout()}
+   * (respectively {@link MaintenanceNotificationsConfig#getRelaxedBlockingTimeout()}), {@code 0}
+   * (infinite) being the loosest, giving in-flight commands extra headroom across a server-side
+   * maintenance event (MIGRATING / FAILING_OVER / MOVING-receiver) without ever tightening the
+   * configured deadline. The original timeouts return
    * into effect once the window closes or {@link #resetRelaxedTimeouts()} is called. Calling this
    * with a later deadline extends the window; an earlier one is ignored.
    * @param period maximum duration of the relaxation window

--- a/src/main/java/redis/clients/jedis/DefaultTimeoutSource.java
+++ b/src/main/java/redis/clients/jedis/DefaultTimeoutSource.java
@@ -1,13 +1,58 @@
 package redis.clients.jedis;
 
-/** Terminal chain link holding the configured baseline timeouts; always has an opinion. */
+/**
+ * Terminal chain link holding the configured baseline timeouts; always has an opinion. Overrides
+ * chained onto this source are maintenance relaxations, so their values are reduced per field to
+ * the looser of the configured and the relaxed value — {@code 0} (infinite) being the loosest —
+ * ensuring a relaxation can only ever loosen the configured deadline, never tighten it.
+ */
 class DefaultTimeoutSource extends ChainedTimeoutSource {
 
-  TimeoutInfo ownInfo;
+  private volatile TimeoutInfo ownInfo;
+
+  /**
+   * Memo of the last fused, keyed by the exact (defaults, relaxed) instance pair. Both inputs are
+   * reference-stable between configuration changes, so the pre-read hot path stays allocation-free.
+   */
+  private volatile FusedInfo fusedInfo;
 
   DefaultTimeoutSource(TimeoutInfo info) {
     super(info);
     ownInfo = info;
+  }
+
+  @Override
+  public TimeoutInfo get() {
+    TimeoutInfo defaults = ownInfo;
+    TimeoutInfo relaxed = getOverrideInfo();
+    if (relaxed == null) {
+      return defaults;
+    }
+    FusedInfo current = fusedInfo;
+    if (current != null && current.defaults == defaults && current.relaxed == relaxed) {
+      return current.fused;
+    }
+    fusedInfo = new FusedInfo(defaults, relaxed);
+    return fusedInfo.fused;
+  }
+
+  private static final class FusedInfo {
+
+    private final TimeoutInfo defaults;
+    private final TimeoutInfo relaxed;
+    private final TimeoutInfo fused;
+
+    FusedInfo(TimeoutInfo defaults, TimeoutInfo relaxed) {
+      this.defaults = defaults;
+      this.relaxed = relaxed;
+      this.fused = new TimeoutInfo(loosest(defaults.timeout, relaxed.timeout),
+          loosest(defaults.blockingTimeout, relaxed.blockingTimeout));
+    }
+
+    /** {@code 0} means infinite, so it beats any finite value. */
+    private static int loosest(int configured, int relaxed) {
+      return (configured == 0 || relaxed == 0) ? 0 : Math.max(configured, relaxed);
+    }
   }
 
   @Override

--- a/src/test/java/redis/clients/jedis/DefaultTimeoutSourceTest.java
+++ b/src/test/java/redis/clients/jedis/DefaultTimeoutSourceTest.java
@@ -1,0 +1,97 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.TimeoutSource.TimeoutInfo;
+
+/**
+ * Fusing behavior of {@link DefaultTimeoutSource}: an override (maintenance relaxation) is fused
+ * per field with the configured value, taking the looser of the two — {@code 0} (infinite) being
+ * the loosest — so relaxation can never tighten the configured deadline.
+ */
+public class DefaultTimeoutSourceTest {
+
+  private static DefaultTimeoutSource source(int timeout, int blockingTimeout) {
+    return new DefaultTimeoutSource(new TimeoutInfo(timeout, blockingTimeout));
+  }
+
+  private static ChainedTimeoutSource override(int timeout, int blockingTimeout) {
+    return new ChainedTimeoutSource(new TimeoutInfo(timeout, blockingTimeout));
+  }
+
+  @Test
+  public void noOverrideReturnsDefaults() {
+    DefaultTimeoutSource source = source(2000, 5000);
+    assertSame(source.getDefaults(), source.get());
+  }
+
+  @Test
+  public void looserOverrideWins() {
+    DefaultTimeoutSource source = source(2000, 5000);
+    source.addOverride(override(10000, 15000));
+    assertEquals(10000, source.get().timeout);
+    assertEquals(15000, source.get().blockingTimeout);
+  }
+
+  @Test
+  public void tighterOverrideLosesToDefaults() {
+    DefaultTimeoutSource source = source(20000, 30000);
+    source.addOverride(override(10000, 15000));
+    assertEquals(20000, source.get().timeout);
+    assertEquals(30000, source.get().blockingTimeout);
+  }
+
+  @Test
+  public void fusingIsAppliedPerField() {
+    DefaultTimeoutSource source = source(2000, 30000);
+    source.addOverride(override(10000, 15000));
+    assertEquals(10000, source.get().timeout, "looser relaxed timeout should win");
+    assertEquals(30000, source.get().blockingTimeout, "looser configured timeout should win");
+  }
+
+  @Test
+  public void infiniteConfiguredTimeoutStaysInfinite() {
+    DefaultTimeoutSource source = source(0, 0);
+    source.addOverride(override(10000, 15000));
+    assertEquals(0, source.get().timeout);
+    assertEquals(0, source.get().blockingTimeout);
+  }
+
+  @Test
+  public void infiniteRelaxedTimeoutLoosensToInfinite() {
+    DefaultTimeoutSource source = source(2000, 5000);
+    source.addOverride(override(0, 0));
+    assertEquals(0, source.get().timeout);
+    assertEquals(0, source.get().blockingTimeout);
+  }
+
+  @Test
+  public void fusedResultIsMemoizedAcrossReads() {
+    DefaultTimeoutSource source = source(2000, 30000);
+    source.addOverride(override(10000, 15000));
+    assertSame(source.get(), source.get());
+  }
+
+  @Test
+  public void changingDefaultsRecomputesFusedResult() {
+    DefaultTimeoutSource source = source(2000, 5000);
+    source.addOverride(override(10000, 15000));
+    assertEquals(10000, source.get().timeout);
+
+    source.setDefaults(25000, 5000);
+    assertEquals(25000, source.get().timeout, "raised configured timeout should win the fusing");
+    assertEquals(15000, source.get().blockingTimeout);
+  }
+
+  @Test
+  public void invalidOverrideFallsBackToDefaults() {
+    DefaultTimeoutSource source = source(2000, 5000);
+    ExpiringTimeoutSource expired = new ExpiringTimeoutSource(new TimeoutInfo(10000, 15000));
+    source.addOverride(expired);
+    // expiration time never set: the override window is closed, so no fusing is involved.
+    assertSame(source.getDefaults(), source.get());
+  }
+}

--- a/src/test/java/redis/clients/jedis/sch/AbstractRelaxedTimeoutBehaviorTest.java
+++ b/src/test/java/redis/clients/jedis/sch/AbstractRelaxedTimeoutBehaviorTest.java
@@ -50,6 +50,7 @@ import redis.clients.jedis.util.server.TcpMockServer;
 public abstract class AbstractRelaxedTimeoutBehaviorTest {
 
   protected static final int SO_TIMEOUT_MS = 2000;
+  protected static final int BLOCKING_SO_TIMEOUT_MS = 5000;
   protected static final int RELAXED_TIMEOUT_MS = 10000;
   protected static final int RELAXED_BLOCKING_TIMEOUT_MS = 15000;
 
@@ -90,10 +91,14 @@ public abstract class AbstractRelaxedTimeoutBehaviorTest {
     ConnectionTestHelper.resetClockNanos();
   }
 
-  /** Default client config: RESP3, mock server's port. */
+  /**
+   * Default client config: RESP3, mock server's port. Both baseline timeouts are finite and smaller
+   * than their relaxed counterparts, so the relaxed values win the only-loosen fusing and land on
+   * the socket during a relaxation window.
+   */
   protected JedisClientConfig defaultClientConfig() {
     return DefaultJedisClientConfig.builder().socketTimeoutMillis(SO_TIMEOUT_MS)
-        .protocol(RedisProtocol.RESP3).build();
+        .blockingSocketTimeoutMillis(BLOCKING_SO_TIMEOUT_MS).protocol(RedisProtocol.RESP3).build();
   }
 
   /**
@@ -160,7 +165,7 @@ public abstract class AbstractRelaxedTimeoutBehaviorTest {
     try {
       // Baseline (non-relaxed) timeouts are read from the default source.
       assertEquals(SO_TIMEOUT_MS, connection.getSoTimeout());
-      assertEquals(0, connection.getBlockingSoTimeout());
+      assertEquals(BLOCKING_SO_TIMEOUT_MS, connection.getBlockingSoTimeout());
 
       ConnectionTestHelper.relaxTimeouts(connection, Durations.FIVE_SECONDS);
       // Configured relaxed timeouts are read from the relaxed source, independent of whether a
@@ -291,5 +296,62 @@ public abstract class AbstractRelaxedTimeoutBehaviorTest {
     assertTrue(connection.ping());
     assertFalse(isRelaxedTimeoutActive(connection));
     assertEquals(SO_TIMEOUT_MS, socket.getSoTimeout());
+  }
+
+  /**
+   * Relaxation may only ever loosen the deadline: when the configured socket timeout is already
+   * larger than the relaxed one, the configured value stays on the socket throughout the relaxation
+   * window.
+   */
+  @Test
+  public void testRelaxationDoesNotTightenLargerConfiguredTimeout()
+      throws IOException, SocketException {
+    int largeSoTimeout = RELAXED_TIMEOUT_MS + 5000;
+    JedisClientConfig config = DefaultJedisClientConfig.builder()
+        .socketTimeoutMillis(largeSoTimeout).protocol(RedisProtocol.RESP3).build();
+    try (
+        ConnectionPool loosePool = createPool(new HostAndPort("localhost", mockServer.getPort()),
+          config, defaultMaintConfig());
+        Connection looseConnection = loosePool.getResource()) {
+      Socket socket = ConnectionTestHelper.getSocket(looseConnection);
+      assertEquals(largeSoTimeout, socket.getSoTimeout());
+
+      mockServer.sendPushMessageToAll(
+        MaintenanceEventMessages.migrating(1, 10, Collections.singletonList("1")));
+      assertTrue(looseConnection.ping());
+      assertTrue(isRelaxedTimeoutActive(looseConnection));
+      assertEquals(largeSoTimeout, socket.getSoTimeout(),
+        "Relaxed timeout smaller than the configured one must not tighten the socket timeout");
+
+      mockServer.sendPushMessageToAll(
+        MaintenanceEventMessages.migrated(1, Collections.singletonList("1")));
+      assertTrue(looseConnection.ping());
+      assertFalse(isRelaxedTimeoutActive(looseConnection));
+      assertEquals(largeSoTimeout, socket.getSoTimeout());
+    }
+  }
+
+  /**
+   * An infinite ({@code 0}) configured socket timeout is the loosest possible deadline, so a
+   * relaxation window must keep it infinite instead of imposing the finite relaxed value.
+   */
+  @Test
+  public void testRelaxationKeepsInfiniteConfiguredTimeout() throws IOException, SocketException {
+    JedisClientConfig config = DefaultJedisClientConfig.builder().socketTimeoutMillis(0)
+        .protocol(RedisProtocol.RESP3).build();
+    try (
+        ConnectionPool infinitePool = createPool(new HostAndPort("localhost", mockServer.getPort()),
+          config, defaultMaintConfig());
+        Connection infiniteConnection = infinitePool.getResource()) {
+      Socket socket = ConnectionTestHelper.getSocket(infiniteConnection);
+      assertEquals(0, socket.getSoTimeout());
+
+      mockServer.sendPushMessageToAll(
+        MaintenanceEventMessages.migrating(1, 10, Collections.singletonList("1")));
+      assertTrue(infiniteConnection.ping());
+      assertTrue(isRelaxedTimeoutActive(infiniteConnection));
+      assertEquals(0, socket.getSoTimeout(),
+        "Relaxation must not replace an infinite configured timeout with a finite one");
+    }
   }
 }


### PR DESCRIPTION
Closes #4602 
## Summary
During a server-side maintenance window (MIGRATING / FAILING_OVER / MOVING), a connection switches to relaxed timeouts to give in-flight commands extra headroom. Previously the relaxed value simply replaced the configured one, which could *shorten* the deadline when the configured timeout was already larger than the relaxed one. Now the relaxed and configured values are fused per field, keeping the looser of the two, so a relaxation can only ever extend a deadline.

## Key Decisions & Assumptions
- Fusing is per field (`timeout` and `blockingTimeout` independently), and `0` (infinite) is treated as the loosest possible value, beating any finite timeout on either side.
- `DefaultTimeoutSource` memoizes the fused result keyed by the exact `(defaults, relaxed)` instance pair. Both inputs are reference-stable between config changes, so the read hot path stays allocation-free; `ownInfo`/`fusedInfo` are `volatile` for safe publication across threads.
- Fusing lives in the terminal `DefaultTimeoutSource`; `ChainedTimeoutSource` was refactored to expose `getOverrideInfo()` so the terminal link can combine the override with its own defaults rather than blindly preferring the override.

## Behavioral / Conceptual Changes
- A relaxation window whose relaxed timeout is smaller than the configured socket timeout now leaves the larger configured value on the socket instead of tightening it.
- An infinite configured timeout stays infinite during relaxation; an infinite relaxed timeout loosens the effective timeout to infinite.
- Connection Javadoc updated to describe the "looser wins" contract in place of the old "relaxed value replaces configured value" wording.

## Testing
Adds `DefaultTimeoutSourceTest` covering the fusing matrix: no override, looser vs. tighter override, per-field fusing, infinite handling on both sides, memoization, recomputation after defaults change, and fallback on an invalid/closed override. Extends `AbstractRelaxedTimeoutBehaviorTest` with a finite blocking timeout in the default config and a case asserting a large configured timeout is not tightened by a smaller relaxed one across a maintenance event.

## Notes
- `pom.xml` widens the license-header include glob from `*TimeoutSource.java` to `*TimeoutSource*.java` so newly added timeout-source classes are covered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how effective SO_TIMEOUT is computed during maintenance events—affects connection reliability under failover—but behavior is narrowly scoped to loosen-only semantics with solid test coverage.
> 
> **Overview**
> **Maintenance relaxation** no longer replaces configured socket timeouts with the relaxed value. **`DefaultTimeoutSource`** now **fuses** configured and relaxed timeouts **per field** (`timeout` and `blockingTimeout`), keeping the **looser** of the two; **`0`** (infinite) wins over any finite value. That way a maintenance window cannot shorten a deadline that was already longer—or turn a finite configured timeout into a stricter one.
> 
> **`ChainedTimeoutSource`** exposes **`getOverrideInfo()`** so the terminal source can combine overrides with defaults instead of always preferring the override. Fused results are **memoized** on the hot read path.
> 
> **`Connection`** Javadoc is updated to describe this “looser wins” behavior for relaxed mode, blocking commands, and **`relaxTimeouts`**.
> 
> Tests add **`DefaultTimeoutSourceTest`** for the fusing matrix and extend **`AbstractRelaxedTimeoutBehaviorTest`** (finite blocking baseline, no tightening when configured timeout exceeds relaxed, infinite configured stays infinite). **`pom.xml`** widens the license-header glob to **`*TimeoutSource*.java`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e79a044272f13a48e72d7dc2cb8636e0881196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->