### PR TITLE
fix: clear credential byte arrays in JedisSafeAuthenticator after use

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisSafeAuthenticator.java
+++ b/src/main/java/redis/clients/jedis/JedisSafeAuthenticator.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis;
 
+import java.util.Arrays;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReference;
@@ -70,9 +71,11 @@ class JedisSafeAuthenticator {
   }
 
   private void safeReAuthenticate(Token token) {
+    byte[] rawPass = null;
+    byte[] rawUser = null;
     try {
-      byte[] rawPass = client.encodeToBytes(token.getValue().toCharArray());
-      byte[] rawUser = client.encodeToBytes(token.getUser().toCharArray());
+      rawPass = client.encodeToBytes(token.getValue().toCharArray());
+      rawUser = client.encodeToBytes(token.getUser().toCharArray());
 
       Token newToken = pendingTokenRef.getAndSet(token);
       if (newToken == null) {
@@ -88,6 +91,9 @@ class JedisSafeAuthenticator {
     } catch (Exception e) {
       logger.error("Error while re-authenticating connection", e);
       client.getAuthXManager().getListener().onConnectionAuthenticationError(e);
+    } finally {
+      if (rawPass != null) Arrays.fill(rawPass, (byte) 0);
+      if (rawUser != null) Arrays.fill(rawUser, (byte) 0);
     }
   }
 

--- a/src/main/java/redis/clients/jedis/JedisSafeAuthenticator.java
+++ b/src/main/java/redis/clients/jedis/JedisSafeAuthenticator.java
@@ -92,8 +92,12 @@ class JedisSafeAuthenticator {
       logger.error("Error while re-authenticating connection", e);
       client.getAuthXManager().getListener().onConnectionAuthenticationError(e);
     } finally {
-      if (rawPass != null) Arrays.fill(rawPass, (byte) 0);
-      if (rawUser != null) Arrays.fill(rawUser, (byte) 0);
+      if (rawPass != null) {
+        Arrays.fill(rawPass, (byte) 0); // clear sensitive data
+      }
+      if (rawUser != null) {
+        Arrays.fill(rawUser, (byte) 0); // clear sensitive data
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

`JedisSafeAuthenticator.safeReAuthenticate()` encodes token credentials into byte arrays but does not zero them after use, unlike the other authentication paths (`Connection.authenticate()`, `Connection.hello()`, `RedisRestAPI.getAuthenticationHeader()`), which all clear credential bytes in a `finally` block. This aligns `JedisSafeAuthenticator` with that pattern.

The arrays are method-local and GC'd after the method returns, but until then the credential bytes remain readable in heap memory (e.g., in a heap dump). Zeroing them shrinks that window, not a functional bug.

## Testing

- Existing `TokenBasedAuthenticationUnitTests` pass (no behavioural change).