### PR TITLE
synchronise the read path in AbstractCache.get

### DIFF
--- a/src/main/java/redis/clients/jedis/csc/AbstractCache.java
+++ b/src/main/java/redis/clients/jedis/csc/AbstractCache.java
@@ -50,11 +50,16 @@ public abstract class AbstractCache implements Cache {
 
   @Override
   public CacheEntry get(CacheKey cacheKey) {
-    CacheEntry entry = getFromStore(cacheKey);
-    if (entry != null) {
-      getEvictionPolicy().touch(cacheKey);
+    lock.lock();
+    try {
+      CacheEntry entry = getFromStore(cacheKey);
+      if (entry != null) {
+        getEvictionPolicy().touch(cacheKey);
+      }
+      return entry;
+    } finally {
+      lock.unlock();
     }
-    return entry;
   }
 
   @Override

--- a/src/test/java/redis/clients/jedis/csc/AbstractCacheConcurrencyTest.java
+++ b/src/test/java/redis/clients/jedis/csc/AbstractCacheConcurrencyTest.java
@@ -1,0 +1,86 @@
+package redis.clients.jedis.csc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.CommandObjects;
+import redis.clients.jedis.RedisProtocol;
+
+public class AbstractCacheConcurrencyTest {
+
+  /**
+   * A store whose read is made to block once, so a reader can be parked inside
+   * {@link AbstractCache#get(CacheKey)} while another thread tries to mutate the cache.
+   */
+  private static class BlockingReadCache extends HashMap<CacheKey, CacheEntry> {
+
+    private final CacheKey blockOn;
+    private final CountDownLatch enteredGet = new CountDownLatch(1);
+    private final CountDownLatch proceedGet = new CountDownLatch(1);
+
+    BlockingReadCache(CacheKey blockOn) {
+      this.blockOn = blockOn;
+    }
+
+    @Override
+    public CacheEntry get(Object key) {
+      if (blockOn.equals(key)) {
+        enteredGet.countDown();
+        try {
+          proceedGet.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      return super.get(key);
+    }
+  }
+
+  @Test
+  public void getHoldsLockWhileReadingStore() throws InterruptedException {
+    CacheKey readKey = new CacheKey<>(new CommandObjects(RedisProtocol.RESP3).get("read"));
+    CacheKey writeKey = new CacheKey<>(new CommandObjects(RedisProtocol.RESP3).get("write"));
+
+    BlockingReadCache store = new BlockingReadCache(readKey);
+    Map<CacheKey, CacheEntry> map = store;
+    TestCache cache = new TestCache(map);
+    cache.set(readKey, new CacheEntry<>(readKey, "read-value", null));
+
+    Thread reader = new Thread(() -> cache.get(readKey), "reader");
+    reader.start();
+
+    // reader is now parked inside get(), reading the store
+    assertTrue(store.enteredGet.await(5, TimeUnit.SECONDS), "reader never entered get()");
+
+    AtomicBoolean writerReturned = new AtomicBoolean(false);
+    CountDownLatch writerDone = new CountDownLatch(1);
+    Thread writer = new Thread(() -> {
+      cache.set(writeKey, new CacheEntry<>(writeKey, "write-value", null));
+      writerReturned.set(true);
+      writerDone.countDown();
+    }, "writer");
+    writer.start();
+
+    // a concurrent mutation must not proceed while a read is in flight
+    boolean finishedEarly = writerDone.await(1, TimeUnit.SECONDS);
+    boolean blocked = !finishedEarly;
+
+    store.proceedGet.countDown();
+    reader.join(5000);
+    assertTrue(writerDone.await(5, TimeUnit.SECONDS), "writer never completed");
+    writer.join(5000);
+
+    assertTrue(writerReturned.get(), "writer never returned");
+    assertTrue(blocked,
+      "set() ran concurrently with an in-flight get(); read path is unsynchronised");
+    assertEquals("read-value", cache.get(readKey).getValue());
+  }
+}


### PR DESCRIPTION
Every mutator in `AbstractCache` takes the `ReentrantLock`; the reader does not:

    set / delete / deleteByRedisKey / deleteByRedisKeys / flush  ->  lock.lock()
    get                                                          ->  getFromStore(...)   // no lock

`DefaultCache` backs the store with a plain `HashMap`, so `get()` runs `HashMap.get` concurrently with a `put`/`remove`/`clear` executing under the lock on another thread. The RESP3 server-push invalidation path (`PushInvalidateConsumer` -> `deleteByRedisKeys`) mutates that same map while application threads read it, so a `get` racing a rehash can observe a stale or foreign `CacheEntry`.

`get()` is a top-level lock acquirer like `set()` and `delete()` (it never runs while the eviction-policy monitor is held), so taking the same lock adds no ordering inversion. The regression test parks a reader inside `get()` and asserts a concurrent `set()` no longer proceeds until the read completes; it fails on the current code and passes with the lock.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path locking for client-side cache reads; correct for thread safety but may increase contention under heavy concurrent access.
> 
> **Overview**
> **`AbstractCache.get`** now acquires the same **`ReentrantLock`** used by **`set`**, **`delete`**, and invalidation paths, so reads no longer run **`getFromStore`** (and eviction **`touch`**) concurrently with mutations on the backing store (e.g. **`DefaultCache`**’s **`HashMap`**).
> 
> Adds **`AbstractCacheConcurrencyTest`**, which blocks a reader inside the store **`get`** and asserts a concurrent **`set`** cannot finish until the read completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7049ac2b74c32b57643c2d6289e6121d71a62e62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->