### PR TITLE
Fix flaky scanType test assuming SCAN page boundaries

### DIFF
--- a/src/test/java/redis/clients/jedis/commands/jedis/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/AllKindOfValuesCommandsTest.java
@@ -881,14 +881,17 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
     jedis.set("e", "e");
     jedis.zadd("f", 0d, "f");
     jedis.set("g", "g");
-
-    binaryResult = jedis.scan(SCAN_POINTER_START_BINARY, pagingParams, string);
-    assertFalse(binaryResult.isCompleteIteration());
-    int page1Count = binaryResult.getResult().size();
-    binaryResult = jedis.scan(binaryResult.getCursorAsBytes(), pagingParams, string);
-    assertTrue(binaryResult.isCompleteIteration());
-    int page2Count = binaryResult.getResult().size();
-    assertEquals(4, page1Count + page2Count);
+    
+    Set<byte[]> binaryStringKeys = new HashSet<>();
+    byte[] binaryCursor = SCAN_POINTER_START_BINARY;
+    do {
+      binaryResult = jedis.scan(binaryCursor, pagingParams, string);
+      binaryStringKeys.addAll(binaryResult.getResult());
+      binaryCursor = binaryResult.getCursorAsBytes();
+    } while (!binaryResult.isCompleteIteration());
+    Set<byte[]> expectedBinaryStringKeys = new HashSet<>(Arrays.asList(
+        "a".getBytes(), "c".getBytes(), "e".getBytes(), "g".getBytes()));
+    AssertUtil.assertByteArraySetEquals(expectedBinaryStringKeys, binaryStringKeys);
 
     binaryResult = jedis.scan(SCAN_POINTER_START_BINARY, noParams, hash);
     AssertUtil.assertByteArrayListEquals(Collections.singletonList(new byte[]{98}), binaryResult.getResult());


### PR DESCRIPTION
## What
Fixes a sporadic failure in the legacy `AllKindOfValuesCommandsTest.scanType` by removing assertions on SCAN page boundaries.

## Why
The binary section asserted that `SCAN 0 COUNT 4 TYPE string` over 7 keys cannot complete in one page (`assertFalse(isCompleteIteration())`). `COUNT` is only a hint: whether one call traverses the whole dict depends on how the keys distribute across hash buckets, which varies with the per-server random SipHash seed — so the test failed sporadically:

```
org.opentest4j.AssertionFailedError: expected: <false> but was: <true>
    at ...AllKindOfValuesCommandsTest.scanType(AllKindOfValuesCommandsTest.java:886)
```

The unified variant (`commands/unified/AllKindOfValuesCommandsTestBase#scanType`) was already fixed with a cursor loop; the legacy copy was left behind.

## Changes
- Replaced the two-page assertions (`assertFalse`/`assertTrue` on `isCompleteIteration()`, page-count sum) with a cursor loop that iterates until completion and asserts on the collected key set, mirroring `AllKindOfValuesCommandsTestBase#scanType` verbatim.

Note: `scanIsCompleteIteration` also asserts `assertFalse(isCompleteIteration())` on a first page, but over 100 keys with default COUNT — a documented, practically safe assumption (see the comment/link in the test) — and is left unchanged.

Verified against a local Redis: the class passes in all parameterized variants (162 tests, 0 failures).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production code or runtime behavior affected.
> 
> **Overview**
> Fixes sporadic failures in **`AllKindOfValuesCommandsTest.scanType`** for the binary `TYPE string` path by **stopping assumptions about how many SCAN pages** `COUNT 4` needs.
> 
> The test no longer asserts that the first `SCAN` call is incomplete, that the second completes, or that page sizes sum to four keys. It now **loops the cursor until iteration completes**, aggregates keys, and asserts the set equals `{a, c, e, g}`—matching the pattern already used in the unified **`AllKindOfValuesCommandsTestBase#scanType`** and the string-key section of the same test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5060767d9b833f550b922b2f37fb0f22b23c1e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->