### PR TITLE
return a defensive copy from getSlotReplicaPools

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -412,7 +412,8 @@ public class JedisClusterInfoCache {
   public List<ConnectionPool> getSlotReplicaPools(int slot) {
     r.lock();
     try {
-      return replicaSlots[slot];
+      List<ConnectionPool> pools = replicaSlots[slot];
+      return pools == null ? null : new ArrayList<>(pools);
     } finally {
       r.unlock();
     }

--- a/src/test/java/redis/clients/jedis/JedisClusterInfoCacheTest.java
+++ b/src/test/java/redis/clients/jedis/JedisClusterInfoCacheTest.java
@@ -99,6 +99,25 @@ public class JedisClusterInfoCacheTest {
   }
 
   @Test
+  public void getSlotReplicaPoolsReturnsIndependentSnapshot() {
+    JedisClusterInfoCache cache = createCacheWithReplicasEnabled();
+
+    when(mockConnection.executeCommand(argThat(commandWithArgs(CLUSTER, "SLOTS"))))
+        .thenReturn(masterReplicaSlotsResponse(MASTER_HOST, REPLICA_1_HOST));
+
+    cache.discoverClusterNodesAndSlots(mockConnection);
+
+    List<ConnectionPool> pools = cache.getSlotReplicaPools(TEST_SLOT);
+    assertEquals(1, pools.size());
+
+    // A topology refresh clears the internal replica-slot lists in place. A leaked
+    // reference would be emptied under the caller between size() and get(idx).
+    cache.reset();
+
+    assertEquals(1, pools.size());
+  }
+
+  @Test
   public void getPrimaryNodesAfterReplicaNodeRemovalAndRediscovery() {
     // Create client config with read-only replicas enabled
     JedisClientConfig clientConfig = DefaultJedisClientConfig.builder()


### PR DESCRIPTION
`ClusterConnectionProvider.getReplicaConnectionFromSlot` reads the list from `getSlotReplicaPools` with no lock held:

    int idx = random.nextInt(connectionPools.size());
    return connectionPools.get(idx).getResource();   // IndexOutOfBoundsException

`getSlotReplicaPools` takes the read lock but returns the raw `replicaSlots[slot]` reference rather than a copy, unlike every other getter here (`getNodes`, `getShuffledNodesPool`). The writers mutate that same list in place under the write lock: `assignSlotsToReplicaNode` calls `.add()`, and `resetReplicaSlots` calls `.clear()` on every topology refresh (including the MOVED-driven `renewSlotCache`). A refresh that clears the list between `size()` and `get(idx)` throws, and an `.add()` during array growth can surface a null or a pool for the wrong node. Being a `RuntimeException` it slips past the `JedisException`-only cluster retry loop and reaches the caller.

Returning `new ArrayList<>(replicaSlots[slot])` gives the caller the stable snapshot the read lock implies and keeps the null-for-no-replicas result. The test drives a refresh against a list already handed to a reader.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster replica routing and concurrency semantics in a hot path; behavior change is intentional and low blast radius but affects all replica reads from slot cache.
> 
> **Overview**
> **`getSlotReplicaPools`** now returns a **defensive `ArrayList` copy** of the per-slot replica pool list (or `null` when there are no replicas), matching other cache getters like **`getNodes`** instead of exposing the mutable internal **`replicaSlots`** list.
> 
> This fixes a race where **`ClusterConnectionProvider.getReplicaConnectionFromSlot`** keeps using the returned list after the read lock is released; in-place **`clear()`** / **`add()`** during topology refresh could shrink or corrupt that list between **`size()`** and **`get(idx)`**, causing **`IndexOutOfBoundsException`** that bypasses cluster **`JedisException`** retry handling.
> 
> A unit test asserts the returned list stays stable after **`cache.reset()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfbd7921c1bdff2d79b1aaabfaabf9ee0e6c03a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->