### PR TITLE
Backport #4601 to 7.5.x: fix ConcurrentModificationException in AuthXManager token renewal

### DIFF
--- a/src/main/java/redis/clients/jedis/authentication/AuthXManager.java
+++ b/src/main/java/redis/clients/jedis/authentication/AuthXManager.java
@@ -3,6 +3,7 @@ package redis.clients.jedis.authentication;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -25,13 +26,13 @@ public final class AuthXManager implements Supplier<RedisCredentials> {
 
     private static final Logger log = LoggerFactory.getLogger(AuthXManager.class);
 
-    private TokenManager tokenManager;
-    private List<WeakReference<Connection>> connections = Collections
+    private final TokenManager tokenManager;
+    private final List<WeakReference<Connection>> connections = Collections
             .synchronizedList(new ArrayList<>());
     private Token currentToken;
     private AuthXEventListener listener = AuthXEventListener.NOOP_LISTENER;
-    private List<Consumer<Token>> postAuthenticateHooks = new ArrayList<>();
-    private AtomicReference<CompletableFuture<Void>> uniqueStarterTask = new AtomicReference<>();
+    private final List<Consumer<Token>> postAuthenticateHooks = new ArrayList<>();
+    private final AtomicReference<CompletableFuture<Void>> uniqueStarterTask = new AtomicReference<>();
 
     protected AuthXManager(TokenManager tokenManager) {
         this.tokenManager = tokenManager;
@@ -82,12 +83,15 @@ public final class AuthXManager implements Supplier<RedisCredentials> {
 
     public void authenticateConnections(Token token) {
         RedisCredentials credentialsFromToken = new TokenCredentials(token);
-        for (WeakReference<Connection> connectionRef : connections) {
-            Connection connection = connectionRef.get();
-            if (connection != null) {
-                connection.setCredentials(credentialsFromToken);
-            } else {
-                connections.remove(connectionRef);
+        synchronized (connections) {
+            Iterator<WeakReference<Connection>> iterator = connections.iterator();
+            while (iterator.hasNext()) {
+                Connection connection = iterator.next().get();
+                if (connection != null) {
+                    connection.setCredentials(credentialsFromToken);
+                } else {
+                    iterator.remove();
+                }
             }
         }
         postAuthenticateHooks.forEach(hook -> hook.accept(token));

--- a/src/test/java/redis/clients/jedis/authentication/TokenBasedAuthenticationUnitTests.java
+++ b/src/test/java/redis/clients/jedis/authentication/TokenBasedAuthenticationUnitTests.java
@@ -11,7 +11,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
+import java.lang.ref.WeakReference;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -32,9 +34,12 @@ import redis.clients.authentication.core.TokenListener;
 import redis.clients.authentication.core.TokenManager;
 import redis.clients.authentication.core.TokenManagerConfig;
 import redis.clients.authentication.core.TokenManagerConfig.RetryPolicy;
+import redis.clients.jedis.Connection;
 import redis.clients.jedis.ConnectionPool;
 import redis.clients.jedis.EndpointConfig;
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.RedisCredentials;
+import redis.clients.jedis.util.ReflectionTestUtil;
 
 public class TokenBasedAuthenticationUnitTests {
 
@@ -248,7 +253,8 @@ public class TokenBasedAuthenticationUnitTests {
         new TokenManagerConfig(0.7F, 200, 2000, new TokenManagerConfig.RetryPolicy(5, 100)));
 
     AuthXManager manager = new AuthXManager(tokenManager);
-    JedisAuthenticationException e = assertThrows(JedisAuthenticationException.class, manager::start);
+    JedisAuthenticationException e = assertThrows(JedisAuthenticationException.class,
+      manager::start);
 
     assertEquals(exceptionMessage, e.getCause().getCause().getMessage());
   }
@@ -270,7 +276,8 @@ public class TokenBasedAuthenticationUnitTests {
         new TokenManagerConfig(0.7F, 200, 1000, new TokenManagerConfig.RetryPolicy(2, 100)));
 
     AuthXManager manager = new AuthXManager(tokenManager);
-    JedisAuthenticationException e = assertThrows(JedisAuthenticationException.class, manager::start);
+    JedisAuthenticationException e = assertThrows(JedisAuthenticationException.class,
+      manager::start);
 
     latch.countDown();
     assertEquals(exceptionMessage, e.getMessage());
@@ -352,5 +359,32 @@ public class TokenBasedAuthenticationUnitTests {
     } finally {
       manager.stop();
     }
+  }
+
+  @Test
+  public void authenticateConnectionsPrunesClearedReferences() {
+    AuthXManager manager = new AuthXManager(mock(TokenManager.class));
+
+    Connection live1 = mock(Connection.class);
+    Connection live2 = mock(Connection.class);
+
+    // A pooled connection that has been garbage collected leaves behind a cleared
+    // WeakReference. Seed one ahead of the live connections so pruning happens mid-walk.
+    List<WeakReference<Connection>> connections = ReflectionTestUtil.getField(manager,
+      "connections");
+    connections.add(new WeakReference<>(null));
+    manager.addConnection(live1);
+    manager.addConnection(live2);
+
+    Token token = new SimpleToken("user1", "tokenVal", System.currentTimeMillis() + 5 * 1000,
+        System.currentTimeMillis(), Collections.singletonMap("oid", "user1"));
+
+    manager.authenticateConnections(token);
+
+    assertEquals(2, connections.size());
+    ArgumentCaptor<RedisCredentials> credentials = ArgumentCaptor.forClass(RedisCredentials.class);
+    verify(live1).setCredentials(credentials.capture());
+    verify(live2).setCredentials(credentials.capture());
+    credentials.getAllValues().forEach(c -> assertEquals("user1", c.getUser()));
   }
 }


### PR DESCRIPTION
Backport of #4601 (fixes #4606) to 7.5.x.

`AuthXManager.authenticateConnections` iterated a `Collections.synchronizedList` while removing cleared `WeakReference` entries in place, throwing `ConcurrentModificationException` and leaving remaining connections without renewed credentials. The loop now runs under `synchronized (connections)` and prunes via `Iterator.remove()`.

Clean cherry-pick of 2a70b9cb2, no conflicts. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches token credential propagation on live connections; the change is small and regression-tested but auth renewal paths are operationally sensitive.
> 
> **Overview**
> Fixes **`ConcurrentModificationException`** during token renewal in **`AuthXManager.authenticateConnections`**, which could abort renewal and leave some pooled connections without updated credentials.
> 
> The connection list walk now runs inside **`synchronized (connections)`** and drops cleared **`WeakReference`** entries with **`Iterator.remove()`** instead of removing from the list while iterating. Several manager fields are marked **`final`**.
> 
> Adds **`authenticateConnectionsPrunesClearedReferences`** to confirm stale references are pruned and live connections still receive credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a28839be0da228aa3e2df930e1494b147844018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->