### PR TITLE
mask credentials in invalid-URI exception messages

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -231,7 +231,8 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   public Jedis(URI uri) {
     if (!JedisURIHelper.isValid(uri)) {
       throw new InvalidURIException(String.format(
-        "Cannot open Redis connection due invalid URI \"%s\".", uri.toString()));
+        "Cannot open Redis connection due invalid URI \"%s\".",
+        JedisURIHelper.toStringWithMaskedCredentials(uri)));
     }
     connection = new Connection(new HostAndPort(uri.getHost(), uri.getPort()),
         DefaultJedisClientConfig.builder().autoNegotiateProtocol(false)
@@ -294,7 +295,8 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   public Jedis(final URI uri, JedisClientConfig config) {
     if (!JedisURIHelper.isValid(uri)) {
       throw new InvalidURIException(String.format(
-        "Cannot open Redis connection due invalid URI \"%s\".", uri.toString()));
+        "Cannot open Redis connection due invalid URI \"%s\".",
+        JedisURIHelper.toStringWithMaskedCredentials(uri)));
     }
     JedisClientConfig effective = sanitize(config);
     connection = new Connection(new HostAndPort(uri.getHost(), uri.getPort()),

--- a/src/main/java/redis/clients/jedis/JedisFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisFactory.java
@@ -159,7 +159,8 @@ public class JedisFactory implements PooledObjectFactory<Jedis> {
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     if (!JedisURIHelper.isValid(uri)) {
       throw new InvalidURIException(
-          String.format("Cannot open Redis connection due invalid URI. %s", uri.toString()));
+          String.format("Cannot open Redis connection due invalid URI. %s",
+              JedisURIHelper.toStringWithMaskedCredentials(uri)));
     }
     this.clientConfig = legacyConfigBuilderWithoutProtocolNegotiation().connectionTimeoutMillis(connectionTimeout)
         .socketTimeoutMillis(soTimeout).blockingSocketTimeoutMillis(infiniteSoTimeout)

--- a/src/main/java/redis/clients/jedis/util/JedisURIHelper.java
+++ b/src/main/java/redis/clients/jedis/util/JedisURIHelper.java
@@ -182,4 +182,27 @@ public final class JedisURIHelper {
     return REDISS.equalsIgnoreCase(uri.getScheme());
   }
 
+  /**
+   * Returns the string form of the URI with any user-info (username and password) replaced by a
+   * fixed placeholder. Use this instead of {@link URI#toString()} when a URI is embedded in a log
+   * or exception message, so that credentials carried in the userinfo are not disclosed.
+   *
+   * @param uri the URI to render
+   * @return the URI string with credentials masked
+   * @since 8.0
+   */
+  public static String toStringWithMaskedCredentials(URI uri) {
+    String rawUserInfo = uri.getRawUserInfo();
+    String uriString = uri.toString();
+    if (rawUserInfo == null || rawUserInfo.isEmpty()) {
+      return uriString;
+    }
+    int index = uriString.indexOf(rawUserInfo + "@");
+    if (index < 0) {
+      return uriString;
+    }
+    return uriString.substring(0, index) + "****@"
+        + uriString.substring(index + rawUserInfo.length() + 1);
+  }
+
 }

--- a/src/test/java/redis/clients/jedis/util/JedisURIHelperTest.java
+++ b/src/test/java/redis/clients/jedis/util/JedisURIHelperTest.java
@@ -149,6 +149,37 @@ public class JedisURIHelperTest {
   }
 
   @Test
+  public void toStringWithMaskedCredentials_masksUserAndPassword() throws URISyntaxException {
+    String masked = toStringWithMaskedCredentials(new URI("redis://user:s3cr3t@host:9000/0"));
+    assertFalse(masked.contains("s3cr3t"));
+    assertFalse(masked.contains("user"));
+    assertEquals("redis://****@host:9000/0", masked);
+  }
+
+  @Test
+  public void toStringWithMaskedCredentials_masksPasswordOnlyUserInfo() throws URISyntaxException {
+    String masked = toStringWithMaskedCredentials(new URI("redis://:s3cr3t@host:9000"));
+    assertFalse(masked.contains("s3cr3t"));
+    assertEquals("redis://****@host:9000", masked);
+  }
+
+  @Test
+  public void toStringWithMaskedCredentials_masksOnInvalidURI() throws URISyntaxException {
+    // Port omitted, so the URI is rejected by isValid and its string reaches the error path.
+    String masked = toStringWithMaskedCredentials(new URI("redis://user:s3cr3t@host"));
+    assertFalse(JedisURIHelper.isValid(new URI("redis://user:s3cr3t@host")));
+    assertFalse(masked.contains("s3cr3t"));
+    assertEquals("redis://****@host", masked);
+  }
+
+  @Test
+  public void toStringWithMaskedCredentials_leavesCredentialFreeURIUnchanged()
+      throws URISyntaxException {
+    assertEquals("redis://host:9000/0",
+      toStringWithMaskedCredentials(new URI("redis://host:9000/0")));
+  }
+
+  @Test
   public void isRedisSSLScheme_shouldBeCaseInsensitive() throws URISyntaxException {
     assertTrue(JedisURIHelper.isRedisSSLScheme(new URI("rediss://host:9000")));
     assertTrue(JedisURIHelper.isRedisSSLScheme(new URI("Rediss://host:9000")));


### PR DESCRIPTION
`new Jedis(URI)` given a URI that fails validation:

    InvalidURIException: Cannot open Redis connection due invalid URI "redis://user:s3cr3t@host".

`JedisURIHelper.isValid` rejects the URI (missing port here, and likewise a non-redis scheme), then the message is built from `uri.toString()`, which keeps the raw userinfo. The password travels into whatever logs the exception (CWE-532). Both `Jedis(URI)` constructors and `JedisFactory(URI, ...)` share the shape.

Mask the userinfo in `JedisURIHelper` before it reaches the message, so the diagnostic still carries scheme, host, port and path but not the credentials.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to exception message text on validation failure; connection and auth logic are unchanged, with a small security hardening against credential leakage in logs.
> 
> **Overview**
> **Invalid Redis URI errors no longer leak credentials** when `Jedis` or `JedisFactory` reject a URI. Exception text now uses a masked URI string instead of `uri.toString()`, which previously echoed raw userinfo (username/password) into logs and monitors.
> 
> Adds **`JedisURIHelper.toStringWithMaskedCredentials`**, replacing the userinfo segment with `****@` while keeping scheme, host, port, and path for debugging. Wired into the three existing `InvalidURIException` paths (both `Jedis(URI…)` constructors and `JedisFactory`’s URI constructor). Unit tests cover user+password, password-only userinfo, credential-free URIs, and invalid URIs still passed through the masker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 240052574c211f0515a765885d1523d6a5b24ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->