### PR TITLE
DO NOT MERGE: Change Redis host from '127.0.0.1' to 'localhost'

### DIFF
--- a/src/test/java/redis/clients/jedis/examples/RetryableCommandExecution.java
+++ b/src/test/java/redis/clients/jedis/examples/RetryableCommandExecution.java
@@ -25,7 +25,7 @@ public class RetryableCommandExecution {
   public static void main(String[] args) {
 
     // Connection and pool parameters
-    HostAndPort hostAndPort = new HostAndPort("127.0.0.1", 6379);
+    HostAndPort hostAndPort = new HostAndPort("localhost", 6379);
     JedisClientConfig clientConfig = DefaultJedisClientConfig.builder().user("myuser").password("mypassword").build();
     GenericObjectPoolConfig<Connection> poolConfig = new ConnectionPoolConfig();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-string change in a test example `main`; no production or library behavior impact.
> 
> **Overview**
> Updates the **RetryableCommandExecution** example so `HostAndPort` uses **`"localhost"`** instead of **`"127.0.0.1"`** on port 6379. No other logic, retry settings, or pool configuration changes.
> 
> The PR title marks this as **do not merge**, which suggests it may be intentional for testing or demonstration rather than a desired product change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0273a7446424fbf994b9af08a30ff1ad3f1245e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->