### PR TITLE
[maintenance events] Support 'none' moving-endpoint-type (CAE-1559)

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -172,7 +172,9 @@ public class Connection implements Closeable {
   private Set<InitVisitor> initVisitors = new HashSet<>();
 
   private static final long EXPIRE_NOT_SET = -1;
-  private long expireAt = EXPIRE_NOT_SET;
+  /** Reconnect-deadline sentinel: always expired without a clock read (MOVING receiver discard). */
+  static final long EXPIRED = 0;
+  private volatile long expireAt = EXPIRE_NOT_SET;
 
   /** Listeners notified synchronously of this connection's maintenance events (pool-injected). */
   private final Set<MaintenanceEventListener> maintenanceEventListeners =  ConcurrentHashMap.newKeySet();
@@ -547,12 +549,15 @@ public class Connection implements Closeable {
     }
   }
 
-  private boolean isExpired() {
-    if ( expireAt == EXPIRE_NOT_SET) {
-      return  false;
+  boolean isExpired() {
+    long at = expireAt;
+    if (at == EXPIRE_NOT_SET) {
+      return false;
     }
-
-    return expireAt <= NanoClock.INSTANCE.getAsLong();
+    if (at == EXPIRED) {
+      return true;
+    }
+    return at <= NanoClock.INSTANCE.getAsLong();
   }
 
   /**

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -172,9 +172,9 @@ public class Connection implements Closeable {
   private Set<InitVisitor> initVisitors = new HashSet<>();
 
   private static final long EXPIRE_NOT_SET = -1;
-  /** Reconnect-deadline sentinel: always expired without a clock read (MOVING receiver discard). */
-  static final long EXPIRED = 0;
   private volatile long expireAt = EXPIRE_NOT_SET;
+    /** Birth instant; connections created after a MOVING's reconnect deadline are its own reconnects. */
+  private final long createdAtNanos = NanoClock.INSTANCE.getAsLong();
 
   /** Listeners notified synchronously of this connection's maintenance events (pool-injected). */
   private final Set<MaintenanceEventListener> maintenanceEventListeners =  ConcurrentHashMap.newKeySet();
@@ -553,9 +553,6 @@ public class Connection implements Closeable {
     long at = expireAt;
     if (at == EXPIRE_NOT_SET) {
       return false;
-    }
-    if (at == EXPIRED) {
-      return true;
     }
     return at <= NanoClock.INSTANCE.getAsLong();
   }
@@ -1075,6 +1072,10 @@ public class Connection implements Closeable {
 
   void expireAt(long expireAt) {
     this.expireAt = expireAt;
+  }
+
+  long createdAtNanos() {
+    return createdAtNanos;
   }
 
   void enableTimeoutRelaxing(ExpiringTimeoutSource relaxedTimeout) {

--- a/src/main/java/redis/clients/jedis/ConnectionFactory.java
+++ b/src/main/java/redis/clients/jedis/ConnectionFactory.java
@@ -187,7 +187,9 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
 
   @Override
   public void activateObject(PooledObject<Connection> pooledConnection) throws Exception {
-    // what to do ??
+    // Deliberately no expiry check: a connection past its maintenance reconnect deadline is still
+    // usable, so borrowed work always gets to run. Expiry is enforced on return to the pool and,
+    // for users who opt into testOnBorrow/testWhileIdle, by validateObject.
   }
 
   @Override
@@ -228,8 +230,13 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
       if (!jedis.isConnected()) {
         return false;
       }
+      if (jedis.isExpired()) {
+        return false; // past its maintenance reconnect deadline -> recycle
+      }
       reAuthenticate(jedis);
-      return jedis.ping();
+      // Re-check expiry after the ping: its read may consume a buffered MOVING push (the server
+      // sends one right after the maintenance subscription +OK) that stamps this connection.
+      return jedis.ping() && !jedis.isExpired();
     } catch (final Exception e) {
       logger.warn("Error while validating pooled Connection object.", e);
       return false;

--- a/src/main/java/redis/clients/jedis/ConnectionPool.java
+++ b/src/main/java/redis/clients/jedis/ConnectionPool.java
@@ -85,7 +85,9 @@ public class ConnectionPool extends Pool<Connection> {
       setEvictionPolicy(new RebindAwareEvictionPolicy(controller, getEvictionPolicy()));
       controller.addHandoffHook(handoff -> evictQuietly());
       returnHook = c -> {
-        if (controller.isAffected(c)) {
+        // Stamp affected peers with the reconnect deadline; drop only once past it (target MOVING
+        // stamps EXPIRED -> dropped now; 'none' within its window -> kept).
+        if (controller.stampExpiryIfAffected(c) && c.isExpired()) {
           super.returnBrokenResource(c);
         } else {
           super.returnResource(c);

--- a/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
@@ -94,6 +94,8 @@ public class MaintenanceAwareVisitor implements InitVisitor {
         return "external-ip";
       case EXTERNAL_FQDN:
         return "external-fqdn";
+      case NONE:
+        return "none";
       default:
         throw new JedisException("Unknown endpoint type: " + endpointType);
     }

--- a/src/main/java/redis/clients/jedis/MaintenanceEvent.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEvent.java
@@ -16,11 +16,15 @@ abstract class MaintenanceEvent {
 }
 
 /**
- * {@code [MOVING, seq, time_s, host:port]} — endpoint moves to {@code target} within
- * {@code ttlSeconds}.
+ * {@code [MOVING, seq, time_s, host:port | null]} — endpoint moves to {@code target} within
+ * {@code ttlSeconds}. A {@code null} target is the {@code none} endpoint type: no remap; reconnect
+ * to the configured endpoint.
  */
 final class MovingEvent extends MaintenanceEvent {
   final long ttlSeconds;
+  /**
+   * New endpoint, or {@code null} for the {@code none} type (reconnect to the configured endpoint).
+   */
   final HostAndPort target;
 
   MovingEvent(long seq, long ttlSeconds, HostAndPort target) {

--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -62,8 +63,10 @@ final class MaintenanceEventController implements MaintenanceEventListener, Sock
   }
 
   /**
-   * Registers a hook invoked synchronously, once, when a MOVING handoff is applied (i.e. a real new
-   * target is committed under the seq guard). Hook exceptions propagate.
+   * Registers a hook invoked synchronously, once per MOVING committed under the seq guard —
+   * including a {@code none} (null-target) MOVING: the pool's hook runs an eviction pass that
+   * stamps idle affected connections with the reconnect deadline (and evicts only those already
+   * past it). Hook exceptions propagate.
    */
   public void addHandoffHook(Consumer<MaintenanceHandoff> hook) {
     handoffHooks.add(hook);
@@ -89,6 +92,20 @@ final class MaintenanceEventController implements MaintenanceEventListener, Sock
     return rebind.isValid() && rebind.affected.contains(c.getRemoteSocketAddress());
   }
 
+  /**
+   * If {@code c}'s peer is in the active rebind, stamp its reconnect deadline and report affected.
+   * Callers (pool return-hook, eviction policy) then discard {@code c} iff
+   * {@link Connection#isExpired()}.
+   */
+  boolean stampExpiryIfAffected(Connection c) {
+    RebindState st = rebind;
+    if (st.isValid() && st.affected.contains(c.getRemoteSocketAddress())) {
+      c.expireAt(st.expireAtNanos);
+      return true;
+    }
+    return false;
+  }
+
   /** True iff there is an active MOVING rebind window in the pool right now. */
   public boolean isRebindActive() {
     return rebind.isValid();
@@ -97,47 +114,41 @@ final class MaintenanceEventController implements MaintenanceEventListener, Sock
   @Override
   public void onMoving(MovingEvent e, Connection c) {
     logger.debug("Moving to {} (seq={}, ttl={}s)", e.target, e.seq, e.ttlSeconds);
-    // Cap the server-supplied ttl at the user-configured backstop so a generous or misbehaving
-    // server can't pin the pool in relaxed mode beyond {@code relaxedTimeoutMaxDuration}.
-    long ttlNanos = Math.min(TimeUnit.SECONDS.toNanos(e.ttlSeconds), maxRelaxedDurationNanos);
-    // Any MOVING affects the receiver: mark for discard and relax commands on it before return.
-    // QUESTION : are we relying on each in-use connection that connected to a rebinding endpoint
-    // will receive a MOVING and then eventually will be marked for discard? If so, we
-    // may want to consider a more aggressive approach to mark connections that are connected to
-    // the rebinding endpoint for discard.
-
-    // UPDATE: we have two different spots that causes connection to be dropped. One is setting
-    // expireAt for connections that received MOVING event, and the other is when a connection is
-    // returned to the pool, we check if it is connected to a rebinding endpoint(isAffected) and if
-    // so, we drop it. So we are covering for both cases.
-
-    // IMPORTANT: in case we like to delay the expiration since NONE as new target may be sent,
-    // dropping the connections immediately just by relying isAffected would be an issue, and cause
-    // immediate drops while it is not supposed to be.
-
     long now = NanoClock.INSTANCE.getAsLong();
-    long deadline = now + ttlNanos;
-    // HERE! we can control if an immediate gracefull drop needed,, or we need to delay in case
-    // MOVING msg suggests a future renewal.
-    c.expireAt(now);
+    // Relax window: cap the server ttl at the configured backstop so a generous or misbehaving
+    // server can't pin the pool in relaxed mode beyond relaxedWindowMaxDuration.
+    long relaxDeadline = now
+        + Math.min(TimeUnit.SECONDS.toNanos(e.ttlSeconds), maxRelaxedDurationNanos);
+    // Reconnect deadline, independent of the relax window: 'none' reconnects to the configured
+    // endpoint at half the raw grace; a real target discards receivers immediately.
+    long expireAt = e.target == null ? now + TimeUnit.SECONDS.toNanos(e.ttlSeconds) / 2
+        : Connection.EXPIRED;
+    // Every receiver gets its deadline up front, before any seq gating — this also covers a
+    // buffered, already-superseded MOVING read late by an idle connection (safety net) and the
+    // no-peer early return below.
+    c.expireAt(expireAt);
+
     SocketAddress affectedPeer = c.getRemoteSocketAddress();
     if (affectedPeer == null) {
       return; // receiver socket already closed; no peer to register
     }
-    SocketAddress target = new InetSocketAddress(e.target.getHost(), e.target.getPort());
+    SocketAddress target = e.target == null ? null
+        : new InetSocketAddress(e.target.getHost(), e.target.getPort());
 
     while (true) {
       RebindState cur = rebind;
       if (e.seq < cur.seq) {
-        return; // older event
+        return; // older event; receiver already stamped up front
       }
       if (e.seq == cur.seq) {
-        // Same handoff event from another affected connection: merge its peer into the set.
-        if (!target.equals(cur.target)) {
+        if (!Objects.equals(target, cur.target)) {
           logger.warn("Ignoring MOVING with conflicting target for seq {}: have {}, got {}", e.seq,
             cur.target, target);
           return;
         }
+        // Same handoff from another affected connection: align to the shared deadline committed by
+        // the first notification of this seq.
+        c.expireAt(cur.expireAtNanos);
         if (cur.affected.contains(affectedPeer)) {
           return; // already merged
         }
@@ -152,8 +163,7 @@ final class MaintenanceEventController implements MaintenanceEventListener, Sock
       }
       // New seq (or first ever): replace state with a fresh single-source set.
       RebindState next = new RebindState(e.seq, Collections.singleton(affectedPeer), target,
-          deadline);
-
+          relaxDeadline, expireAt);
       if (REBIND.compareAndSet(this, cur, next)) {
         logger.debug("Rebinding {} -> {} (seq={}, ttl={}s)", affectedPeer, target, e.seq,
           e.ttlSeconds);
@@ -218,7 +228,10 @@ final class MaintenanceEventController implements MaintenanceEventListener, Sock
       return seq;
     }
 
-    /** The new endpoint connections will be routed to during the handoff window. */
+    /**
+     * The new endpoint connections will be routed to during the handoff window, or {@code null} for
+     * a {@code none} MOVING (no remap; reconnect to the configured endpoint).
+     */
     public HostAndPort getTarget() {
       return target;
     }
@@ -242,26 +255,31 @@ final class MaintenanceEventController implements MaintenanceEventListener, Sock
    */
   private static final class RebindState {
 
-    static final RebindState EXPIRED_STATE = new RebindState(-1, Collections.emptySet(), null, 0L);
+    static final RebindState EXPIRED_STATE = new RebindState(-1, Collections.emptySet(), null, 0L,
+        Connection.EXPIRED);
     final long seq;
     final Set<SocketAddress> affected;
     final SocketAddress target;
-    final long deadlineNanos;
+    final long deadlineNanos; // relax-window end; gates isValid()/remap
+    final long expireAtNanos; // shared per-connection reconnect deadline (EXPIRED |
+                              // now+ttl/2)
     volatile boolean expired = false;
 
     private RebindState(long seq, Set<SocketAddress> affected, SocketAddress target,
-        long deadlineNanos) {
+        long deadlineNanos, long expireAtNanos) {
       this.seq = seq;
       this.affected = affected;
       this.target = target;
       this.deadlineNanos = deadlineNanos;
+      this.expireAtNanos = expireAtNanos;
     }
 
     private RebindState merge(SocketAddress peer) {
       Set<SocketAddress> merged = new HashSet<>(affected.size() + 1, 1.0f);
       merged.addAll(affected);
       merged.add(peer);
-      return new RebindState(seq, Collections.unmodifiableSet(merged), target, deadlineNanos);
+      return new RebindState(seq, Collections.unmodifiableSet(merged), target, deadlineNanos,
+          expireAtNanos);
     }
 
     private boolean isValid() {

--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -93,13 +93,17 @@ final class MaintenanceEventController implements MaintenanceEventListener, Sock
   }
 
   /**
-   * If {@code c}'s peer is in the active rebind, stamp its reconnect deadline and report affected.
+   * If {@code c} is in the active rebind's scope — its peer is an affected source AND it was
+   * created before the rebind's reconnect deadline — stamp its deadline and report affected.
    * Callers (pool return-hook, eviction policy) then discard {@code c} iff
-   * {@link Connection#isExpired()}.
+   * {@link Connection#isExpired()}. Connections created after the deadline are the rebind's own
+   * reconnects: with a null target they re-land on the same peer, and stamping them with the (past)
+   * shared deadline would churn them on every return.
    */
   boolean stampExpiryIfAffected(Connection c) {
     RebindState st = rebind;
-    if (st.isValid() && st.affected.contains(c.getRemoteSocketAddress())) {
+    if (st.isValid() && c.createdAtNanos() <= st.expireAtNanos
+        && st.affected.contains(c.getRemoteSocketAddress())) {
       c.expireAt(st.expireAtNanos);
       return true;
     }
@@ -120,13 +124,10 @@ final class MaintenanceEventController implements MaintenanceEventListener, Sock
     long relaxDeadline = now
         + Math.min(TimeUnit.SECONDS.toNanos(e.ttlSeconds), maxRelaxedDurationNanos);
     // Reconnect deadline, independent of the relax window: 'none' reconnects to the configured
-    // endpoint at half the raw grace; a real target discards receivers immediately.
-    long expireAt = e.target == null ? now + TimeUnit.SECONDS.toNanos(e.ttlSeconds) / 2
-        : Connection.EXPIRED;
-    // Every receiver gets its deadline up front, before any seq gating — this also covers a
-    // buffered, already-superseded MOVING read late by an idle connection (safety net) and the
-    // no-peer early return below.
-    c.expireAt(expireAt);
+    // endpoint at half the raw grace; a real target discards receivers immediately (deadline is
+    // the commit instant itself). A real timestamp in both cases — it doubles as the rebind's
+    // scope bound: connections created after it are the rebind's own reconnects, never stamped.
+    long expireAt = e.target == null ? now + TimeUnit.SECONDS.toNanos(e.ttlSeconds) / 2 : now;
 
     SocketAddress affectedPeer = c.getRemoteSocketAddress();
     if (affectedPeer == null) {
@@ -138,7 +139,9 @@ final class MaintenanceEventController implements MaintenanceEventListener, Sock
     while (true) {
       RebindState cur = rebind;
       if (e.seq < cur.seq) {
-        return; // older event; receiver already stamped up front
+        // Stale replay of a superseded event: no stamp. Stragglers are covered by the gated
+        // return-hook (if still in the current rebind's scope) and by the remote close at time_s.
+        return;
       }
       if (e.seq == cur.seq) {
         if (!Objects.equals(target, cur.target)) {
@@ -146,9 +149,13 @@ final class MaintenanceEventController implements MaintenanceEventListener, Sock
             cur.target, target);
           return;
         }
-        // Same handoff from another affected connection: align to the shared deadline committed by
-        // the first notification of this seq.
-        c.expireAt(cur.expireAtNanos);
+        // Same handoff from another affected connection: align to the shared deadline committed
+        // by the first notification — but only for connections that predate it. A connection
+        // created after the deadline is this rebind's own reconnect, re-notified because it
+        // re-landed on the still-moving node; stamping it would churn every replacement.
+        if (c.createdAtNanos() <= cur.expireAtNanos) {
+          c.expireAt(cur.expireAtNanos);
+        }
         if (cur.affected.contains(affectedPeer)) {
           return; // already merged
         }
@@ -167,6 +174,7 @@ final class MaintenanceEventController implements MaintenanceEventListener, Sock
       if (REBIND.compareAndSet(this, cur, next)) {
         logger.debug("Rebinding {} -> {} (seq={}, ttl={}s)", affectedPeer, target, e.seq,
           e.ttlSeconds);
+        c.expireAt(expireAt); // the receiver predates the commit it just created
         fireHandoffHook(e);
         return;
       }
@@ -256,13 +264,13 @@ final class MaintenanceEventController implements MaintenanceEventListener, Sock
   private static final class RebindState {
 
     static final RebindState EXPIRED_STATE = new RebindState(-1, Collections.emptySet(), null, 0L,
-        Connection.EXPIRED);
+        0L);
     final long seq;
     final Set<SocketAddress> affected;
     final SocketAddress target;
     final long deadlineNanos; // relax-window end; gates isValid()/remap
-    final long expireAtNanos; // shared per-connection reconnect deadline (EXPIRED |
-                              // now+ttl/2)
+    final long expireAtNanos; // shared reconnect deadline (commit instant | commit+ttl/2) and the
+                              // rebind's scope bound: later-created connections are its reconnects
     volatile boolean expired = false;
 
     private RebindState(long seq, Set<SocketAddress> affected, SocketAddress target,

--- a/src/main/java/redis/clients/jedis/MaintenanceNotificationsConfig.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceNotificationsConfig.java
@@ -35,7 +35,13 @@ public class MaintenanceNotificationsConfig {
     /** External IP address (for public network connections) */
     EXTERNAL_IP,
     /** External fully qualified domain name (for public network connections with TLS) */
-    EXTERNAL_FQDN
+    EXTERNAL_FQDN,
+    /**
+     * No endpoint: MOVING carries a null target. The client does not remap; it reconnects to the
+     * currently-configured endpoint at half the grace period.
+     * @since 8.0
+     */
+    NONE
   }
 
   /**

--- a/src/main/java/redis/clients/jedis/MaintenancePushCodec.java
+++ b/src/main/java/redis/clients/jedis/MaintenancePushCodec.java
@@ -57,19 +57,22 @@ final class MaintenancePushCodec {
   /**
    * Builds the domain event for an already-resolved push type.
    * @throws MalformedMaintenanceEventException if the frame's fields are malformed (missing or
-   *           wrong-typed seq/time/shards, or a MOVING with an absent or unparseable target)
+   *           wrong-typed seq/time/shards, or a MOVING with a missing or unparseable target — a
+   *           null target is valid and denotes the {@code none} endpoint type)
    */
   static MaintenanceEvent build(PushType type, PushMessage msg) {
     return type.decoder.apply(msg.getContent());
   }
 
-  private static MaintenanceEvent moving(List<Object> c) { // [MOVING, seq, time_s, host:port]
-    if (c.size() < 3 || !(c.get(1) instanceof Long) || !(c.get(2) instanceof Long)) {
+  private static MaintenanceEvent moving(List<Object> c) { // [MOVING, seq, time_s, host:port |
+                                                           // null]
+    if (c.size() < 4 || !(c.get(1) instanceof Long) || !(c.get(2) instanceof Long)) {
       throw malformed("MOVING", c);
     }
-    // TODO: once explicit 'none' target support lands, build a MovingEvent with a null target for
-    // that case instead of treating an absent target as malformed.
-    return new MovingEvent((Long) c.get(1), (Long) c.get(2), parseHostPort(c, 3));
+    // Explicit RESP3 null target => 'none' endpoint type (no remap). A byte[] target is parsed;
+    // anything else (wrong type, unparseable) is malformed.
+    HostAndPort target = c.get(3) == null ? null : parseHostPort(c, 3);
+    return new MovingEvent((Long) c.get(1), (Long) c.get(2), target);
   }
 
   private static MaintenanceEvent migrating(List<Object> c) { // [MIGRATING, seq, time_s, shards]

--- a/src/main/java/redis/clients/jedis/RebindAwareEvictionPolicy.java
+++ b/src/main/java/redis/clients/jedis/RebindAwareEvictionPolicy.java
@@ -8,9 +8,11 @@ import org.apache.commons.pool2.impl.EvictionConfig;
 import org.apache.commons.pool2.impl.EvictionPolicy;
 
 /**
- * commons-pool2 eviction policy that destroys idle connections whose peer matches the active MOVING
- * rebind's affected node; all other connections are deferred to the wrapped delegate (typically the
- * user's configured policy, defaulting to {@link DefaultEvictionPolicy}).
+ * commons-pool2 eviction policy for idle connections whose peer matches the active MOVING rebind:
+ * it stamps the reconnect deadline and evicts once the connection is past it (immediately for a
+ * real target, at half the grace for {@code none}). All other connections are deferred to the
+ * wrapped delegate (typically the user's configured policy, defaulting to
+ * {@link DefaultEvictionPolicy}).
  */
 final class RebindAwareEvictionPolicy implements EvictionPolicy<Connection> {
 
@@ -25,8 +27,9 @@ final class RebindAwareEvictionPolicy implements EvictionPolicy<Connection> {
 
   @Override
   public boolean evict(EvictionConfig config, PooledObject<Connection> underTest, int idleCount) {
-    if (controller.isAffected(underTest.getObject())) {
-      return true;
+    Connection conn = underTest.getObject();
+    if (controller.stampExpiryIfAffected(conn)) {
+      return conn.isExpired();
     }
     return delegate.evict(config, underTest, idleCount);
   }

--- a/src/test/java/redis/clients/jedis/ConnectionPoolExpiryMockTest.java
+++ b/src/test/java/redis/clients/jedis/ConnectionPoolExpiryMockTest.java
@@ -1,0 +1,254 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.util.SafeEncoder;
+import redis.clients.jedis.util.server.RespResponse;
+import redis.clients.jedis.util.server.TcpMockServer;
+
+/**
+ * Expiry (maintenance reconnect deadline) enforcement in the pool lifecycle: expired connections
+ * are still handed out on borrow (an expired deadline is a recycle hint, not a health signal) and
+ * destroyed on return; {@link ConnectionFactory#validateObject} reports them invalid so the
+ * standard {@code testOnBorrow}/{@code testWhileIdle} knobs opt into stricter cleanup.
+ */
+@Tag("sch")
+public class ConnectionPoolExpiryMockTest {
+
+  private TcpMockServer mockServer;
+  private HostAndPort mockAddress;
+  private JedisClientConfig clientConfig;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    mockServer = new TcpMockServer();
+    mockServer.start();
+    mockAddress = new HostAndPort("127.0.0.1", mockServer.getPort());
+    clientConfig = DefaultJedisClientConfig.builder().socketTimeoutMillis(5000)
+        .protocol(RedisProtocol.RESP3).build();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    mockServer.stop();
+  }
+
+  // --- factory hooks as units ---
+
+  @Test
+  public void activateObject_passesEvenWhenExpired() {
+    ConnectionFactory factory = new ConnectionFactory(mockAddress, clientConfig);
+    Connection conn = new Connection(mockAddress);
+    conn.expireAt(Connection.EXPIRED);
+    // Availability decision: expired connections are still usable and must reach borrowed work.
+    assertDoesNotThrow(() -> factory.activateObject(pooled(conn)));
+  }
+
+  @Test
+  public void validateObject_failsForExpiredConnection() throws Exception {
+    ConnectionFactory factory = new ConnectionFactory(mockAddress, clientConfig);
+    PooledObject<Connection> pooled = factory.makeObject();
+    try {
+      pooled.getObject().expireAt(Connection.EXPIRED);
+      assertFalse(factory.validateObject(pooled));
+    } finally {
+      factory.destroyObject(pooled);
+    }
+  }
+
+  @Test
+  public void validateObject_passesForFutureOrNoDeadline() throws Exception {
+    ConnectionFactory factory = new ConnectionFactory(mockAddress, clientConfig);
+    PooledObject<Connection> pooled = factory.makeObject();
+    try {
+      assertTrue(factory.validateObject(pooled)); // EXPIRE_NOT_SET
+      pooled.getObject().expireAt(NanoClock.INSTANCE.getAsLong() + TimeUnit.HOURS.toNanos(1));
+      assertTrue(factory.validateObject(pooled));
+    } finally {
+      factory.destroyObject(pooled);
+    }
+  }
+
+  // --- default borrow path: availability first ---
+
+  @Test
+  public void expiredIdleIsServedThenDestroyedOnReturn() {
+    ConnectionPoolConfig poolConfig = new ConnectionPoolConfig();
+    poolConfig.setMaxTotal(1);
+
+    try (ConnectionPool pool = new ConnectionPool(mockAddress, clientConfig, poolConfig)) {
+      Connection first = pool.getResource();
+      first.close(); // healthy return -> idle
+      first.expireAt(Connection.EXPIRED); // expires while idle
+
+      Connection second = pool.getResource();
+      assertSame(first, second, "expired idle is still handed out");
+      assertTrue(second.ping(), "borrowed work runs on the expired connection");
+
+      second.close(); // return: Connection.close routes expired -> returnBrokenResource
+      assertEquals(1, pool.getDestroyedCount(), "expired connection destroyed on return");
+      // (invalidateObject may pre-create a replacement idle; no assertion on getNumIdle here)
+
+      Connection third = pool.getResource();
+      assertNotSame(second, third);
+      assertFalse(third.isExpired());
+      third.close();
+    }
+  }
+
+  // --- opt-in strictness via the standard validation knobs ---
+
+  @Test
+  public void testOnBorrow_replacesExpiredIdleWithinOneBorrow() {
+    ConnectionPoolConfig poolConfig = new ConnectionPoolConfig();
+    poolConfig.setMaxTotal(1);
+    poolConfig.setTestOnBorrow(true);
+
+    try (ConnectionPool pool = new ConnectionPool(mockAddress, clientConfig, poolConfig)) {
+      Connection first = pool.getResource();
+      first.close();
+      first.expireAt(Connection.EXPIRED);
+
+      Connection second = pool.getResource(); // validate fails -> destroy -> fresh, one call
+      assertNotSame(first, second, "testOnBorrow never hands out an expired connection");
+      assertFalse(second.isExpired());
+      assertEquals(1, pool.getDestroyedCount());
+      second.close();
+    }
+  }
+
+  @Test
+  public void evictorReapsExpiredIdleViaValidation() throws Exception {
+    ConnectionPoolConfig poolConfig = new ConnectionPoolConfig(); // testWhileIdle=true default
+    poolConfig.setMaxTotal(1);
+
+    try (ConnectionPool pool = new ConnectionPool(mockAddress, clientConfig, poolConfig)) {
+      Connection conn = pool.getResource();
+      conn.close();
+      conn.expireAt(Connection.EXPIRED);
+      assertEquals(1, pool.getNumIdle());
+
+      pool.evict(); // one synchronous pass: testWhileIdle -> validateObject false -> destroy
+      assertEquals(1, pool.getDestroyedCount(), "expired idle reaped by idle validation");
+      assertEquals(0, pool.getNumIdle());
+    }
+  }
+
+  // --- baseline envelope: remote drop of an idle connection (no maintenance involved) ---
+
+  @Test
+  public void remoteDropOfIdleConnectionSurfacesOnFirstUseByDefault() {
+    ConnectionPoolConfig poolConfig = new ConnectionPoolConfig(); // testOnBorrow=false default
+    poolConfig.setMaxTotal(1);
+
+    try (ConnectionPool pool = new ConnectionPool(mockAddress, clientConfig, poolConfig)) {
+      Connection idle = pool.getResource();
+      idle.close(); // healthy return -> idle
+
+      // Remote peer drops the pooled idle; a peer close is invisible locally (isConnected() stays
+      // true in CLOSE_WAIT), so only I/O can detect it.
+      mockServer.disconnectAllClients();
+
+      Connection borrowed = pool.getResource();
+      assertSame(idle, borrowed, "dead idle is handed out without borrow-time validation");
+      assertThrows(JedisConnectionException.class, borrowed::ping,
+        "first use surfaces the dead connection");
+
+      borrowed.close(); // broken -> destroyed on return
+      assertEquals(1, pool.getDestroyedCount());
+
+      Connection fresh = pool.getResource(); // listener still up: pool recovers
+      assertTrue(fresh.ping());
+      fresh.close();
+    }
+  }
+
+  /**
+   * Real server behavior during an active maintenance window: the MOVING push follows the +OK of
+   * CLIENT MAINT_NOTIFICATIONS ON, so every new connection is stamped from its own push stream
+   * (consumed by the first read after the handshake) rather than by any factory-level marking.
+   */
+  private void injectMovingOnNewConnection() {
+    String target = "127.0.0.1:" + mockServer.getPort(); // remap-neutral: the mock itself
+    String okThenMoving = "+OK\r\n" + RespResponse.push(Arrays.asList("MOVING", 1, 30, target));
+    mockServer.setCommandHandler((args, clientId) -> {
+      if (args.size() < 2) return null;
+      String cmd = SafeEncoder.encode(args.getCommand().getRaw()).toUpperCase();
+      String sub = SafeEncoder.encode(args.get(1).getRaw()).toUpperCase();
+      return "CLIENT".equals(cmd) && "MAINT_NOTIFICATIONS".equals(sub) ? okThenMoving : null;
+    });
+  }
+
+  @Test
+  public void movingOnNewConnectionIsServedThenRecycledByDefault() {
+    injectMovingOnNewConnection();
+
+    MaintenanceNotificationsConfig maintConfig = MaintenanceNotificationsConfig.builder()
+        .mode(MaintenanceNotificationsConfig.Mode.ENABLED).build();
+    ConnectionPoolConfig poolConfig = new ConnectionPoolConfig(); // testOnBorrow=false default
+    poolConfig.setMaxTotal(1);
+
+    try (ConnectionPool pool = new ConnectionPool(
+        ConnectionFactory.builder().hostAndPort(mockAddress).clientConfig(clientConfig), poolConfig,
+        maintConfig)) {
+      // Default settings: no borrow-time validation, so the connection is handed out; its first
+      // read consumes the MOVING and stamps it for recycle.
+      Connection conn = pool.getResource();
+      assertTrue(conn.ping(), "borrowed work runs");
+      assertTrue(conn.isExpired(), "the ping consumed the MOVING push and stamped the connection");
+
+      conn.close();
+      assertEquals(1, pool.getDestroyedCount(), "stamped connection recycled on first return");
+
+      Connection next = pool.getResource(); // pool stays functional
+      assertTrue(next.ping());
+      next.close();
+    }
+  }
+
+  @Test
+  @Timeout(10)
+  public void movingOnNewConnectionFailsFastUnderTestOnBorrow() {
+    injectMovingOnNewConnection();
+
+    MaintenanceNotificationsConfig maintConfig = MaintenanceNotificationsConfig.builder()
+        .mode(MaintenanceNotificationsConfig.Mode.ENABLED).build();
+    ConnectionPoolConfig poolConfig = new ConnectionPoolConfig();
+    poolConfig.setMaxTotal(1);
+    poolConfig.setTestOnBorrow(true);
+
+    try (ConnectionPool pool = new ConnectionPool(
+        ConnectionFactory.builder().hostAndPort(mockAddress).clientConfig(clientConfig), poolConfig,
+        maintConfig)) {
+      // Strict validation must not hand out a connection stamped during its own validation ping.
+      // Failed validation of a freshly created object surfaces as the pool's own borrow failure
+      // (NoSuchElementException wrapped by Pool.getResource) - it must not spin creating forever.
+      assertThrows(JedisException.class, pool::getResource);
+      assertTrue(pool.getDestroyedCount() >= 1, "the rejected fresh connection is destroyed");
+    }
+  }
+
+  private static PooledObject<Connection> pooled(Connection conn) {
+    return new DefaultPooledObject<>(conn);
+  }
+}

--- a/src/test/java/redis/clients/jedis/ConnectionPoolExpiryMockTest.java
+++ b/src/test/java/redis/clients/jedis/ConnectionPoolExpiryMockTest.java
@@ -59,7 +59,7 @@ public class ConnectionPoolExpiryMockTest {
   public void activateObject_passesEvenWhenExpired() {
     ConnectionFactory factory = new ConnectionFactory(mockAddress, clientConfig);
     Connection conn = new Connection(mockAddress);
-    conn.expireAt(Connection.EXPIRED);
+    conn.expireAt(NanoClock.INSTANCE.getAsLong()); // deadline == now -> expired on next check
     // Availability decision: expired connections are still usable and must reach borrowed work.
     assertDoesNotThrow(() -> factory.activateObject(pooled(conn)));
   }
@@ -69,7 +69,7 @@ public class ConnectionPoolExpiryMockTest {
     ConnectionFactory factory = new ConnectionFactory(mockAddress, clientConfig);
     PooledObject<Connection> pooled = factory.makeObject();
     try {
-      pooled.getObject().expireAt(Connection.EXPIRED);
+      pooled.getObject().expireAt(NanoClock.INSTANCE.getAsLong());
       assertFalse(factory.validateObject(pooled));
     } finally {
       factory.destroyObject(pooled);
@@ -99,7 +99,7 @@ public class ConnectionPoolExpiryMockTest {
     try (ConnectionPool pool = new ConnectionPool(mockAddress, clientConfig, poolConfig)) {
       Connection first = pool.getResource();
       first.close(); // healthy return -> idle
-      first.expireAt(Connection.EXPIRED); // expires while idle
+      first.expireAt(NanoClock.INSTANCE.getAsLong()); // expires while idle
 
       Connection second = pool.getResource();
       assertSame(first, second, "expired idle is still handed out");
@@ -127,7 +127,7 @@ public class ConnectionPoolExpiryMockTest {
     try (ConnectionPool pool = new ConnectionPool(mockAddress, clientConfig, poolConfig)) {
       Connection first = pool.getResource();
       first.close();
-      first.expireAt(Connection.EXPIRED);
+      first.expireAt(NanoClock.INSTANCE.getAsLong());
 
       Connection second = pool.getResource(); // validate fails -> destroy -> fresh, one call
       assertNotSame(first, second, "testOnBorrow never hands out an expired connection");
@@ -145,7 +145,7 @@ public class ConnectionPoolExpiryMockTest {
     try (ConnectionPool pool = new ConnectionPool(mockAddress, clientConfig, poolConfig)) {
       Connection conn = pool.getResource();
       conn.close();
-      conn.expireAt(Connection.EXPIRED);
+      conn.expireAt(NanoClock.INSTANCE.getAsLong()); // deadline == now -> expired on next check
       assertEquals(1, pool.getNumIdle());
 
       pool.evict(); // one synchronous pass: testWhileIdle -> validateObject false -> destroy
@@ -220,9 +220,13 @@ public class ConnectionPoolExpiryMockTest {
       conn.close();
       assertEquals(1, pool.getDestroyedCount(), "stamped connection recycled on first return");
 
-      Connection next = pool.getResource(); // pool stays functional
-      assertTrue(next.ping());
+      // The replacement is re-notified with the same-seq MOVING but postdates the reconnect
+      // deadline: it is this rebind's own reconnect and must not be stamped (churn guard).
+      Connection next = pool.getResource();
+      assertTrue(next.ping()); // consumes its own re-notification
+      assertFalse(next.isExpired(), "replacement is immune to the same-seq re-notification");
       next.close();
+      assertEquals(1, pool.getDestroyedCount(), "recycled once, then immune");
     }
   }
 

--- a/src/test/java/redis/clients/jedis/MaintenanceEventControllerTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceEventControllerTest.java
@@ -280,6 +280,58 @@ public class MaintenanceEventControllerTest {
   }
 
   @Test
+  public void stampExpiryIfAffected_skipsConnectionsCreatedAfterDeadline() throws Exception {
+    movingNone(1L, 10); // committed at now=0, reconnect deadline 5s
+    advanceSeconds(6); // past the deadline; relax window (10s) still open
+    // The reconnect re-lands on the same peer; stamping it with the past shared deadline would
+    // churn it on every return for the rest of the relax window.
+    Connection reconnect = new Connection(new HostAndPort("127.0.0.1", mockServer.getPort()));
+    reconnect.connect();
+    try {
+      assertFalse(controller.stampExpiryIfAffected(reconnect),
+        "a connection created after the deadline is this rebind's own reconnect - never stamped");
+      assertFalse(reconnect.isExpired());
+      assertTrue(controller.stampExpiryIfAffected(receiver),
+        "pre-existing connection is still stamped");
+    } finally {
+      reconnect.close();
+    }
+  }
+
+  @Test
+  public void sameSeqRenotificationAfterDeadline_doesNotStamp() throws Exception {
+    movingNone(1L, 10); // reconnect deadline 5s
+    advanceSeconds(6);
+    // The moving node re-notifies every new connection (push follows the subscription +OK); a
+    // reconnect that re-landed on it receives the same-seq MOVING and must not inherit the past
+    // shared deadline.
+    Connection reconnect = new Connection(new HostAndPort("127.0.0.1", mockServer.getPort()));
+    reconnect.connect();
+    try {
+      controller.onMoving(new MovingEvent(1L, 10, null), reconnect);
+      assertFalse(reconnect.isExpired(), "re-notified reconnect is outside the rebind's scope");
+    } finally {
+      reconnect.close();
+    }
+  }
+
+  @Test
+  public void sameSeqNotificationBeforeDeadline_alignsToSharedDeadline() throws Exception {
+    movingNone(1L, 10); // reconnect deadline 5s
+    advanceSeconds(2); // first half: newcomers sit on the dying node and must participate
+    Connection newcomer = new Connection(new HostAndPort("127.0.0.1", mockServer.getPort()));
+    newcomer.connect();
+    try {
+      controller.onMoving(new MovingEvent(1L, 10, null), newcomer);
+      assertFalse(newcomer.isExpired(), "aligned to the shared deadline, which is still ahead");
+      advanceSeconds(4); // now=6s, past the shared 5s deadline (not the newcomer's own 2+5)
+      assertTrue(newcomer.isExpired(), "stamped with the FIRST notification's deadline");
+    } finally {
+      newcomer.close();
+    }
+  }
+
+  @Test
   public void stampExpiryIfAffected_onlyWithinWindow() {
     assertFalse(controller.stampExpiryIfAffected(receiver), "no rebind yet");
     movingNone(1L, 10);

--- a/src/test/java/redis/clients/jedis/MaintenanceEventControllerTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceEventControllerTest.java
@@ -190,6 +190,104 @@ public class MaintenanceEventControllerTest {
       "newer event after expiry applies again");
   }
 
+  // --- 'none' endpoint type (null target): lazy reconnect via per-connection deadline ---
+
+  private void movingNone(long seq, long ttlSeconds) {
+    controller.onMoving(new MovingEvent(seq, ttlSeconds, null), receiver);
+  }
+
+  @Test
+  public void target_stampsReceiverExpiredImmediately() {
+    moving(1L, TARGET_B, 100);
+    assertTrue(receiver.isExpired(),
+      "a real-target MOVING marks the receiver for immediate discard");
+  }
+
+  @Test
+  public void noneTarget_doesNotRemap() {
+    movingNone(1L, 10);
+    assertNull(controller.getSocketAddress(receiverPeer), "'none' MOVING never remaps");
+    assertTrue(controller.isAffected(receiver),
+      "receiver is still affected (relaxed) during the window");
+  }
+
+  @Test
+  public void noneTarget_reconnectsAtHalfGrace() {
+    movingNone(1L, 10); // reconnect deadline = now + ttl/2 = 5s
+    advanceSeconds(4);
+    assertFalse(receiver.isExpired(), "before half-grace: reconnect not yet due");
+    advanceSeconds(2); // total 6s > 5s
+    assertTrue(receiver.isExpired(), "past half-grace: reconnect due");
+  }
+
+  @Test
+  public void noneTarget_firesHandoffHookWithNullTarget() {
+    AtomicReference<MaintenanceHandoff> seen = new AtomicReference<>();
+    controller.addHandoffHook(seen::set);
+    movingNone(1L, 10);
+    // The hook drives the pool's eviction pass, which stamps idle affected connections with the
+    // reconnect deadline (evicting only those already past it).
+    assertNotNull(seen.get(), "'none' fires the handoff hook too");
+    assertNull(seen.get().getTarget(), "'none' handoff carries a null target");
+  }
+
+  @Test
+  public void olderSeqNone_stillStampsReceiver() {
+    moving(5L, TARGET_B, 100); // current state at seq 5
+    // A buffered older 'none' MOVING (seq 3) read late by this receiver: superseded (no state
+    // change) but the receiver must still get a reconnect deadline.
+    controller.onMoving(new MovingEvent(3L, 10, null), receiver);
+    assertEquals(TARGET_B_ADDR, controller.getSocketAddress(receiverPeer),
+      "state unchanged by older event");
+    advanceSeconds(6); // > ttl/2 (5s) of the older event
+    assertTrue(receiver.isExpired(), "older-seq receiver still marked for reconnect");
+  }
+
+  @Test
+  public void sameSeqNone_sharesFirstNotificationDeadline() {
+    movingNone(1L, 10); // deadline = 5s (now=0)
+    advanceSeconds(3); // now = 3s
+    controller.onMoving(new MovingEvent(1L, 10, null), receiver); // same seq, later now
+    advanceSeconds(2); // now = 5s == first deadline
+    assertTrue(receiver.isExpired(),
+      "same-seq reporter inherits the FIRST notification's deadline (5s), not 3+5=8s");
+  }
+
+  @Test
+  public void newerTarget_supersedesNoneDeadline() {
+    movingNone(1L, 100); // reconnect deadline = now + 50s
+    assertFalse(receiver.isExpired(), "'none' deadline is in the future");
+    moving(2L, TARGET_B, 100); // newer target seq: discard now
+    assertTrue(receiver.isExpired(), "newer target overwrites the future 'none' deadline");
+  }
+
+  @Test
+  public void stampExpiryIfAffected_overwritesStaleNoneDeadline() throws Exception {
+    movingNone(1L, 100); // receiver deadline = now + 50s
+    // Newer target MOVING delivered on a sibling connection to the same endpoint (same peer).
+    Connection sibling = new Connection(new HostAndPort("127.0.0.1", mockServer.getPort()));
+    sibling.connect();
+    try {
+      controller.onMoving(new MovingEvent(2L, 100, TARGET_B), sibling);
+      assertFalse(receiver.isExpired(), "receiver still holds the stale future 'none' deadline");
+      assertTrue(controller.stampExpiryIfAffected(receiver),
+        "receiver's peer is covered by the newer state");
+      assertTrue(receiver.isExpired(),
+        "stale 'none' deadline overwritten to immediate discard (last-writer-wins)");
+    } finally {
+      sibling.close();
+    }
+  }
+
+  @Test
+  public void stampExpiryIfAffected_onlyWithinWindow() {
+    assertFalse(controller.stampExpiryIfAffected(receiver), "no rebind yet");
+    movingNone(1L, 10);
+    assertTrue(controller.stampExpiryIfAffected(receiver));
+    advanceSeconds(11); // relax window (min(10,60)=10s) closed
+    assertFalse(controller.stampExpiryIfAffected(receiver), "not stamped after the window closes");
+  }
+
   // --- Handoff hooks ---
 
   @Test

--- a/src/test/java/redis/clients/jedis/MaintenancePushCodecTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenancePushCodecTest.java
@@ -58,6 +58,15 @@ public class MaintenancePushCodecTest {
   }
 
   @Test
+  public void buildMovingNoneTarget() { // null endpoint => 'none' type, no remap
+    MovingEvent m = assertInstanceOf(MovingEvent.class,
+      build(PushType.MOVING, push(type("MOVING"), 30L, 15L, null)));
+    assertEquals(30L, m.seq);
+    assertEquals(15L, m.ttlSeconds);
+    assertNull(m.target);
+  }
+
+  @Test
   public void buildMigrating() {
     MigratingEvent e = assertInstanceOf(MigratingEvent.class,
       build(PushType.MIGRATING, push(type("MIGRATING"), 6L, 2L, SHARDS)));

--- a/src/test/java/redis/clients/jedis/sch/AbstractRebindBehaviorTest.java
+++ b/src/test/java/redis/clients/jedis/sch/AbstractRebindBehaviorTest.java
@@ -235,6 +235,68 @@ public abstract class AbstractRebindBehaviorTest {
   }
 
   @Test
+  public void testNoneMovingKeepsConnectionDuringGraceWindow() {
+    ConnectionPoolConfig poolConfig = new ConnectionPoolConfig();
+    poolConfig.setMaxTotal(1);
+
+    try (
+        UnifiedJedis client = createClient(server1Address, clientConfig, maintConfig, poolConfig)) {
+      Pool<Connection> pool = poolOf(client);
+
+      Connection activeConnection = pool.getResource();
+      assertEquals(1, mockServer1.getConnectedClientCount());
+
+      // 'none' endpoint type: null target, 60s grace -> reconnect deadline 30s (far future).
+      mockServer1.sendPushMessageToAll("MOVING", 30, 60, null);
+
+      // Reads the push; unlike a target MOVING, the connection survives return and re-borrow.
+      assertTrue(activeConnection.ping());
+      activeConnection.close();
+      assertEquals(0, pool.getDestroyedCount(), "'none' must not discard within the grace window");
+      assertEquals(1, pool.getNumIdle());
+
+      assertEquals("PONG", client.ping());
+      assertEquals(0, pool.getDestroyedCount());
+      assertEquals(1, mockServer1.getConnectedClientCount(),
+        "no remap: still on the original endpoint");
+      assertEquals(0, mockServer2.getConnectedClientCount());
+    }
+  }
+
+  @Test
+  public void testNoneMovingReconnectsAfterHalfGrace() {
+    ConnectionPoolConfig poolConfig = new ConnectionPoolConfig();
+    poolConfig.setMaxTotal(1);
+
+    try (
+        UnifiedJedis client = createClient(server1Address, clientConfig, maintConfig, poolConfig)) {
+      Pool<Connection> pool = poolOf(client);
+
+      assertEquals("PONG", client.ping());
+      assertEquals(1, mockServer1.getConnectedClientCount());
+
+      // 'none' with a 2s grace -> reconnect deadline 1s after receipt.
+      mockServer1.sendPushMessageToAll("MOVING", 30, 2, null);
+      assertEquals("PONG", client.ping()); // reads the push, stamps the deadline; still usable
+      assertEquals(0, pool.getDestroyedCount());
+
+      // Past the half-grace deadline the borrow gate discards the idle connection and a fresh one
+      // is created against the CONFIGURED endpoint (no remap). The mock cannot repoint DNS, so the
+      // replacement re-lands on the same affected peer and is re-stamped on return until the relax
+      // window closes — assert >= 1 here; the churn-guard follow-up tightens this to exactly 1.
+      await().atMost(Duration.ofSeconds(4)).pollInterval(Duration.ofMillis(100))
+          .untilAsserted(() -> {
+            assertEquals("PONG", client.ping());
+            assertTrue(pool.getDestroyedCount() >= 1,
+              "expired connection replaced on borrow after half the grace period");
+            assertEquals(1, mockServer1.getConnectedClientCount(),
+              "reconnect targets the configured endpoint");
+            assertEquals(0, mockServer2.getConnectedClientCount());
+          });
+    }
+  }
+
+  @Test
   public void testRebindRevertsToOriginalEndpointAfterTtl() {
     ConnectionPoolConfig poolConfig = new ConnectionPoolConfig();
     poolConfig.setMaxTotal(1);

--- a/src/test/java/redis/clients/jedis/sch/AbstractRebindBehaviorTest.java
+++ b/src/test/java/redis/clients/jedis/sch/AbstractRebindBehaviorTest.java
@@ -280,15 +280,15 @@ public abstract class AbstractRebindBehaviorTest {
       assertEquals("PONG", client.ping()); // reads the push, stamps the deadline; still usable
       assertEquals(0, pool.getDestroyedCount());
 
-      // Past the half-grace deadline the borrow gate discards the idle connection and a fresh one
-      // is created against the CONFIGURED endpoint (no remap). The mock cannot repoint DNS, so the
-      // replacement re-lands on the same affected peer and is re-stamped on return until the relax
-      // window closes — assert >= 1 here; the churn-guard follow-up tightens this to exactly 1.
+      // Past the half-grace deadline the stale connection is dropped on return and replaced
+      // against the CONFIGURED endpoint (no remap). Exactly one replacement: the mock cannot
+      // repoint DNS, so the fresh connection re-lands on the same affected peer — but it
+      // postdates the reconnect deadline, so it is never re-stamped (churn guard).
       await().atMost(Duration.ofSeconds(4)).pollInterval(Duration.ofMillis(100))
           .untilAsserted(() -> {
             assertEquals("PONG", client.ping());
-            assertTrue(pool.getDestroyedCount() >= 1,
-              "expired connection replaced on borrow after half the grace period");
+            assertEquals(1, pool.getDestroyedCount(),
+              "expired connection replaced exactly once after half the grace period");
             assertEquals(1, mockServer1.getConnectedClientCount(),
               "reconnect targets the configured endpoint");
             assertEquals(0, mockServer2.getConnectedClientCount());

--- a/src/test/java/redis/clients/jedis/util/server/RespResponse.java
+++ b/src/test/java/redis/clients/jedis/util/server/RespResponse.java
@@ -65,6 +65,7 @@ public class RespResponse {
    * Create an array response. Supports mixed data types. Not all RESP data types are supported.
    * Only the following are supported: Each element is automatically encoded based on its type:
    * <ul>
+   * <li>null → RESP3 null (_\r\n)</li>
    * <li>Integer → RESP integer (:123\r\n)</li>
    * <li>Long → RESP integer (:123\r\n)</li>
    * <li>String → RESP bulk string ($3\r\nabc\r\n)</li>
@@ -118,7 +119,9 @@ public class RespResponse {
    * @return RESP-encoded string
    */
   private static String encodeElement(Object element) {
-    if (element instanceof Integer) {
+    if (element == null) {
+      return "_\r\n"; // RESP3 null
+    } else if (element instanceof Integer) {
       return integer((Integer) element);
     } else if (element instanceof Long) {
       return integer((Long) element);

--- a/src/test/java/redis/clients/jedis/util/server/TcpMockServer.java
+++ b/src/test/java/redis/clients/jedis/util/server/TcpMockServer.java
@@ -205,6 +205,14 @@ public class TcpMockServer {
   }
 
   /**
+   * Server-side drop of all connected clients while the listener stays up: simulates the remote
+   * peer closing pooled connections (e.g. a server-side idle timeout or node restart).
+   */
+  public void disconnectAllClients() {
+    closeAllActiveConnections();
+  }
+
+  /**
    * Close all active client connections
    */
   private void closeAllActiveConnections() {


### PR DESCRIPTION
Adds the `none` value for `moving-endpoint-type` (CAE-1559).

With `EndpointType.NONE` the client sends `CLIENT MAINT_NOTIFICATIONS ON moving-endpoint-type none`, and the server's MOVING carries a RESP3 null endpoint. On such a MOVING the client performs no handoff: connections keep serving the current endpoint with relaxed timeouts and reconnect to the configured endpoint after half the grace period (`time_s/2`), giving DNS time to repoint.

### Behavior
- `MaintenancePushCodec` decodes an explicit RESP3 null MOVING target as a null-target `MovingEvent` (previously collapsed into malformed). A MOVING without the endpoint element remains malformed.
- Reconnect is a per-connection deadline (`Connection.expireAt`) — no background scheduler:
  - a target MOVING stamps the receiver for immediate discard (existing behavior); a `none` MOVING stamps `now + time_s/2`;
  - all connections affected by the same MOVING share the first notification's deadline;
  - expired connections are destroyed on return to the pool; borrow never blocks on expiry, so borrowed work always runs and a stale connection serves at most one more command;
  - `RebindAwareEvictionPolicy` stamps idle affected connections at notification time and evicts only those past their deadline;
  - `validateObject` reports expired connections invalid — `testOnBorrow`/`testWhileIdle` opt into stricter cleanup, mirroring how dead-while-idle connections are handled.
- Relax window and reconnect deadline are independent timers; supersession stays seq-gated for target and `none` alike.

### Testing
- `MaintenancePushCodecTest`: null-target decode + malformed frame shapes.
- `MaintenanceEventControllerTest`: `none` deadlines, shared same-seq deadline, supersession (`none` <-> target), handoff hook payload.
- `ConnectionPoolExpiryMockTest`: pool lifecycle — expired idle served then destroyed on return, validation semantics, `testOnBorrow`/`testWhileIdle` strictness, fail-fast termination bound.
- `AbstractRebindBehaviorTest` (RedisClient + MultiDbClient): `none` keeps connections through the window, no remap, replacement after half the grace period.

### Churn guard (second commit)
A reconnect that re-lands on a not-yet-repointed endpoint (JVM DNS cache, DNS lag, raw-IP config) would be re-stamped with the past shared deadline on every return and on the same-seq re-notification the moving node sends to every new connection - a new connection per command until the relax window closes. `RebindState.expireAtNanos` (the moment recycling starts) now also scopes the rebind: connections created before it are recycled on return; connections created after it are the rebind's own reconnects and are left alone. The target case stores the receipt time instead of the `EXPIRED` sentinel, which is removed.