### PR TITLE
[maintenance events] Auto-resolve moving-endpoint-type from connection characteristics

### DIFF
--- a/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
@@ -67,7 +67,7 @@ public class MaintenanceAwareVisitor implements InitVisitor {
     relaxedTimeoutSource.addOverride(rebindTimeoutSource);
 
     connection.sendCommand(Command.CLIENT, "MAINT_NOTIFICATIONS", "ON", "moving-endpoint-type",
-      resolveEndpointType(maintenanceConfig.getEndpointType()));
+      resolveEndpointType(connection, maintenanceConfig));
     try {
       connection.getStatusCodeReply();
     } catch (JedisDataException e) {
@@ -84,7 +84,14 @@ public class MaintenanceAwareVisitor implements InitVisitor {
     }
   }
 
-  private String resolveEndpointType(MaintenanceNotificationsConfig.EndpointType endpointType) {
+  /** The {@code moving-endpoint-type} value for this connection. */
+  private String resolveEndpointType(Connection connection, MaintenanceNotificationsConfig config) {
+    // TLS as declared by the client config: enabled when either ssl(true) or sslOptions is set,
+    // mirroring DefaultJedisSocketFactory#createSocket.
+    JedisClientConfig clientConfig = builder.getClientConfig();
+    boolean sslEnabled = clientConfig.isSsl() || clientConfig.getSslOptions() != null;
+    MaintenanceNotificationsConfig.EndpointType endpointType = config.getEndpointTypeSource()
+        .getEndpointType(connection.getRemoteSocketAddress(), sslEnabled);
     switch (endpointType) {
       case INTERNAL_IP:
         return "internal-ip";

--- a/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
@@ -90,7 +90,7 @@ public class MaintenanceAwareVisitor implements InitVisitor {
     // mirroring DefaultJedisSocketFactory#createSocket.
     JedisClientConfig clientConfig = builder.getClientConfig();
     boolean sslEnabled = clientConfig.isSsl() || clientConfig.getSslOptions() != null;
-    MaintenanceNotificationsConfig.EndpointType endpointType = config.getEndpointTypeSource()
+    MaintenanceNotificationsConfig.EndpointType endpointType = config.getEndpointTypeResolver()
         .getEndpointType(connection.getRemoteSocketAddress(), sslEnabled);
     switch (endpointType) {
       case INTERNAL_IP:

--- a/src/main/java/redis/clients/jedis/MaintenanceNotificationsConfig.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceNotificationsConfig.java
@@ -1,8 +1,10 @@
 package redis.clients.jedis;
 
+import java.net.SocketAddress;
 import java.time.Duration;
 
 import redis.clients.jedis.util.JedisAsserts;
+import redis.clients.jedis.util.NetUtils;
 
 public class MaintenanceNotificationsConfig {
 
@@ -14,7 +16,7 @@ public class MaintenanceNotificationsConfig {
   public static final int DEFAULT_RELAXED_BLOCKING_SOCKET_TIMEOUT_MS = 0;
 
   private MaintenanceNotificationsConfig(Builder builder) {
-    this.endpointType = builder.endpointType;
+    this.endpointTypeSource = builder.endpointTypeSource;
     this.mode = builder.mode;
     this.relaxedWindowMaxDuration = builder.relaxedWindowMaxDuration;
     this.relaxedTimeout = builder.relaxedTimeout;
@@ -39,6 +41,65 @@ public class MaintenanceNotificationsConfig {
   }
 
   /**
+   * Strategy determining the {@link EndpointType} to request in MOVING notifications, evaluated per
+   * connection at handshake time.
+   * @since 8.0
+   */
+  public interface EndpointTypeSource {
+
+    /**
+     * Determines the endpoint type based on connection characteristics.
+     * @param remoteAddress the remote socket address of the connection
+     * @param sslEnabled whether TLS/SSL is enabled for the connection
+     * @return the {@link EndpointType} to request
+     */
+    EndpointType getEndpointType(SocketAddress remoteAddress, boolean sslEnabled);
+  }
+
+  /**
+   * Auto-resolves from connection characteristics: private remote IP (see
+   * {@link NetUtils#isPrivateIp}) selects {@code INTERNAL_*}, public {@code EXTERNAL_*}; TLS
+   * selects {@code *_FQDN}, plaintext {@code *_IP}.
+   */
+  private static final class AutoResolveEndpointTypeSource implements EndpointTypeSource {
+
+    static final AutoResolveEndpointTypeSource INSTANCE = new AutoResolveEndpointTypeSource();
+
+    @Override
+    public EndpointType getEndpointType(SocketAddress remoteAddress, boolean sslEnabled) {
+      if (NetUtils.isPrivateIp(remoteAddress)) {
+        return sslEnabled ? EndpointType.INTERNAL_FQDN : EndpointType.INTERNAL_IP;
+      }
+      return sslEnabled ? EndpointType.EXTERNAL_FQDN : EndpointType.EXTERNAL_IP;
+    }
+
+    @Override
+    public String toString() {
+      return "AutoResolveEndpointTypeSource";
+    }
+  }
+
+  /** Always requests the user-chosen endpoint type, ignoring connection characteristics. */
+  private static final class FixedEndpointTypeSource implements EndpointTypeSource {
+
+    private final EndpointType endpointType;
+
+    FixedEndpointTypeSource(EndpointType endpointType) {
+      this.endpointType = endpointType;
+    }
+
+    @Override
+    public EndpointType getEndpointType(SocketAddress remoteAddress, boolean sslEnabled) {
+      return endpointType;
+    }
+
+    @Override
+    public String toString() {
+      return "FixedEndpointTypeSource(" + endpointType + ")";
+    }
+  }
+
+  /**
    * Mode for maintenance event notifications.
    * <ul>
    * <li>ENABLED - Maintenance notifications are explicitly enabled. Both timeout relaxation and
@@ -53,14 +114,19 @@ public class MaintenanceNotificationsConfig {
     ENABLED, DISABLED, AUTO
   }
 
-  private final EndpointType endpointType;
+  private final EndpointTypeSource endpointTypeSource;
   private final Mode mode;
   private final Duration relaxedWindowMaxDuration;
   private final int relaxedTimeout;
   private final int relaxedBlockingTimeout;
 
-  public EndpointType getEndpointType() {
-    return endpointType;
+  /**
+   * The strategy that decides which endpoint type to request in MOVING notifications; defaults to
+   * auto-resolution from connection characteristics.
+   * @since 8.0
+   */
+  public EndpointTypeSource getEndpointTypeSource() {
+    return endpointTypeSource;
   }
 
   public Mode getMode() {
@@ -105,14 +171,32 @@ public class MaintenanceNotificationsConfig {
       .build();
 
   public static class Builder {
-    private EndpointType endpointType = EndpointType.EXTERNAL_IP;
+    private EndpointTypeSource endpointTypeSource = AutoResolveEndpointTypeSource.INSTANCE;
     private Mode mode = Mode.AUTO;
     private Duration relaxedWindowMaxDuration = DEFAULT_RELAXED_WINDOW_MAX_DURATION;
     private int relaxedTimeout = DEFAULT_RELAXED_SOCKET_TIMEOUT_MS;
     private int relaxedBlockingTimeout = DEFAULT_RELAXED_BLOCKING_SOCKET_TIMEOUT_MS;
 
+    /**
+     * Requests a fixed endpoint type for all MOVING notifications. Mutually exclusive with
+     * {@link #autoResolveEndpointType()}; the last call wins.
+     * @since 8.0
+     */
     public Builder endpointType(EndpointType endpointType) {
-      this.endpointType = endpointType;
+      JedisAsserts.notNull(endpointType, "endpointType must not be null");
+      this.endpointTypeSource = new FixedEndpointTypeSource(endpointType);
+      return this;
+    }
+
+    /**
+     * Requests the endpoint type resolved per connection from its characteristics: private remote
+     * IP selects {@code INTERNAL_*}, public {@code EXTERNAL_*}; TLS selects {@code *_FQDN},
+     * plaintext {@code *_IP}. This is the default. Mutually exclusive with
+     * {@link #endpointType(EndpointType)}; the last call wins.
+     * @since 8.0
+     */
+    public Builder autoResolveEndpointType() {
+      this.endpointTypeSource = AutoResolveEndpointTypeSource.INSTANCE;
       return this;
     }
 

--- a/src/main/java/redis/clients/jedis/MaintenanceNotificationsConfig.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceNotificationsConfig.java
@@ -16,7 +16,7 @@ public class MaintenanceNotificationsConfig {
   public static final int DEFAULT_RELAXED_BLOCKING_SOCKET_TIMEOUT_MS = 0;
 
   private MaintenanceNotificationsConfig(Builder builder) {
-    this.endpointTypeSource = builder.endpointTypeSource;
+    this.endpointTypeResolver = builder.endpointTypeResolver;
     this.mode = builder.mode;
     this.relaxedWindowMaxDuration = builder.relaxedWindowMaxDuration;
     this.relaxedTimeout = builder.relaxedTimeout;
@@ -45,7 +45,7 @@ public class MaintenanceNotificationsConfig {
    * connection at handshake time.
    * @since 8.0
    */
-  public interface EndpointTypeSource {
+  public interface EndpointTypeResolver {
 
     /**
      * Determines the endpoint type based on connection characteristics.
@@ -61,9 +61,9 @@ public class MaintenanceNotificationsConfig {
    * {@link NetUtils#isPrivateIp}) selects {@code INTERNAL_*}, public {@code EXTERNAL_*}; TLS
    * selects {@code *_FQDN}, plaintext {@code *_IP}.
    */
-  private static final class AutoResolveEndpointTypeSource implements EndpointTypeSource {
+  private static final class AutoEndpointTypeResolver implements EndpointTypeResolver {
 
-    static final AutoResolveEndpointTypeSource INSTANCE = new AutoResolveEndpointTypeSource();
+    static final AutoEndpointTypeResolver INSTANCE = new AutoEndpointTypeResolver();
 
     @Override
     public EndpointType getEndpointType(SocketAddress remoteAddress, boolean sslEnabled) {
@@ -75,16 +75,16 @@ public class MaintenanceNotificationsConfig {
 
     @Override
     public String toString() {
-      return "AutoResolveEndpointTypeSource";
+      return "AutoEndpointTypeResolver";
     }
   }
 
   /** Always requests the user-chosen endpoint type, ignoring connection characteristics. */
-  private static final class FixedEndpointTypeSource implements EndpointTypeSource {
+  private static final class FixedEndpointTypeResolver implements EndpointTypeResolver {
 
     private final EndpointType endpointType;
 
-    FixedEndpointTypeSource(EndpointType endpointType) {
+    FixedEndpointTypeResolver(EndpointType endpointType) {
       this.endpointType = endpointType;
     }
 
@@ -95,7 +95,7 @@ public class MaintenanceNotificationsConfig {
 
     @Override
     public String toString() {
-      return "FixedEndpointTypeSource(" + endpointType + ")";
+      return "FixedEndpointTypeResolver(" + endpointType + ")";
     }
   }
 
@@ -114,7 +114,7 @@ public class MaintenanceNotificationsConfig {
     ENABLED, DISABLED, AUTO
   }
 
-  private final EndpointTypeSource endpointTypeSource;
+  private final EndpointTypeResolver endpointTypeResolver;
   private final Mode mode;
   private final Duration relaxedWindowMaxDuration;
   private final int relaxedTimeout;
@@ -125,8 +125,8 @@ public class MaintenanceNotificationsConfig {
    * auto-resolution from connection characteristics.
    * @since 8.0
    */
-  public EndpointTypeSource getEndpointTypeSource() {
-    return endpointTypeSource;
+  public EndpointTypeResolver getEndpointTypeResolver() {
+    return endpointTypeResolver;
   }
 
   public Mode getMode() {
@@ -171,7 +171,7 @@ public class MaintenanceNotificationsConfig {
       .build();
 
   public static class Builder {
-    private EndpointTypeSource endpointTypeSource = AutoResolveEndpointTypeSource.INSTANCE;
+    private EndpointTypeResolver endpointTypeResolver = AutoEndpointTypeResolver.INSTANCE;
     private Mode mode = Mode.AUTO;
     private Duration relaxedWindowMaxDuration = DEFAULT_RELAXED_WINDOW_MAX_DURATION;
     private int relaxedTimeout = DEFAULT_RELAXED_SOCKET_TIMEOUT_MS;
@@ -184,7 +184,7 @@ public class MaintenanceNotificationsConfig {
      */
     public Builder endpointType(EndpointType endpointType) {
       JedisAsserts.notNull(endpointType, "endpointType must not be null");
-      this.endpointTypeSource = new FixedEndpointTypeSource(endpointType);
+      this.endpointTypeResolver = new FixedEndpointTypeResolver(endpointType);
       return this;
     }
 
@@ -196,7 +196,7 @@ public class MaintenanceNotificationsConfig {
      * @since 8.0
      */
     public Builder autoResolveEndpointType() {
-      this.endpointTypeSource = AutoResolveEndpointTypeSource.INSTANCE;
+      this.endpointTypeResolver = AutoEndpointTypeResolver.INSTANCE;
       return this;
     }
 

--- a/src/main/java/redis/clients/jedis/util/NetUtils.java
+++ b/src/main/java/redis/clients/jedis/util/NetUtils.java
@@ -1,0 +1,43 @@
+package redis.clients.jedis.util;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+public final class NetUtils {
+
+  private NetUtils() {
+    throw new InstantiationError("Must not instantiate this class");
+  }
+
+  /**
+   * Determine if the given {@link SocketAddress} represents a private IP address: loopback,
+   * link-local, site-local, or IPv6 unique-local.
+   * @param socketAddress the address to check
+   * @return {@code true} if the address is a resolved private IP address
+   * @since 8.0
+   */
+  public static boolean isPrivateIp(SocketAddress socketAddress) {
+    if (!(socketAddress instanceof InetSocketAddress)) {
+      return false;
+    }
+
+    InetAddress address = ((InetSocketAddress) socketAddress).getAddress();
+    if (address == null || address.isAnyLocalAddress()) {
+      return false;
+    }
+
+    return address.isLoopbackAddress() || address.isLinkLocalAddress()
+        || address.isSiteLocalAddress() || isUniqueLocalAddress(address);
+  }
+
+  // https://datatracker.ietf.org/doc/html/rfc4193
+  private static boolean isUniqueLocalAddress(InetAddress address) {
+    if (!(address instanceof Inet6Address)) {
+      return false;
+    }
+    byte[] bytes = address.getAddress();
+    return (bytes[0] & (byte) 0xfe) == (byte) 0xfc; // fc00::/7
+  }
+}

--- a/src/test/java/redis/clients/jedis/MaintenanceNotificationsConfigTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceNotificationsConfigTest.java
@@ -13,7 +13,7 @@ import java.net.SocketAddress;
 import java.time.Duration;
 
 import redis.clients.jedis.MaintenanceNotificationsConfig.EndpointType;
-import redis.clients.jedis.MaintenanceNotificationsConfig.EndpointTypeSource;
+import redis.clients.jedis.MaintenanceNotificationsConfig.EndpointTypeResolver;
 
 @Tag("unit")
 public class MaintenanceNotificationsConfigTest {
@@ -30,34 +30,34 @@ public class MaintenanceNotificationsConfigTest {
   }
 
   @Test
-  public void defaultSourceAutoResolvesFromConnectionCharacteristics() {
-    EndpointTypeSource source = MaintenanceNotificationsConfig.builder().build()
-        .getEndpointTypeSource();
+  public void defaultResolverAutoResolvesFromConnectionCharacteristics() {
+    EndpointTypeResolver resolver = MaintenanceNotificationsConfig.builder().build()
+        .getEndpointTypeResolver();
 
-    assertEquals(EndpointType.INTERNAL_IP, source.getEndpointType(PRIVATE_ADDR, false));
-    assertEquals(EndpointType.INTERNAL_FQDN, source.getEndpointType(PRIVATE_ADDR, true));
-    assertEquals(EndpointType.EXTERNAL_IP, source.getEndpointType(PUBLIC_ADDR, false));
-    assertEquals(EndpointType.EXTERNAL_FQDN, source.getEndpointType(PUBLIC_ADDR, true));
+    assertEquals(EndpointType.INTERNAL_IP, resolver.getEndpointType(PRIVATE_ADDR, false));
+    assertEquals(EndpointType.INTERNAL_FQDN, resolver.getEndpointType(PRIVATE_ADDR, true));
+    assertEquals(EndpointType.EXTERNAL_IP, resolver.getEndpointType(PUBLIC_ADDR, false));
+    assertEquals(EndpointType.EXTERNAL_FQDN, resolver.getEndpointType(PUBLIC_ADDR, true));
   }
 
   @Test
-  public void autoResolveEndpointTypeRestoresDefaultSource() {
-    EndpointTypeSource source = MaintenanceNotificationsConfig.builder()
+  public void autoResolveEndpointTypeRestoresDefaultResolver() {
+    EndpointTypeResolver resolver = MaintenanceNotificationsConfig.builder()
         .endpointType(EndpointType.EXTERNAL_FQDN).autoResolveEndpointType().build()
-        .getEndpointTypeSource();
+        .getEndpointTypeResolver();
 
-    assertEquals(EndpointType.INTERNAL_IP, source.getEndpointType(PRIVATE_ADDR, false));
-    assertEquals(EndpointType.EXTERNAL_FQDN, source.getEndpointType(PUBLIC_ADDR, true));
+    assertEquals(EndpointType.INTERNAL_IP, resolver.getEndpointType(PRIVATE_ADDR, false));
+    assertEquals(EndpointType.EXTERNAL_FQDN, resolver.getEndpointType(PUBLIC_ADDR, true));
   }
 
   @Test
   public void fixedEndpointTypeIgnoresConnectionCharacteristics() {
-    EndpointTypeSource source = MaintenanceNotificationsConfig.builder()
-        .endpointType(EndpointType.EXTERNAL_FQDN).build().getEndpointTypeSource();
+    EndpointTypeResolver resolver = MaintenanceNotificationsConfig.builder()
+        .endpointType(EndpointType.EXTERNAL_FQDN).build().getEndpointTypeResolver();
 
-    assertEquals(EndpointType.EXTERNAL_FQDN, source.getEndpointType(PRIVATE_ADDR, false));
-    assertEquals(EndpointType.EXTERNAL_FQDN, source.getEndpointType(PUBLIC_ADDR, true));
-    assertEquals(EndpointType.EXTERNAL_FQDN, source.getEndpointType(null, false));
+    assertEquals(EndpointType.EXTERNAL_FQDN, resolver.getEndpointType(PRIVATE_ADDR, false));
+    assertEquals(EndpointType.EXTERNAL_FQDN, resolver.getEndpointType(PUBLIC_ADDR, true));
+    assertEquals(EndpointType.EXTERNAL_FQDN, resolver.getEndpointType(null, false));
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/MaintenanceNotificationsConfigTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceNotificationsConfigTest.java
@@ -2,23 +2,68 @@ package redis.clients.jedis;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.time.Duration;
+
+import redis.clients.jedis.MaintenanceNotificationsConfig.EndpointType;
+import redis.clients.jedis.MaintenanceNotificationsConfig.EndpointTypeSource;
 
 @Tag("unit")
 public class MaintenanceNotificationsConfigTest {
+
+  private static final SocketAddress PRIVATE_ADDR = new InetSocketAddress("10.0.0.1", 6379);
+  private static final SocketAddress PUBLIC_ADDR = new InetSocketAddress("8.8.8.8", 6379);
 
   @Test
   public void builderDefaultsToAuto() {
     MaintenanceNotificationsConfig built = MaintenanceNotificationsConfig.builder().build();
     assertEquals(MaintenanceNotificationsConfig.Mode.AUTO, built.getMode());
-    assertEquals(MaintenanceNotificationsConfig.EndpointType.EXTERNAL_IP, built.getEndpointType());
     assertTrue(built.isEnabledOrAuto());
     assertEquals(Duration.ofSeconds(60), built.getRelaxedWindowMaxDuration());
+  }
+
+  @Test
+  public void defaultSourceAutoResolvesFromConnectionCharacteristics() {
+    EndpointTypeSource source = MaintenanceNotificationsConfig.builder().build()
+        .getEndpointTypeSource();
+
+    assertEquals(EndpointType.INTERNAL_IP, source.getEndpointType(PRIVATE_ADDR, false));
+    assertEquals(EndpointType.INTERNAL_FQDN, source.getEndpointType(PRIVATE_ADDR, true));
+    assertEquals(EndpointType.EXTERNAL_IP, source.getEndpointType(PUBLIC_ADDR, false));
+    assertEquals(EndpointType.EXTERNAL_FQDN, source.getEndpointType(PUBLIC_ADDR, true));
+  }
+
+  @Test
+  public void autoResolveEndpointTypeRestoresDefaultSource() {
+    EndpointTypeSource source = MaintenanceNotificationsConfig.builder()
+        .endpointType(EndpointType.EXTERNAL_FQDN).autoResolveEndpointType().build()
+        .getEndpointTypeSource();
+
+    assertEquals(EndpointType.INTERNAL_IP, source.getEndpointType(PRIVATE_ADDR, false));
+    assertEquals(EndpointType.EXTERNAL_FQDN, source.getEndpointType(PUBLIC_ADDR, true));
+  }
+
+  @Test
+  public void fixedEndpointTypeIgnoresConnectionCharacteristics() {
+    EndpointTypeSource source = MaintenanceNotificationsConfig.builder()
+        .endpointType(EndpointType.EXTERNAL_FQDN).build().getEndpointTypeSource();
+
+    assertEquals(EndpointType.EXTERNAL_FQDN, source.getEndpointType(PRIVATE_ADDR, false));
+    assertEquals(EndpointType.EXTERNAL_FQDN, source.getEndpointType(PUBLIC_ADDR, true));
+    assertEquals(EndpointType.EXTERNAL_FQDN, source.getEndpointType(null, false));
+  }
+
+  @Test
+  public void nullEndpointTypeRejected() {
+    assertThrows(IllegalArgumentException.class,
+      () -> MaintenanceNotificationsConfig.builder().endpointType(null));
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/sch/AbstractMaintenanceHandshakeTest.java
+++ b/src/test/java/redis/clients/jedis/sch/AbstractMaintenanceHandshakeTest.java
@@ -5,6 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -91,6 +95,69 @@ public abstract class AbstractMaintenanceHandshakeTest {
 
     HostAndPort hp = new HostAndPort("localhost", mockServer.getPort());
     assertThrows(JedisConnectionException.class, () -> buildConnection(hp, cfg, maint));
+  }
+
+  /**
+   * Captures each {@code CLIENT MAINT_NOTIFICATIONS} command as decoded tokens; replies stay on
+   * default handling ({@code +OK}).
+   */
+  private List<List<String>> captureMaintNotificationsCommands() {
+    List<List<String>> captured = new CopyOnWriteArrayList<>();
+    mockServer.setCommandHandler((args, clientId) -> {
+      List<String> tokens = new ArrayList<>();
+      args.forEach(arg -> tokens.add(SafeEncoder.encode(arg.getRaw())));
+      if (tokens.size() >= 2 && "CLIENT".equalsIgnoreCase(tokens.get(0))
+          && "MAINT_NOTIFICATIONS".equalsIgnoreCase(tokens.get(1))) {
+        captured.add(tokens);
+      }
+      return null;
+    });
+    return captured;
+  }
+
+  private MaintenanceNotificationsConfig.Builder enabledMaint() {
+    return MaintenanceNotificationsConfig.builder()
+        .mode(MaintenanceNotificationsConfig.Mode.ENABLED);
+  }
+
+  /**
+   * Default endpoint-type source auto-resolves per connection: the mock server peer is loopback
+   * (private) over plaintext, so the handshake must request {@code internal-ip}.
+   */
+  @Test
+  public void handshakeRequestsAutoResolvedEndpointType() {
+    List<List<String>> captured = captureMaintNotificationsCommands();
+
+    JedisClientConfig cfg = DefaultJedisClientConfig.builder().protocol(RedisProtocol.RESP3)
+        .build();
+    HostAndPort hp = new HostAndPort("localhost", mockServer.getPort());
+    try (Connection c = buildConnection(hp, cfg, enabledMaint().build())) {
+      assertTrue(c.ping());
+    }
+
+    assertEquals(1, captured.size());
+    assertEquals(
+      Arrays.asList("CLIENT", "MAINT_NOTIFICATIONS", "ON", "moving-endpoint-type", "internal-ip"),
+      captured.get(0));
+  }
+
+  /** A fixed endpoint type overrides auto-resolution regardless of connection characteristics. */
+  @Test
+  public void handshakeRequestsFixedEndpointType() {
+    List<List<String>> captured = captureMaintNotificationsCommands();
+
+    JedisClientConfig cfg = DefaultJedisClientConfig.builder().protocol(RedisProtocol.RESP3)
+        .build();
+    HostAndPort hp = new HostAndPort("localhost", mockServer.getPort());
+    try (Connection c = buildConnection(hp, cfg, enabledMaint()
+        .endpointType(MaintenanceNotificationsConfig.EndpointType.EXTERNAL_FQDN).build())) {
+      assertTrue(c.ping());
+    }
+
+    assertEquals(1, captured.size());
+    assertEquals(
+      Arrays.asList("CLIENT", "MAINT_NOTIFICATIONS", "ON", "moving-endpoint-type", "external-fqdn"),
+      captured.get(0));
   }
 
   /** {@code Mode.AUTO} with the server rejecting {@code CLIENT MAINT_NOTIFICATIONS}: succeeds. */

--- a/src/test/java/redis/clients/jedis/util/NetUtilsTest.java
+++ b/src/test/java/redis/clients/jedis/util/NetUtilsTest.java
@@ -1,0 +1,54 @@
+package redis.clients.jedis.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class NetUtilsTest {
+
+  private static SocketAddress addr(String host) {
+    return new InetSocketAddress(host, 6379);
+  }
+
+  @Test
+  public void privateIpv4RangesArePrivate() {
+    assertTrue(NetUtils.isPrivateIp(addr("10.0.0.1")));
+    assertTrue(NetUtils.isPrivateIp(addr("172.16.0.1")));
+    assertTrue(NetUtils.isPrivateIp(addr("192.168.1.1")));
+  }
+
+  @Test
+  public void loopbackAndLinkLocalArePrivate() {
+    assertTrue(NetUtils.isPrivateIp(addr("127.0.0.1")));
+    assertTrue(NetUtils.isPrivateIp(addr("169.254.0.1")));
+    assertTrue(NetUtils.isPrivateIp(addr("::1")));
+    assertTrue(NetUtils.isPrivateIp(addr("fe80::1")));
+  }
+
+  @Test
+  public void ipv6UniqueLocalIsPrivate() {
+    assertTrue(NetUtils.isPrivateIp(addr("fc00::1")));
+    assertTrue(NetUtils.isPrivateIp(addr("fd12:3456:789a::1")));
+  }
+
+  @Test
+  public void publicAddressesAreNotPrivate() {
+    assertFalse(NetUtils.isPrivateIp(addr("8.8.8.8")));
+    assertFalse(NetUtils.isPrivateIp(addr("2001:4860:4860::8888")));
+  }
+
+  @Test
+  public void wildcardUnresolvedAndNonInetAreNotPrivate() {
+    assertFalse(NetUtils.isPrivateIp(addr("0.0.0.0")));
+    assertFalse(NetUtils.isPrivateIp(InetSocketAddress.createUnresolved("intranet.local", 6379)));
+    assertFalse(NetUtils.isPrivateIp(null));
+    assertFalse(NetUtils.isPrivateIp(new SocketAddress() {
+    }));
+  }
+}


### PR DESCRIPTION
## What
Resolves the `moving-endpoint-type` requested in the `CLIENT MAINT_NOTIFICATIONS` handshake automatically from each connection's characteristics, instead of always sending a fixed configured value.

Closes [CAE-1560](https://redislabs.atlassian.net/browse/CAE-1560).

## Why
Previously, the handshake always requested the configured fixed endpoint type (default `external-ip`), which is incorrect for private networks and TLS connections. Per the SCH HLD (and matching Lettuce's implementation), the `default` should be resolved per connection: private peer IP selects `internal-*`, public `external-*`; TLS selects `*-fqdn`, plaintext `*-ip`.

## Changes
- `MaintenanceNotificationsConfig`: new `EndpointTypeSource` strategy interface evaluated per connection at handshake time; the builder default is now auto-resolution (`AutoResolveEndpointTypeSource`), with `endpointType(...)` installing a `FixedEndpointTypeSource` override and a new `autoResolveEndpointType()` restoring the default (mutually exclusive, last call wins). `getEndpointType()` replaced by `getEndpointTypeSource()` (unreleased 8.0 API).
- `MaintenanceAwareVisitor`: resolves the endpoint type per connection using the live remote address and the declared TLS setting (`isSsl()` or `sslOptions` set, mirroring `DefaultJedisSocketFactory`).
- `util/NetUtils` (new): `isPrivateIp` — loopback, link-local, site-local, IPv6 unique-local (`fc00::/7`).
- Tests: `NetUtilsTest`; resolution-matrix and builder tests in `MaintenanceNotificationsConfigTest`; wire-level handshake assertions in `AbstractMaintenanceHandshakeTest` (auto-resolved `internal-ip` on loopback, fixed `external-fqdn`) running through both `Connection` and `CacheConnection`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes unreleased 8.0 maintenance-notification config API and default handshake behavior during failover/rebind; wrong classification could yield incorrect MOVING endpoints, though fixed `endpointType` preserves prior behavior.
> 
> **Overview**
> The `CLIENT MAINT_NOTIFICATIONS` handshake no longer always sends a single configured `moving-endpoint-type` (previously default **`external-ip`**). **`MaintenanceNotificationsConfig`** now holds an **`EndpointTypeResolver`** evaluated at handshake time: the default **auto-resolves** from the connection’s remote address (private vs public via new **`NetUtils.isPrivateIp`**) and whether TLS is enabled on the client config; **`endpointType(...)`** still forces a fixed type, and **`autoResolveEndpointType()`** restores auto mode (last builder call wins). **`getEndpointType()`** is replaced by **`getEndpointTypeResolver()`** (8.0 API).
> 
> **`MaintenanceAwareVisitor`** picks the wire value per connection using the live remote socket address and SSL flags aligned with **`DefaultJedisSocketFactory`**. Tests cover resolver matrices, **`NetUtils`**, and captured handshake commands (e.g. loopback → **`internal-ip`**, fixed override → **`external-fqdn`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b202204402e63a3fdd1aa70affea7ceb13606fb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[CAE-1560]: https://redislabs.atlassian.net/browse/CAE-1560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ