### PR TITLE
[maintenance events] Relax handshake reads for connections opened during a rebind window

### DIFF
--- a/src/main/java/redis/clients/jedis/ChainedTimeoutSource.java
+++ b/src/main/java/redis/clients/jedis/ChainedTimeoutSource.java
@@ -9,9 +9,16 @@ class ChainedTimeoutSource implements TimeoutSource {
 
   private volatile ChainedTimeoutSource override;
   private final TimeoutInfo info;
+  private final Object identity;
 
   ChainedTimeoutSource(TimeoutInfo info) {
     this.info = info;
+    this.identity = this.getClass();
+  }
+
+  ChainedTimeoutSource(TimeoutInfo info, Object identity) {
+    this.info = info;
+    this.identity = identity;
   }
 
   @Override
@@ -50,5 +57,16 @@ class ChainedTimeoutSource implements TimeoutSource {
     } else if (override != null) {
       override.removeOverride(other);
     }
+  }
+
+  ChainedTimeoutSource seekBy(Object identity) {
+    if (this.identity == identity) {
+      return this;
+    }
+    ChainedTimeoutSource override = this.override;
+    if (override == null) {
+      return null;
+    }
+    return override.seekBy(identity);
   }
 }

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -175,11 +175,10 @@ public class Connection implements Closeable {
   private long expireAt = EXPIRE_NOT_SET;
 
   /** Listeners notified synchronously of this connection's maintenance events (pool-injected). */
-  private final Set<MaintenanceEventListener> maintenanceEventListeners =  ConcurrentHashMap.newKeySet();
+  private final Set<MaintenanceEventListener> maintenanceEventListeners = ConcurrentHashMap
+      .newKeySet();
 
-  private final DefaultTimeoutSource defaultTimeoutSource = new DefaultTimeoutSource(
-      new TimeoutInfo(0, 0));
-  private ExpiringTimeoutSource relaxedTimeoutSource;
+  private final DefaultTimeoutSource defaultTimeoutSource = new DefaultTimeoutSource(new TimeoutInfo(0, 0));
 
   private JedisClientConfig clientConfig;
   private final ProtocolHandshake handshake = new ProtocolHandshake(this);
@@ -794,6 +793,12 @@ public class Connection implements Closeable {
 
   protected void initializeFromClientConfig(final JedisClientConfig config) {
     try {
+      // Pre-handshake hook: lets visitors install state that must already be in effect while the
+      // AUTH/HELLO handshake talks to the server (e.g. the maintenance rebind timeout overlay).
+      for (InitVisitor visitor : initVisitors) {
+        visitor.visitBeforeHandshake(this);
+      }
+
       defaultTimeoutSource.setDefaults(config.getSocketTimeoutMillis(),
         config.getBlockingSocketTimeoutMillis());
 
@@ -862,13 +867,14 @@ public class Connection implements Closeable {
       }
       getMany(fireAndForgetMsg.size());
 
-      for (InitVisitor visitor : initVisitors) {
-        visitor.visit(this);
-      }
 
       int dbIndex = config.getDatabase();
       if (dbIndex > 0) {
         select(dbIndex);
+      }
+
+      for (InitVisitor visitor : initVisitors) {
+        visitor.visitAfterHandshake(this);
       }
 
     } catch (JedisException je) {
@@ -1075,52 +1081,8 @@ public class Connection implements Closeable {
     this.expireAt = expireAt;
   }
 
-  void enableTimeoutRelaxing(ExpiringTimeoutSource relaxedTimeout) {
-    if (this.relaxedTimeoutSource != null) {
-      throw new IllegalStateException("Relaxed timeouts already activated");
-    }
-    this.relaxedTimeoutSource = relaxedTimeout;
-    this.defaultTimeoutSource.addOverride(relaxedTimeout);
-  }
-
-  void disableTimeoutRelaxing() {
-    if (this.relaxedTimeoutSource == null) {
-      throw new IllegalStateException("Relaxed timeouts not activated");
-    }
-    this.defaultTimeoutSource.removeOverride(relaxedTimeoutSource);
-    this.relaxedTimeoutSource = null;
-  }
-
-  /**
-   * Switches this connection to relaxed timeouts for at most {@code period}. While the window is
-   * open, commands use the looser of the configured value and {@link MaintenanceNotificationsConfig#getRelaxedTimeout()}
-   * (respectively {@link MaintenanceNotificationsConfig#getRelaxedBlockingTimeout()}), {@code 0}
-   * (infinite) being the loosest, giving in-flight commands extra headroom across a server-side
-   * maintenance event (MIGRATING / FAILING_OVER / MOVING-receiver) without ever tightening the
-   * configured deadline. The original timeouts return
-   * into effect once the window closes or {@link #resetRelaxedTimeouts()} is called. Calling this
-   * with a later deadline extends the window; an earlier one is ignored.
-   * @param period maximum duration of the relaxation window
-   */
-  @Experimental
-  void relaxTimeouts(long expiration) {
-    if (this.relaxedTimeoutSource == null) {
-      throw new IllegalStateException("Relaxed timeouts not activated");
-    }
-    relaxedTimeoutSource.setExpirationTime(expiration);
-    applyCurrentTimeout();
-  }
-
-  /**
-   * Clears the per-receiver relaxation deadline and eagerly realigns the socket (cache-checked).
-   */
-  @Experimental
-  void resetRelaxedTimeouts() {
-    if (this.relaxedTimeoutSource == null) {
-      throw new IllegalStateException("Relaxed timeouts not activated");
-    }
-    relaxedTimeoutSource.setExpirationTime(0);
-    applyCurrentTimeout();
+  ChainedTimeoutSource getTimeoutSource() {
+    return defaultTimeoutSource;
   }
 
   /** The connected peer's address, or {@code null} if the socket is not (yet) open. */

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -868,14 +868,13 @@ public class Connection implements Closeable {
       }
       getMany(fireAndForgetMsg.size());
 
+      for (InitVisitor visitor : initVisitors) {
+        visitor.visitAfterHandshake(this);
+      }
 
       int dbIndex = config.getDatabase();
       if (dbIndex > 0) {
         select(dbIndex);
-      }
-
-      for (InitVisitor visitor : initVisitors) {
-        visitor.visitAfterHandshake(this);
       }
 
     } catch (JedisException je) {

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -348,7 +348,7 @@ public class Connection implements Closeable {
     return isBlocking ? defaultTimeoutSource.get().blockingTimeout : defaultTimeoutSource.get().timeout;
   }
 
-  private void applyCurrentTimeout() {
+  void applyCurrentTimeout() {
     int timeout = currentTimeout();
      if (timeout == appliedSoTimeout || socket == null) {
       return;

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -178,7 +178,8 @@ public class Connection implements Closeable {
   private final Set<MaintenanceEventListener> maintenanceEventListeners = ConcurrentHashMap
       .newKeySet();
 
-  private final DefaultTimeoutSource defaultTimeoutSource = new DefaultTimeoutSource(new TimeoutInfo(0, 0));
+  private final DefaultTimeoutSource defaultTimeoutSource = new DefaultTimeoutSource(
+      new TimeoutInfo(0, 0));
 
   private JedisClientConfig clientConfig;
   private final ProtocolHandshake handshake = new ProtocolHandshake(this);

--- a/src/main/java/redis/clients/jedis/InitVisitor.java
+++ b/src/main/java/redis/clients/jedis/InitVisitor.java
@@ -2,5 +2,7 @@ package redis.clients.jedis;
 
 interface InitVisitor {
 
-  void visit(Connection connection);
+  void visitBeforeHandshake(Connection connection);
+
+  void visitAfterHandshake(Connection connection);
 }

--- a/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
@@ -27,61 +27,91 @@ public class MaintenanceAwareVisitor implements InitVisitor {
     this.controller = maintenanceController;
   }
 
+  /**
+   * Installs the pool-wide MOVING rebind timeout overlay before the handshake runs, so a connection
+   * opened while a rebind window is open already relaxes its AUTH/HELLO handshake reads. The
+   * overlay is torn down again in {@link #visit(Connection)} if the feature turns out to be
+   * unsupported on this connection.
+   */
   @Override
-  public void visit(Connection connection) {
-    RedisProtocol protocol = connection.getRedisProtocol();
-    Set<MaintenanceEventListener> maintenanceEventListeners = connection
-        .getMaintenanceEventListeners();
-    MaintenanceNotificationsConfig maintenanceConfig = builder.getMaintenanceConfig();
-
-    if (maintenanceConfig == null
-        || maintenanceConfig.getMode() == MaintenanceNotificationsConfig.Mode.DISABLED) {
-      return;
-    }
-    boolean strict = maintenanceConfig.getMode() == MaintenanceNotificationsConfig.Mode.ENABLED;
-
-    // Maintenance push frames require RESP3.
-    if (protocol != RedisProtocol.RESP3) {
-      String reason = "RESP3 is required but the established protocol is "
-          + (protocol == null ? "RESP2" : protocol);
-      if (strict) {
-        throw new JedisConnectionException("Maintenance notifications: " + reason);
-      }
-      logger.debug("Maintenance notifications disabled: {}.", reason);
+  public void visitBeforeHandshake(Connection connection) {
+    MaintenanceNotificationsConfig mConfig = builder.getMaintenanceConfig();
+    if (!isMaintenanceEnabled(mConfig)) {
       return;
     }
 
-    maintenanceEventListeners.add(controller);
+    ChainedTimeoutSource dts = connection.getTimeoutSource();
+    dts.addOverride(new RebindTimeoutSource(controller));
 
-    // The server must accept CLIENT MAINT_NOTIFICATIONS ON. Pre-register the consumer so a
-    // push
-    // frame the server emits immediately on accepting the subscription cannot race ahead.
-    MaintenanceEventConsumer consumer = new MaintenanceEventConsumer(connection,
-        maintenanceEventListeners);
-    connection.addPushConsumer(consumer);
-    ExpiringTimeoutSource relaxedTimeoutSource = new ExpiringTimeoutSource(new TimeoutInfo(
-        maintenanceConfig.getRelaxedTimeout(), maintenanceConfig.getRelaxedBlockingTimeout()));
-    connection.enableTimeoutRelaxing(relaxedTimeoutSource);
+    TimeoutInfo relaxedTimeout = new TimeoutInfo(mConfig.getRelaxedTimeout(),
+        mConfig.getRelaxedBlockingTimeout());
+    dts.addOverride(new ExpiringTimeoutSource(relaxedTimeout));
+  }
 
-    ChainedTimeoutSource rebindTimeoutSource = new RebindTimeoutSource(controller);
-    relaxedTimeoutSource.addOverride(rebindTimeoutSource);
+  @Override
+  public void visitAfterHandshake(Connection connection) {
+    MaintenanceNotificationsConfig mConfig = builder.getMaintenanceConfig();
+    if (!isMaintenanceEnabled(mConfig)) {
+      return;
+    }
 
-    connection.sendCommand(Command.CLIENT, "MAINT_NOTIFICATIONS", "ON", "moving-endpoint-type",
-      resolveEndpointType(maintenanceConfig.getEndpointType()));
+    boolean strict = mConfig.getMode() == MaintenanceNotificationsConfig.Mode.ENABLED;
+    boolean keepOverrides = false;
+
     try {
-      connection.getStatusCodeReply();
-    } catch (JedisDataException e) {
-      connection.removePushConsumer(consumer);
-      relaxedTimeoutSource.removeOverride(rebindTimeoutSource);
-      connection.disableTimeoutRelaxing();
-      if (strict) {
-        throw new JedisConnectionException(
-            "Maintenance notifications: events not supported on server", e);
+      // Maintenance push frames require RESP3.
+      RedisProtocol protocol = connection.getRedisProtocol();
+      if (protocol != RedisProtocol.RESP3) {
+        String reason = "RESP3 is required but the established protocol is "
+            + (protocol == null ? "RESP2" : protocol);
+        if (strict) {
+          throw new JedisConnectionException("Maintenance notifications: " + reason);
+        }
+        logger.debug("Maintenance notifications disabled: {}.", reason);
+        return;
       }
-      logger.debug(
-        "Maintenance notifications disabled: server rejected CLIENT MAINT_NOTIFICATIONS ({}).",
-        e.getMessage());
+
+      Set<MaintenanceEventListener> maintenanceEventListeners = connection
+          .getMaintenanceEventListeners();
+      maintenanceEventListeners.add(controller);
+
+      // The server must accept CLIENT MAINT_NOTIFICATIONS ON. Pre-register the consumer so a
+      // push
+      // frame the server emits immediately on accepting the subscription cannot race ahead.
+      MaintenanceEventConsumer consumer = new MaintenanceEventConsumer(connection,
+          maintenanceEventListeners);
+      connection.addPushConsumer(consumer);
+
+      connection.sendCommand(Command.CLIENT, "MAINT_NOTIFICATIONS", "ON", "moving-endpoint-type",
+        resolveEndpointType(mConfig.getEndpointType()));
+      try {
+        connection.getStatusCodeReply();
+        keepOverrides = true;
+      } catch (JedisDataException e) {
+        connection.removePushConsumer(consumer);
+
+        if (strict) {
+          throw new JedisConnectionException(
+              "Maintenance notifications: events not supported on server", e);
+        }
+        logger.debug(
+          "Maintenance notifications disabled: server rejected CLIENT MAINT_NOTIFICATIONS ({}).",
+          e.getMessage());
+      }
+    } finally {
+      if (!keepOverrides) {
+        // Undo the rebind overlay installed before the handshake — this connection does NOT support
+        // maintenance notifications.
+        ChainedTimeoutSource dts = connection.getTimeoutSource();
+        dts.removeOverride(dts.seekBy(controller));
+        dts.removeOverride(dts.seekBy(ExpiringTimeoutSource.class));
+      }
     }
+  }
+
+  private static boolean isMaintenanceEnabled(MaintenanceNotificationsConfig maintenanceConfig) {
+    return maintenanceConfig != null
+        && maintenanceConfig.getMode() != MaintenanceNotificationsConfig.Mode.DISABLED;
   }
 
   private String resolveEndpointType(MaintenanceNotificationsConfig.EndpointType endpointType) {
@@ -105,7 +135,7 @@ public class MaintenanceAwareVisitor implements InitVisitor {
     private final MaintenanceEventController controller;
 
     RebindTimeoutSource(MaintenanceEventController controller) {
-      super(null);
+      super(null, controller);
       this.controller = controller;
     }
 

--- a/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
@@ -30,8 +30,8 @@ public class MaintenanceAwareVisitor implements InitVisitor {
   /**
    * Installs the pool-wide MOVING rebind timeout overlay before the handshake runs, so a connection
    * opened while a rebind window is open already relaxes its AUTH/HELLO handshake reads. The
-   * overlay is torn down again in {@link #visitAfterHandshake(Connection)} if the feature turns out to be
-   * unsupported on this connection.
+   * overlay is torn down again in {@link #visitAfterHandshake(Connection)} if the feature turns out
+   * to be unsupported on this connection.
    */
   @Override
   public void visitBeforeHandshake(Connection connection) {

--- a/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
@@ -83,9 +83,7 @@ public class MaintenanceAwareVisitor implements InitVisitor {
       connection.addPushConsumer(consumer);
 
       connection.sendCommand(Command.CLIENT, "MAINT_NOTIFICATIONS", "ON", "moving-endpoint-type",
-        resolveEndpointType(mConfig.getEndpointType()));
-      connection.sendCommand(Command.CLIENT, "MAINT_NOTIFICATIONS", "ON", "moving-endpoint-type",
-        resolveEndpointType(connection, maintenanceConfig));
+        resolveEndpointType(connection, mConfig));
       try {
         connection.getStatusCodeReply();
         keepOverrides = true;

--- a/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
@@ -30,7 +30,7 @@ public class MaintenanceAwareVisitor implements InitVisitor {
   /**
    * Installs the pool-wide MOVING rebind timeout overlay before the handshake runs, so a connection
    * opened while a rebind window is open already relaxes its AUTH/HELLO handshake reads. The
-   * overlay is torn down again in {@link #visit(Connection)} if the feature turns out to be
+   * overlay is torn down again in {@link #visitAfterHandshake(Connection)} if the feature turns out to be
    * unsupported on this connection.
    */
   @Override

--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -203,6 +203,7 @@ final class MaintenanceEventController implements MaintenanceEventListener, Sock
     if (source != null) {
       ((ExpiringTimeoutSource) source).setExpirationTime(expirationTime);
     }
+    c.applyCurrentTimeout();
   }
 
   /** Observation payload delivered to handoff hooks: seq, new endpoint, and the handoff window. */

--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -177,28 +177,32 @@ final class MaintenanceEventController implements MaintenanceEventListener, Sock
   @Override
   public void onMigrating(MigratingEvent e, Connection c) {
     logger.debug("Migrating shards {} (seq={}, ttl={}s)", e.shardIds, e.seq, e.ttlSeconds);
-    c.relaxTimeouts(maxRelaxedDurationNanos + NanoClock.INSTANCE.getAsLong()); // time_s = "starts
-                                                                               // within";
-    // backstop
+    relaxConnectionTimeoutsFor(c, maxRelaxedDurationNanos + NanoClock.INSTANCE.getAsLong());
   }
 
   @Override
   public void onFailingOver(FailingOverEvent e, Connection c) {
     logger.debug("Failing over shards {} (seq={}, ttl={}s)", e.shardIds, e.seq, e.ttlSeconds);
-    c.relaxTimeouts(maxRelaxedDurationNanos + NanoClock.INSTANCE.getAsLong()); // time_s = "starts
-                                                                               // within"; backstop
+    relaxConnectionTimeoutsFor(c, maxRelaxedDurationNanos + NanoClock.INSTANCE.getAsLong());
   }
 
   @Override
   public void onMigrated(MigratedEvent e, Connection c) {
     logger.debug("Migrated shards {} (seq={})", e.shardIds, e.seq);
-    c.resetRelaxedTimeouts();
+    relaxConnectionTimeoutsFor(c, 0);
   }
 
   @Override
   public void onFailedOver(FailedOverEvent e, Connection c) {
     logger.debug("Failed over shards {} (seq={})", e.shardIds, e.seq);
-    c.resetRelaxedTimeouts();
+    relaxConnectionTimeoutsFor(c, 0);
+  }
+
+  private void relaxConnectionTimeoutsFor(Connection c, long expirationTime) {
+    ChainedTimeoutSource source = c.getTimeoutSource().seekBy(ExpiringTimeoutSource.class);
+    if (source != null) {
+      ((ExpiringTimeoutSource) source).setExpirationTime(expirationTime);
+    }
   }
 
   /** Observation payload delivered to handoff hooks: seq, new endpoint, and the handoff window. */

--- a/src/test/java/redis/clients/jedis/ConnectionTestHelper.java
+++ b/src/test/java/redis/clients/jedis/ConnectionTestHelper.java
@@ -50,14 +50,15 @@ public class ConnectionTestHelper {
   }
 
   /**
-   * Maintenance relaxed-timeout state on {@link Connection}. The relaxed timeout is wired only when
-   * the maintenance feature is active (a {@link MaintenanceEventController} attached via the pool);
-   * these read the internal {@code relaxedTimeoutSource} directly so tests in other packages can
-   * observe it without a public accessor.
+   * Maintenance relaxed-timeout state on {@link Connection}. Relaxation is wired only when the
+   * maintenance feature is active (a {@link MaintenanceEventController} attached via the pool), and
+   * is layered as overrides on the connection's timeout source chain — the pool-wide rebind window
+   * ({@code RebindTimeoutSource}) and the per-connection MOVING window
+   * ({@code ExpiringTimeoutSource}). The timeout is relaxed whenever any override currently has an
+   * opinion, so this observes the chain rather than a single source.
    */
   public static boolean isRelaxedTimeoutActive(Connection connection) {
-    ExpiringTimeoutSource source = ReflectionTestUtil.getField(connection, "relaxedTimeoutSource");
-    return source != null && source.get() != null;
+    return connection.getTimeoutSource().getOverrideInfo() != null;
   }
 
   public static void relaxTimeouts(Connection connection, Duration period) {
@@ -80,9 +81,10 @@ public class ConnectionTestHelper {
     return relaxedInfo(connection).blockingTimeout;
   }
 
-  /** The configured relaxed timeouts, or a zeroed pair when relaxation was never wired. */
+  /** The configured relaxed timeouts, or {@code null} when relaxation was never wired. */
   private static TimeoutSource.TimeoutInfo relaxedInfo(Connection connection) {
-    ExpiringTimeoutSource source = ReflectionTestUtil.getField(connection, "relaxedTimeoutSource");
+    ExpiringTimeoutSource source = (ExpiringTimeoutSource) connection.getTimeoutSource()
+        .seekBy(ExpiringTimeoutSource.class);
     return source == null ? null : source.get();
   }
 

--- a/src/test/java/redis/clients/jedis/ConnectionTestHelper.java
+++ b/src/test/java/redis/clients/jedis/ConnectionTestHelper.java
@@ -61,11 +61,15 @@ public class ConnectionTestHelper {
   }
 
   public static void relaxTimeouts(Connection connection, Duration period) {
-    connection.relaxTimeouts(NanoClock.INSTANCE.getAsLong() + period.toNanos());
+    ChainedTimeoutSource dts = connection.getTimeoutSource();
+    ExpiringTimeoutSource ets = ((ExpiringTimeoutSource) dts.seekBy(ExpiringTimeoutSource.class));
+    ets.setExpirationTime(NanoClock.INSTANCE.getAsLong() + period.toNanos());
   }
 
   public static void resetRelaxedTimeouts(Connection connection) {
-    connection.resetRelaxedTimeouts();
+    ChainedTimeoutSource dts = connection.getTimeoutSource();
+    ExpiringTimeoutSource ets = ((ExpiringTimeoutSource) dts.seekBy(ExpiringTimeoutSource.class));
+    ets.setExpirationTime(0);
   }
 
   public static int getRelaxedSoTimeout(Connection connection) {

--- a/src/test/java/redis/clients/jedis/MaintenanceEventControllerTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceEventControllerTest.java
@@ -331,13 +331,16 @@ public class MaintenanceEventControllerTest {
   private static void sleepUninterruptibly(long millis) {
     long deadline = System.currentTimeMillis() + millis;
     long remaining;
+    boolean interrupted = false;
     while ((remaining = deadline - System.currentTimeMillis()) > 0) {
       try {
         Thread.sleep(remaining);
       } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        return;
+        interrupted = true;
       }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/src/test/java/redis/clients/jedis/MaintenanceEventControllerTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceEventControllerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.InetSocketAddress;
@@ -24,6 +25,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import redis.clients.jedis.MaintenanceEventController.MaintenanceHandoff;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.util.SafeEncoder;
 import redis.clients.jedis.util.server.TcpMockServer;
 
 /**
@@ -274,6 +277,67 @@ public class MaintenanceEventControllerTest {
         "an active pool-wide rebind window relaxes any borrowed connection's next command");
     } finally {
       pooled.getObject().close();
+    }
+  }
+
+  /**
+   * A connection opened while a pool-wide rebind window is open must relax its read timeouts from
+   * before the AUTH/HELLO handshake, not only afterwards. The server delays its HELLO reply beyond
+   * the tight configured socket timeout but within the looser relaxed timeout: the handshake only
+   * survives if the rebind overlay is already in effect when the handshake runs.
+   */
+  @Test
+  public void handshakeReadsRelaxed_whenConnectionOpensDuringRebindWindow() throws Exception {
+    int soTimeoutMs = 250;
+    int relaxedTimeoutMs = 4000;
+    long helloDelayMs = 900;
+
+    mockServer.setCommandHandler((args, clientId) -> {
+      String cmd = SafeEncoder.encode(args.getCommand().getRaw()).toUpperCase();
+      if ("HELLO".equals(cmd)) {
+        sleepUninterruptibly(helloDelayMs);
+      }
+      return null; // fall through to the built-in handler
+    });
+
+    MaintenanceNotificationsConfig maintConfig = MaintenanceNotificationsConfig.builder()
+        .relaxedTimeout(relaxedTimeoutMs).build();
+    DefaultJedisClientConfig clientConfig = DefaultJedisClientConfig.builder()
+        .socketTimeoutMillis(soTimeoutMs).protocol(RedisProtocol.RESP3).build();
+    HostAndPort mock = new HostAndPort("127.0.0.1", mockServer.getPort());
+
+    MaintenanceEventController poolCtl = MaintenanceEventController.from(maintConfig);
+    ConnectionFactory factory = ConnectionFactory.builder().hostAndPort(mock)
+        .clientConfig(clientConfig).maintenanceController(poolCtl).build();
+
+    // No rebind window: the tight configured timeout applies to the slow HELLO, so the handshake
+    // times out.
+    assertThrows(JedisConnectionException.class, factory::makeObject,
+      "without a rebind window the slow HELLO exceeds the configured socket timeout");
+
+    // Open a pool-wide rebind window, then open a fresh connection: its handshake reads are relaxed
+    // from before the HELLO, so the slow HELLO now completes within the relaxed timeout.
+    poolCtl.onMoving(new MovingEvent(1L, 100, mock), receiver);
+    PooledObject<Connection> pooled = factory.makeObject();
+    try {
+      Connection borrowed = pooled.getObject();
+      assertTrue(borrowed.isConnected());
+      assertEquals(RedisProtocol.RESP3, borrowed.getRedisProtocol());
+    } finally {
+      pooled.getObject().close();
+    }
+  }
+
+  private static void sleepUninterruptibly(long millis) {
+    long deadline = System.currentTimeMillis() + millis;
+    long remaining;
+    while ((remaining = deadline - System.currentTimeMillis()) > 0) {
+      try {
+        Thread.sleep(remaining);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
     }
   }
 

--- a/src/test/java/redis/clients/jedis/authentication/TokenBasedAuthenticationIntegrationTests.java
+++ b/src/test/java/redis/clients/jedis/authentication/TokenBasedAuthenticationIntegrationTests.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -106,7 +107,7 @@ public class TokenBasedAuthenticationIntegrationTests {
 
     AuthXManager authXManager = new AuthXManager(tokenAuthConfig);
     authXManager = spy(authXManager);
-    List<Connection> connections = new ArrayList<>();
+    List<Connection> connections = new CopyOnWriteArrayList<>();
     doAnswer(invocation -> {
       Connection connection = spy((Connection) invocation.getArgument(0));
       invocation.getArguments()[0] = connection;

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -24,6 +24,7 @@
   <!-- Set Redis client logging to DEBUG level -->
   <logger name="redis.clients.jedis" level="DEBUG" />
   <logger name="redis.clients.jedis.mcf.HealthCheck" level="ERROR" />
+  <logger name="redis.clients.jedis.MaintenanceAwareVisitor" level="WARN" />
   
   <!-- Set other libraries to appropriate levels -->
   <logger name="org.apache.http" level="INFO" />


### PR DESCRIPTION
Closes #4621 
## Summary
Connections opened while a pool-wide maintenance rebind window is open now relax their read timeouts starting *before* the AUTH/HELLO handshake, rather than only after it completes. Previously the relaxed/rebind timeout overlay was installed as part of post-handshake init, so a slow HELLO during maintenance could exceed the tight configured socket timeout and fail the connection outright.

## Key Decisions & Assumptions
- `InitVisitor.visit` is split into `visitBeforeHandshake` and `visitAfterHandshake`. The pre-handshake hook installs state that must already be in effect while AUTH/HELLO runs; the post-handshake hook does the work that requires a negotiated protocol.
- Per-connection relaxed-timeout state (the `enableTimeoutRelaxing` / `disableTimeoutRelaxing` / `relaxTimeouts` / `resetRelaxedTimeouts` methods and the `relaxedTimeoutSource` field) is removed from `Connection`. The timeout chain is now the single source of truth, exposed via `getTimeoutSource()`.
- `ChainedTimeoutSource` gains an `identity` tag and `seekBy(identity)` so a specific override (the rebind source keyed by its controller, or the `ExpiringTimeoutSource` by class) can be located and mutated/removed within the chain.

## Behavioral / Conceptual Changes
- When maintenance is enabled, the rebind and relaxed-timeout overrides are added to the connection's timeout chain before the handshake. If the connection turns out not to support maintenance notifications (non-RESP3, or the server rejects `CLIENT MAINT_NOTIFICATIONS ON`), both overrides are torn down again after the handshake.
- `MaintenanceEventController` now drives relaxation by setting the expiration time on the `ExpiringTimeoutSource` it locates in the chain (via `seekBy`) instead of calling the removed `Connection.relaxTimeouts` / `resetRelaxedTimeouts` methods.

## Testing
Adds a test that opens a connection against a mock server whose HELLO reply is delayed beyond the configured socket timeout but within the relaxed timeout: without a rebind window the handshake times out, and after opening a pool-wide rebind window a fresh connection's handshake completes. Test helpers were updated to reach the `ExpiringTimeoutSource` through the timeout chain rather than the removed `Connection` methods.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection initialization and maintenance timeout wiring on the critical handshake path; behavior changes when opening connections during rebind, though unsupported maintenance paths roll back overrides.
> 
> **Overview**
> Connections opened while a **pool-wide maintenance rebind window** is active now use relaxed read timeouts **before** AUTH/HELLO, so a slow handshake during maintenance is less likely to fail on the tight configured `SO_TIMEOUT`.
> 
> **Init lifecycle:** `InitVisitor` is split into `visitBeforeHandshake` and `visitAfterHandshake`. `MaintenanceAwareVisitor` installs `RebindTimeoutSource` and `ExpiringTimeoutSource` on the timeout chain pre-handshake; post-handshake it enables RESP3 maintenance push handling and tears down both overrides if notifications are unsupported (non-RESP3 or server rejects `CLIENT MAINT_NOTIFICATIONS ON`).
> 
> **Timeout model:** Per-connection `relaxedTimeoutSource` and `relaxTimeouts` / `resetRelaxedTimeouts` on `Connection` are removed in favor of `getTimeoutSource()` and `ChainedTimeoutSource.seekBy(identity)` so overrides can be found and updated. `MaintenanceEventController` relaxes/clears timeouts by mutating the chain’s `ExpiringTimeoutSource`.
> 
> **Tests:** Adds a mock-server test where delayed HELLO fails without a rebind window and succeeds with one; helpers now observe relaxation via the override chain. Minor test harness tweaks (`CopyOnWriteArrayList`, logback WARN for `MaintenanceAwareVisitor`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe2d7565e8a44e41eb0da3dd77f619270a889bb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->