### PR TITLE
[Redis 8.10] Add EXCLUDEEMPTY option to TS.MRANGE / TS.MREVRANGE

### DIFF
--- a/src/main/java/redis/clients/jedis/timeseries/TSMRangeParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSMRangeParams.java
@@ -38,6 +38,8 @@ public class TSMRangeParams implements IParams {
 
   private boolean empty;
 
+  private boolean excludeEmpty;
+
   private String[] filters;
 
   private String groupByLabel;
@@ -209,6 +211,24 @@ public class TSMRangeParams implements IParams {
     return this;
   }
 
+  /**
+   * Omits matching time series with no reported samples for the queried range and options from the
+   * {@code TS.MRANGE} / {@code TS.MREVRANGE} reply by sending the {@code EXCLUDEEMPTY} flag.
+   * <p>
+   * By default, matching series can be returned with an empty samples array. When enabled, a matching
+   * series is returned only when the command reports at least one sample for that series; if every
+   * matching series is empty, the reply is an empty array.
+   * <p>
+   * This flag must not be combined with {@link #groupBy(String, String)}.
+   *
+   * @return this
+   * @since 8.0
+   */
+  public TSMRangeParams excludeEmpty() {
+    this.excludeEmpty = true;
+    return this;
+  }
+
   public TSMRangeParams filter(String... filters) {
     this.filters = filters;
     return this;
@@ -225,6 +245,10 @@ public class TSMRangeParams implements IParams {
 
     if (filters == null) {
       throw new IllegalArgumentException("FILTER arguments must be set.");
+    }
+
+    if (excludeEmpty && groupByLabel != null && groupByReduce != null) {
+      throw new IllegalArgumentException("EXCLUDEEMPTY is not allowed with GROUPBY.");
     }
 
     if (fromTimestamp == null) {
@@ -288,6 +312,10 @@ public class TSMRangeParams implements IParams {
       }
     }
 
+    if (excludeEmpty) {
+      args.add(EXCLUDEEMPTY);
+    }
+
     args.add(FILTER);
     for (String filter : filters) {
       args.add(filter);
@@ -310,6 +338,7 @@ public class TSMRangeParams implements IParams {
     TSMRangeParams that = (TSMRangeParams) o;
     return latest == that.latest && withLabels == that.withLabels &&
         bucketDuration == that.bucketDuration && empty == that.empty &&
+        excludeEmpty == that.excludeEmpty &&
         Objects.equals(fromTimestamp, that.fromTimestamp) &&
         Objects.equals(toTimestamp, that.toTimestamp) &&
         Arrays.equals(filterByTimestamps, that.filterByTimestamps) &&
@@ -338,6 +367,7 @@ public class TSMRangeParams implements IParams {
     result = 31 * result + Long.hashCode(bucketDuration);
     result = 31 * result + Arrays.hashCode(bucketTimestamp);
     result = 31 * result + Boolean.hashCode(empty);
+    result = 31 * result + Boolean.hashCode(excludeEmpty);
     result = 31 * result + Arrays.hashCode(filters);
     result = 31 * result + Objects.hashCode(groupByLabel);
     result = 31 * result + Objects.hashCode(groupByReduce);

--- a/src/main/java/redis/clients/jedis/timeseries/TimeSeriesProtocol.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TimeSeriesProtocol.java
@@ -67,6 +67,7 @@ public class TimeSeriesProtocol {
     DEBUG,
     LATEST,
     EMPTY,
+    EXCLUDEEMPTY,
     BUCKETTIMESTAMP;
 
     private final byte[] raw;

--- a/src/test/java/io/redis/test/utils/RedisVersion.java
+++ b/src/test/java/io/redis/test/utils/RedisVersion.java
@@ -11,6 +11,8 @@ public class RedisVersion implements Comparable<RedisVersion> {
     public static final RedisVersion V8_4_0 = RedisVersion.of("8.4.0");
     public static final RedisVersion V8_6_0 = RedisVersion.of("8.6.0");
     public static final RedisVersion V8_6_1 = RedisVersion.of("8.6.1");
+    public static final String V8_10_0_RC2_STRING = "8.9.241";
+    public static final RedisVersion V8_10_0_RC2 = RedisVersion.of(V8_10_0_RC2_STRING);
 
     private final int major;
     private final int minor;

--- a/src/test/java/redis/clients/jedis/commands/unified/UnifiedJedisCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/UnifiedJedisCommandsTestBase.java
@@ -4,6 +4,7 @@ package redis.clients.jedis.commands.unified;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.BeforeAll;
 import redis.clients.jedis.EndpointConfig;
@@ -14,6 +15,7 @@ import redis.clients.jedis.commands.CommandsTestsParameters;
 import redis.clients.jedis.util.EnabledOnCommandCondition;
 import redis.clients.jedis.util.EnvCondition;
 import redis.clients.jedis.util.RedisVersionCondition;
+import redis.clients.jedis.util.TestKeyRegistry;
 
 @Tag("integration")
 public abstract class UnifiedJedisCommandsTestBase {
@@ -27,6 +29,13 @@ public abstract class UnifiedJedisCommandsTestBase {
   protected final RedisProtocol protocol;
 
   protected UnifiedJedis jedis;
+
+  /**
+   * Per-test registry for unique key names on the shared test endpoints. Keys created via
+   * {@code keys.key(...)} are namespaced by test and deleted automatically after each test;
+   * tests that don't use it are unaffected.
+   */
+  protected TestKeyRegistry keys;
 
   protected static EndpointConfig endpoint;
 
@@ -69,7 +78,8 @@ public abstract class UnifiedJedisCommandsTestBase {
   }
 
   @BeforeEach
-  void setUpBase() {
+  void setUpBase(TestInfo testInfo) {
+    keys = TestKeyRegistry.create(testInfo);
     jedis = createTestClient();
     clearData();
   }
@@ -77,6 +87,7 @@ public abstract class UnifiedJedisCommandsTestBase {
   @AfterEach
   void tearDownBase() {
     if (jedis != null) {
+      keys.cleanup(jedis);
       jedis.close();
     }
   }

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -1,10 +1,11 @@
 package redis.clients.jedis.commands.unified.timeseries;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static redis.clients.jedis.util.AssertUtil.assertEqualsByProtocol;
@@ -1575,5 +1576,134 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
         .filter("kind=mrevrange-multi-no-match"));
     assertNotNull(revRanges);
     assertTrue(revRanges.isEmpty());
+  }
+
+  /**
+   * Sets up the three series used by the EXCLUDEEMPTY examples in the design document. Series
+   * {@code s} and {@code t} have samples inside {@code [-, 500]}; series {@code u} only has a
+   * sample at {@code 2000}, so it is empty for a query bounded at {@code 500}.
+   */
+  private void setupExcludeEmptySeries() {
+    jedis.tsCreate("s",
+      TSCreateParams.createParams().labels(convertMap("sensor", "1", "type", "demo")));
+    jedis.tsCreate("t",
+      TSCreateParams.createParams().labels(convertMap("sensor", "1", "type", "demo")));
+    jedis.tsCreate("u",
+      TSCreateParams.createParams().labels(convertMap("sensor", "1", "type", "demo")));
+
+    jedis.tsAdd("s", 100, 100);
+    jedis.tsAdd("t", 100, 100);
+    jedis.tsAdd("s", 200, 200);
+    jedis.tsAdd("t", 300, 300);
+    jedis.tsAdd("s", 400, 400);
+    jedis.tsAdd("t", 400, 400);
+    jedis.tsAdd("u", 2000, 2000);
+  }
+
+  /**
+   * TS.MRANGE with EXCLUDEEMPTY omits matching series that have no samples in the requested range.
+   * Mirrors the design document success example: series {@code u} is dropped, {@code s} and
+   * {@code t} remain unchanged. The default (include-empty) behavior is asserted first to show the
+   * option is what makes the difference (R.1, NF.3).
+   */
+  @Test
+  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  public void mRangeExcludeEmpty() {
+    setupExcludeEmptySeries();
+
+    // Default: matching series u is still reported, with an empty samples array.
+    Map<String, TSMRangeElements> included = jedis.tsMRange(
+      TSMRangeParams.multiRangeParams().toTimestamp(500L).withLabels().filter("sensor=1"));
+    assertEquals(3, included.size());
+    assertTrue(included.containsKey("u"));
+    assertTrue(included.get("u").getValue().isEmpty());
+
+    // EXCLUDEEMPTY: series u is omitted from the reply; s and t are unchanged.
+    Map<String, TSMRangeElements> excluded = jedis.tsMRange(TSMRangeParams.multiRangeParams()
+        .toTimestamp(500L).withLabels().excludeEmpty().filter("sensor=1"));
+    assertEquals(2, excluded.size());
+    assertFalse(excluded.containsKey("u"));
+    assertEquals(
+      Arrays.asList(new TSElement(100, 100), new TSElement(200, 200), new TSElement(400, 400)),
+      excluded.get("s").getValue());
+    assertEquals(
+      Arrays.asList(new TSElement(100, 100), new TSElement(300, 300), new TSElement(400, 400)),
+      excluded.get("t").getValue());
+  }
+
+  /**
+   * TS.MREVRANGE with EXCLUDEEMPTY omits empty matching series and keeps the reverse sample order
+   * for the series that remain (R.1, R.3).
+   */
+  @Test
+  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  public void mRevRangeExcludeEmpty() {
+    setupExcludeEmptySeries();
+
+    Map<String, TSMRangeElements> excluded = jedis.tsMRevRange(
+      TSMRangeParams.multiRangeParams().toTimestamp(500L).excludeEmpty().filter("sensor=1"));
+    assertEquals(2, excluded.size());
+    assertFalse(excluded.containsKey("u"));
+    // Samples inside each returned series are ordered in reverse timestamp order.
+    assertEquals(
+      Arrays.asList(new TSElement(400, 400), new TSElement(200, 200), new TSElement(100, 100)),
+      excluded.get("s").getValue());
+  }
+
+  /**
+   * EXCLUDEEMPTY composes with AGGREGATION: a matching series with no reported buckets for the
+   * requested range and aggregation is omitted (R.5, NF.2).
+   */
+  @Test
+  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  public void mRangeExcludeEmptyWithAggregation() {
+    setupExcludeEmptySeries();
+
+    Map<String, TSMRangeElements> excluded = jedis
+        .tsMRange(TSMRangeParams.multiRangeParams().toTimestamp(500L).withLabels()
+            .aggregation(AggregationType.MIN, 100L).excludeEmpty().filter("sensor=1"));
+    assertEquals(2, excluded.size());
+    assertFalse(excluded.containsKey("u"));
+  }
+
+  /**
+   * When every matching series is empty, EXCLUDEEMPTY yields an empty top-level reply (R.3).
+   */
+  @Test
+  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  public void mRangeExcludeEmptyAllEmpty() {
+    setupExcludeEmptySeries();
+
+    // No matching series has a sample in [1, 50].
+    Map<String, TSMRangeElements> excluded = jedis
+        .tsMRange(TSMRangeParams.multiRangeParams(1L, 50L).excludeEmpty().filter("sensor=1"));
+    assertNotNull(excluded);
+    assertTrue(excluded.isEmpty());
+  }
+
+  /**
+   * The typed helper API rejects EXCLUDEEMPTY combined with GROUPBY locally, before a command is
+   * sent (R.4).
+   */
+  @Test
+  public void mRangeExcludeEmptyWithGroupByRejectedLocally() {
+    assertThrows(IllegalArgumentException.class, () -> jedis.tsMRange(TSMRangeParams
+        .multiRangeParams(0L, 100L).excludeEmpty().filter("sensor=1").groupBy("type", "max")));
+  }
+
+  /**
+   * A raw TS.MRANGE that combines EXCLUDEEMPTY with GROUPBY must be sent unchanged and the server
+   * error propagated as-is (R.4, R.6).
+   */
+  @Test
+  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  public void rawMRangeExcludeEmptyWithGroupByPropagatesServerError() {
+    setupExcludeEmptySeries();
+
+    JedisDataException error = assertThrows(JedisDataException.class,
+      () -> jedis.sendCommand(TimeSeriesProtocol.TimeSeriesCommand.MRANGE, "-", "500",
+        "EXCLUDEEMPTY", "FILTER", "sensor=1", "GROUPBY", "type", "REDUCE", "max"));
+    assertTrue(error.getMessage().contains("EXCLUDEEMPTY"),
+      "Server error must be propagated as-is, was: " + error.getMessage());
   }
 }

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -1580,26 +1580,33 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
     assertTrue(revRanges.isEmpty());
   }
 
+  private String s, t, u, sensorFilter;
+
   /**
    * Sets up the three series used by the EXCLUDEEMPTY examples in the design document. Series
    * {@code s} and {@code t} have samples inside {@code [-, 500]}; series {@code u} only has a
    * sample at {@code 2000}, so it is empty for a query bounded at {@code 500}.
    */
   private void setupExcludeEmptySeries() {
-    jedis.tsCreate("s",
-      TSCreateParams.createParams().labels(convertMap("sensor", "1", "type", "demo")));
-    jedis.tsCreate("t",
-      TSCreateParams.createParams().labels(convertMap("sensor", "1", "type", "demo")));
-    jedis.tsCreate("u",
-      TSCreateParams.createParams().labels(convertMap("sensor", "1", "type", "demo")));
+    s = keys.key("s");
+    t = keys.key("t");
+    u = keys.key("u");
+    // MRANGE matches by label, so the filter value must be test-unique as well
+    String sensor = keys.key("sensor");
+    sensorFilter = "sensor=" + sensor;
 
-    jedis.tsAdd("s", 100, 100);
-    jedis.tsAdd("t", 100, 100);
-    jedis.tsAdd("s", 200, 200);
-    jedis.tsAdd("t", 300, 300);
-    jedis.tsAdd("s", 400, 400);
-    jedis.tsAdd("t", 400, 400);
-    jedis.tsAdd("u", 2000, 2000);
+    Map<String, String> labels = convertMap("sensor", sensor, "type", "demo");
+    jedis.tsCreate(s, TSCreateParams.createParams().labels(labels));
+    jedis.tsCreate(t, TSCreateParams.createParams().labels(labels));
+    jedis.tsCreate(u, TSCreateParams.createParams().labels(labels));
+
+    jedis.tsAdd(s, 100, 100);
+    jedis.tsAdd(t, 100, 100);
+    jedis.tsAdd(s, 200, 200);
+    jedis.tsAdd(t, 300, 300);
+    jedis.tsAdd(s, 400, 400);
+    jedis.tsAdd(t, 400, 400);
+    jedis.tsAdd(u, 2000, 2000);
   }
 
   /**
@@ -1615,22 +1622,22 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
 
     // Default: matching series u is still reported, with an empty samples array.
     Map<String, TSMRangeElements> included = jedis.tsMRange(
-      TSMRangeParams.multiRangeParams().toTimestamp(500L).withLabels().filter("sensor=1"));
+      TSMRangeParams.multiRangeParams().toTimestamp(500L).withLabels().filter(sensorFilter));
     assertEquals(3, included.size());
-    assertTrue(included.containsKey("u"));
-    assertTrue(included.get("u").getValue().isEmpty());
+    assertTrue(included.containsKey(u));
+    assertTrue(included.get(u).getValue().isEmpty());
 
     // EXCLUDEEMPTY: series u is omitted from the reply; s and t are unchanged.
     Map<String, TSMRangeElements> excluded = jedis.tsMRange(TSMRangeParams.multiRangeParams()
-        .toTimestamp(500L).withLabels().excludeEmpty().filter("sensor=1"));
+        .toTimestamp(500L).withLabels().excludeEmpty().filter(sensorFilter));
     assertEquals(2, excluded.size());
-    assertFalse(excluded.containsKey("u"));
+    assertFalse(excluded.containsKey(u));
     assertEquals(
       Arrays.asList(new TSElement(100, 100), new TSElement(200, 200), new TSElement(400, 400)),
-      excluded.get("s").getValue());
+      excluded.get(s).getValue());
     assertEquals(
       Arrays.asList(new TSElement(100, 100), new TSElement(300, 300), new TSElement(400, 400)),
-      excluded.get("t").getValue());
+      excluded.get(t).getValue());
   }
 
   /**
@@ -1643,13 +1650,13 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
     setupExcludeEmptySeries();
 
     Map<String, TSMRangeElements> excluded = jedis.tsMRevRange(
-      TSMRangeParams.multiRangeParams().toTimestamp(500L).excludeEmpty().filter("sensor=1"));
+      TSMRangeParams.multiRangeParams().toTimestamp(500L).excludeEmpty().filter(sensorFilter));
     assertEquals(2, excluded.size());
-    assertFalse(excluded.containsKey("u"));
+    assertFalse(excluded.containsKey(u));
     // Samples inside each returned series are ordered in reverse timestamp order.
     assertEquals(
       Arrays.asList(new TSElement(400, 400), new TSElement(200, 200), new TSElement(100, 100)),
-      excluded.get("s").getValue());
+      excluded.get(s).getValue());
   }
 
   /**
@@ -1663,9 +1670,9 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
 
     Map<String, TSMRangeElements> excluded = jedis
         .tsMRange(TSMRangeParams.multiRangeParams().toTimestamp(500L).withLabels()
-            .aggregation(AggregationType.MIN, 100L).excludeEmpty().filter("sensor=1"));
+            .aggregation(AggregationType.MIN, 100L).excludeEmpty().filter(sensorFilter));
     assertEquals(2, excluded.size());
-    assertFalse(excluded.containsKey("u"));
+    assertFalse(excluded.containsKey(u));
   }
 
   /**
@@ -1678,7 +1685,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
 
     // No matching series has a sample in [1, 50].
     Map<String, TSMRangeElements> excluded = jedis
-        .tsMRange(TSMRangeParams.multiRangeParams(1L, 50L).excludeEmpty().filter("sensor=1"));
+        .tsMRange(TSMRangeParams.multiRangeParams(1L, 50L).excludeEmpty().filter(sensorFilter));
     assertNotNull(excluded);
     assertTrue(excluded.isEmpty());
   }
@@ -1704,7 +1711,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
 
     JedisDataException error = assertThrows(JedisDataException.class,
       () -> jedis.sendCommand(TimeSeriesProtocol.TimeSeriesCommand.MRANGE, "-", "500",
-        "EXCLUDEEMPTY", "FILTER", "sensor=1", "GROUPBY", "type", "REDUCE", "max"));
+        "EXCLUDEEMPTY", "FILTER", sensorFilter, "GROUPBY", "type", "REDUCE", "max"));
     assertTrue(error.getMessage().contains("EXCLUDEEMPTY"),
       "Server error must be propagated as-is, was: " + error.getMessage());
   }

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static io.redis.test.utils.RedisVersion.V8_10_0_RC2_STRING;
 import static org.junit.jupiter.api.Assertions.fail;
 import static redis.clients.jedis.util.AssertUtil.assertEqualsByProtocol;
 
@@ -1616,7 +1617,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
    * option is what makes the difference (R.1, NF.3).
    */
   @Test
-  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRangeExcludeEmpty() {
     setupExcludeEmptySeries();
 
@@ -1645,7 +1646,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
    * for the series that remain (R.1, R.3).
    */
   @Test
-  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRevRangeExcludeEmpty() {
     setupExcludeEmptySeries();
 
@@ -1664,7 +1665,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
    * requested range and aggregation is omitted (R.5, NF.2).
    */
   @Test
-  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRangeExcludeEmptyWithAggregation() {
     setupExcludeEmptySeries();
 
@@ -1679,7 +1680,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
    * When every matching series is empty, EXCLUDEEMPTY yields an empty top-level reply (R.3).
    */
   @Test
-  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRangeExcludeEmptyAllEmpty() {
     setupExcludeEmptySeries();
 
@@ -1705,7 +1706,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
    * error propagated as-is (R.4, R.6).
    */
   @Test
-  @SinceRedisVersion(value = "8.9.241", message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
+  @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void rawMRangeExcludeEmptyWithGroupByPropagatesServerError() {
     setupExcludeEmptySeries();
 

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -1582,8 +1582,9 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   }
 
   /**
-   * The three series from the EXCLUDEEMPTY design document examples, all matched by
-   * {@link #filter}.
+   * Sets up the three series used by the EXCLUDEEMPTY examples in the design document. Series
+   * {@code s} and {@code t} have samples inside {@code [-, 500]}; series {@code u} only has a
+   * sample at {@code 2000}, so it is empty for a query bounded at {@code 500}.
    */
   private static final class ExcludeEmptyFixture {
     final String seriesS; // samples at 100, 200, 400
@@ -1604,7 +1605,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
     String seriesT = keys.key("t");
     String seriesU = keys.key("u");
     // MRANGE matches by label, so the filter value must be test-unique as well
-    String sensor = keys.key("sensor");
+    String sensor = keys.name("sensor");
 
     Map<String, String> labels = convertMap("sensor", sensor, "type", "demo");
     jedis.tsCreate(seriesS, TSCreateParams.createParams().labels(labels));

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -1581,33 +1581,45 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
     assertTrue(revRanges.isEmpty());
   }
 
-  private String s, t, u, sensorFilter;
-
   /**
-   * Sets up the three series used by the EXCLUDEEMPTY examples in the design document. Series
-   * {@code s} and {@code t} have samples inside {@code [-, 500]}; series {@code u} only has a
-   * sample at {@code 2000}, so it is empty for a query bounded at {@code 500}.
+   * The three series from the EXCLUDEEMPTY design document examples, all matched by
+   * {@link #filter}.
    */
-  private void setupExcludeEmptySeries() {
-    s = keys.key("s");
-    t = keys.key("t");
-    u = keys.key("u");
+  private static final class ExcludeEmptyFixture {
+    final String seriesS; // samples at 100, 200, 400
+    final String seriesT; // samples at 100, 300, 400
+    final String seriesU; // only sample at 2000 — empty for any range bounded at 500
+    final String filter; // label filter matching all three, unique per test
+
+    ExcludeEmptyFixture(String seriesS, String seriesT, String seriesU, String filter) {
+      this.seriesS = seriesS;
+      this.seriesT = seriesT;
+      this.seriesU = seriesU;
+      this.filter = filter;
+    }
+  }
+
+  private ExcludeEmptyFixture setupExcludeEmptyFixture() {
+    String seriesS = keys.key("s");
+    String seriesT = keys.key("t");
+    String seriesU = keys.key("u");
     // MRANGE matches by label, so the filter value must be test-unique as well
     String sensor = keys.key("sensor");
-    sensorFilter = "sensor=" + sensor;
 
     Map<String, String> labels = convertMap("sensor", sensor, "type", "demo");
-    jedis.tsCreate(s, TSCreateParams.createParams().labels(labels));
-    jedis.tsCreate(t, TSCreateParams.createParams().labels(labels));
-    jedis.tsCreate(u, TSCreateParams.createParams().labels(labels));
+    jedis.tsCreate(seriesS, TSCreateParams.createParams().labels(labels));
+    jedis.tsCreate(seriesT, TSCreateParams.createParams().labels(labels));
+    jedis.tsCreate(seriesU, TSCreateParams.createParams().labels(labels));
 
-    jedis.tsAdd(s, 100, 100);
-    jedis.tsAdd(t, 100, 100);
-    jedis.tsAdd(s, 200, 200);
-    jedis.tsAdd(t, 300, 300);
-    jedis.tsAdd(s, 400, 400);
-    jedis.tsAdd(t, 400, 400);
-    jedis.tsAdd(u, 2000, 2000);
+    jedis.tsAdd(seriesS, 100, 100);
+    jedis.tsAdd(seriesT, 100, 100);
+    jedis.tsAdd(seriesS, 200, 200);
+    jedis.tsAdd(seriesT, 300, 300);
+    jedis.tsAdd(seriesS, 400, 400);
+    jedis.tsAdd(seriesT, 400, 400);
+    jedis.tsAdd(seriesU, 2000, 2000);
+
+    return new ExcludeEmptyFixture(seriesS, seriesT, seriesU, "sensor=" + sensor);
   }
 
   /**
@@ -1619,26 +1631,26 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   @Test
   @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRangeExcludeEmpty() {
-    setupExcludeEmptySeries();
+    ExcludeEmptyFixture fixture = setupExcludeEmptyFixture();
 
     // Default: matching series u is still reported, with an empty samples array.
     Map<String, TSMRangeElements> included = jedis.tsMRange(
-      TSMRangeParams.multiRangeParams().toTimestamp(500L).withLabels().filter(sensorFilter));
+      TSMRangeParams.multiRangeParams().toTimestamp(500L).withLabels().filter(fixture.filter));
     assertEquals(3, included.size());
-    assertTrue(included.containsKey(u));
-    assertTrue(included.get(u).getValue().isEmpty());
+    assertTrue(included.containsKey(fixture.seriesU));
+    assertTrue(included.get(fixture.seriesU).getValue().isEmpty());
 
     // EXCLUDEEMPTY: series u is omitted from the reply; s and t are unchanged.
     Map<String, TSMRangeElements> excluded = jedis.tsMRange(TSMRangeParams.multiRangeParams()
-        .toTimestamp(500L).withLabels().excludeEmpty().filter(sensorFilter));
+        .toTimestamp(500L).withLabels().excludeEmpty().filter(fixture.filter));
     assertEquals(2, excluded.size());
-    assertFalse(excluded.containsKey(u));
+    assertFalse(excluded.containsKey(fixture.seriesU));
     assertEquals(
       Arrays.asList(new TSElement(100, 100), new TSElement(200, 200), new TSElement(400, 400)),
-      excluded.get(s).getValue());
+      excluded.get(fixture.seriesS).getValue());
     assertEquals(
       Arrays.asList(new TSElement(100, 100), new TSElement(300, 300), new TSElement(400, 400)),
-      excluded.get(t).getValue());
+      excluded.get(fixture.seriesT).getValue());
   }
 
   /**
@@ -1648,16 +1660,16 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   @Test
   @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRevRangeExcludeEmpty() {
-    setupExcludeEmptySeries();
+    ExcludeEmptyFixture fixture = setupExcludeEmptyFixture();
 
     Map<String, TSMRangeElements> excluded = jedis.tsMRevRange(
-      TSMRangeParams.multiRangeParams().toTimestamp(500L).excludeEmpty().filter(sensorFilter));
+      TSMRangeParams.multiRangeParams().toTimestamp(500L).excludeEmpty().filter(fixture.filter));
     assertEquals(2, excluded.size());
-    assertFalse(excluded.containsKey(u));
+    assertFalse(excluded.containsKey(fixture.seriesU));
     // Samples inside each returned series are ordered in reverse timestamp order.
     assertEquals(
       Arrays.asList(new TSElement(400, 400), new TSElement(200, 200), new TSElement(100, 100)),
-      excluded.get(s).getValue());
+      excluded.get(fixture.seriesS).getValue());
   }
 
   /**
@@ -1667,13 +1679,13 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   @Test
   @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRangeExcludeEmptyWithAggregation() {
-    setupExcludeEmptySeries();
+    ExcludeEmptyFixture fixture = setupExcludeEmptyFixture();
 
     Map<String, TSMRangeElements> excluded = jedis
         .tsMRange(TSMRangeParams.multiRangeParams().toTimestamp(500L).withLabels()
-            .aggregation(AggregationType.MIN, 100L).excludeEmpty().filter(sensorFilter));
+            .aggregation(AggregationType.MIN, 100L).excludeEmpty().filter(fixture.filter));
     assertEquals(2, excluded.size());
-    assertFalse(excluded.containsKey(u));
+    assertFalse(excluded.containsKey(fixture.seriesU));
   }
 
   /**
@@ -1682,11 +1694,11 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   @Test
   @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void mRangeExcludeEmptyAllEmpty() {
-    setupExcludeEmptySeries();
+    ExcludeEmptyFixture fixture = setupExcludeEmptyFixture();
 
     // No matching series has a sample in [1, 50].
     Map<String, TSMRangeElements> excluded = jedis
-        .tsMRange(TSMRangeParams.multiRangeParams(1L, 50L).excludeEmpty().filter(sensorFilter));
+        .tsMRange(TSMRangeParams.multiRangeParams(1L, 50L).excludeEmpty().filter(fixture.filter));
     assertNotNull(excluded);
     assertTrue(excluded.isEmpty());
   }
@@ -1708,11 +1720,11 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   @Test
   @SinceRedisVersion(value = V8_10_0_RC2_STRING, message = "Requires RedisTimeSeries EXCLUDEEMPTY support for TS.MRANGE / TS.MREVRANGE.")
   public void rawMRangeExcludeEmptyWithGroupByPropagatesServerError() {
-    setupExcludeEmptySeries();
+    ExcludeEmptyFixture fixture = setupExcludeEmptyFixture();
 
     JedisDataException error = assertThrows(JedisDataException.class,
       () -> jedis.sendCommand(TimeSeriesProtocol.TimeSeriesCommand.MRANGE, "-", "500",
-        "EXCLUDEEMPTY", "FILTER", sensorFilter, "GROUPBY", "type", "REDUCE", "max"));
+        "EXCLUDEEMPTY", "FILTER", fixture.filter, "GROUPBY", "type", "REDUCE", "max"));
     assertTrue(error.getMessage().contains("EXCLUDEEMPTY"),
       "Server error must be propagated as-is, was: " + error.getMessage());
   }

--- a/src/test/java/redis/clients/jedis/timeseries/TSMRangeParamsTest.java
+++ b/src/test/java/redis/clients/jedis/timeseries/TSMRangeParamsTest.java
@@ -3,11 +3,15 @@ package redis.clients.jedis.timeseries;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static redis.clients.jedis.timeseries.TimeSeriesProtocol.MINUS;
 import static redis.clients.jedis.timeseries.TimeSeriesProtocol.PLUS;
 import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeyword.AGGREGATION;
+import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeyword.EXCLUDEEMPTY;
 import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeyword.FILTER;
+import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeyword.WITHLABELS;
+import static redis.clients.jedis.util.CommandArgumentsMatchers.containsArguments;
 import static redis.clients.jedis.util.CommandArgumentsMatchers.hasArgument;
 import static redis.clients.jedis.util.CommandArgumentsMatchers.hasArgumentCount;
 import static redis.clients.jedis.util.CommandArgumentsMatchers.hasArguments;
@@ -34,6 +38,14 @@ public class TSMRangeParamsTest {
     public void aggregatorsNullElementThrowsException() {
       assertThrows(IllegalArgumentException.class,
         () -> TSMRangeParams.multiRangeParams().aggregation(new AggregationType[] { null }, 1000L));
+    }
+
+    @Test
+    public void excludeEmptyWithGroupByThrowsException() {
+      TSMRangeParams params = TSMRangeParams.multiRangeParams().filter("l=v").excludeEmpty()
+          .groupBy("metric_name", "max");
+      CommandArguments args = new CommandArguments(TimeSeriesCommand.MRANGE);
+      assertThrows(IllegalArgumentException.class, () -> params.addParams(args));
     }
   }
 
@@ -99,6 +111,64 @@ public class TSMRangeParamsTest {
       assertThat(args, hasArguments(TimeSeriesCommand.MRANGE, RawableFactory.from(MINUS),
         RawableFactory.from(PLUS), FILTER, RawableFactory.from("l=v")));
       assertThat(args, not(hasArgument(3, AGGREGATION)));
+    }
+  }
+
+  @Nested
+  class ExcludeEmptyTests {
+
+    @Test
+    public void excludeEmptyEmitsFlagOnceBeforeFilter() {
+      TSMRangeParams params = TSMRangeParams.multiRangeParams().excludeEmpty().filter("sensor=1");
+      CommandArguments args = new CommandArguments(TimeSeriesCommand.MRANGE);
+      params.addParams(args);
+
+      // Expected: TS.MRANGE - + EXCLUDEEMPTY FILTER sensor=1
+      assertThat(args, hasArgumentCount(6));
+      assertThat(args, hasArguments(TimeSeriesCommand.MRANGE, RawableFactory.from(MINUS),
+        RawableFactory.from(PLUS), EXCLUDEEMPTY, FILTER, RawableFactory.from("sensor=1")));
+      // EXCLUDEEMPTY is placed with the range options, immediately before FILTER.
+      assertThat(args, hasArgument(3, EXCLUDEEMPTY));
+    }
+
+    @Test
+    public void noExcludeEmptyFlagWhenUnset() {
+      TSMRangeParams params = TSMRangeParams.multiRangeParams().filter("sensor=1");
+      CommandArguments args = new CommandArguments(TimeSeriesCommand.MRANGE);
+      params.addParams(args);
+
+      // Expected: TS.MRANGE - + FILTER sensor=1 (no EXCLUDEEMPTY)
+      assertThat(args, hasArgumentCount(5));
+      assertThat(args, not(containsArguments(EXCLUDEEMPTY)));
+    }
+
+    @Test
+    public void excludeEmptyComposesWithRangeOptions() {
+      TSMRangeParams params = TSMRangeParams.multiRangeParams(1L, 500L).withLabels()
+          .aggregation(AggregationType.MIN, 100L).excludeEmpty().filter("sensor=1");
+      CommandArguments args = new CommandArguments(TimeSeriesCommand.MRANGE);
+      params.addParams(args);
+
+      // Expected: TS.MRANGE 1 500 WITHLABELS AGGREGATION MIN 100 EXCLUDEEMPTY FILTER sensor=1
+      // EXCLUDEEMPTY composes with the other range options and is emitted once, immediately
+      // before FILTER, after the aggregation clause. The response parser is unchanged.
+      assertThat(args, hasArgumentCount(10));
+      assertThat(args,
+        hasArguments(TimeSeriesCommand.MRANGE, RawableFactory.from(1L), RawableFactory.from(500L),
+          WITHLABELS, AGGREGATION, RawableFactory.from(AggregationType.MIN.getRaw()),
+          RawableFactory.from(100L), EXCLUDEEMPTY, FILTER, RawableFactory.from("sensor=1")));
+    }
+
+    @Test
+    public void excludeEmptyDistinguishesEquality() {
+      TSMRangeParams withExclude = TSMRangeParams.multiRangeParams().excludeEmpty().filter("l=v");
+      TSMRangeParams withoutExclude = TSMRangeParams.multiRangeParams().filter("l=v");
+      assertNotEquals(withExclude, withoutExclude);
+
+      TSMRangeParams withExcludeAgain = TSMRangeParams.multiRangeParams().excludeEmpty()
+          .filter("l=v");
+      assertEquals(withExclude, withExcludeAgain);
+      assertEquals(withExclude.hashCode(), withExcludeAgain.hashCode());
     }
   }
 }

--- a/src/test/java/redis/clients/jedis/util/TestKeyRegistry.java
+++ b/src/test/java/redis/clients/jedis/util/TestKeyRegistry.java
@@ -74,6 +74,13 @@ public interface TestKeyRegistry {
    */
   byte[] bKey(String pattern);
 
+  /**
+   * Returns a test-unique name derived from the given pattern (same rules as {@link #key(String)})
+   * without registering it for cleanup. For resources that are not Redis keys — label values, group
+   * or consumer names — or keys whose cleanup is handled elsewhere.
+   */
+  String name(String pattern);
+
   /** Registers an externally-created key for cleanup and returns it. Duplicates are ignored. */
   String register(String key);
 
@@ -120,6 +127,11 @@ public interface TestKeyRegistry {
     @Override
     public byte[] bKey(String pattern) {
       return register(SafeEncoder.encode(expand(pattern)));
+    }
+
+    @Override
+    public String name(String pattern) {
+      return expand(pattern);
     }
 
     @Override


### PR DESCRIPTION
## Summary
Adds support for the RedisTimeSeries `EXCLUDEEMPTY` flag to `TSMRangeParams` via a new
`excludeEmpty()` builder method. When set, matching series that report no samples for the
queried range are omitted from the `TS.MRANGE` / `TS.MREVRANGE` reply instead of being
returned with an empty samples array.

## Key Decisions & Assumptions
- The flag is emitted once, with the range options and immediately before `FILTER`, so it
  composes with existing options (`WITHLABELS`, `AGGREGATION`, etc.). The response parser is
  unchanged — an empty reply simply carries fewer (or zero) series.
- `EXCLUDEEMPTY` cannot be combined with `GROUPBY`. The typed helper rejects this
  combination locally with an `IllegalArgumentException` before sending a command; a raw
  request that combines them is still sent unchanged and left for the server to reject.
- Requires server-side support (RedisTimeSeries, Redis 8.9.241+); annotated `@since 8.0`.

## Behavioral / Conceptual Changes
- `excludeEmpty()` now emits the `EXCLUDEEMPTY` keyword; without it, behavior is unchanged.
- `equals`/`hashCode` on `TSMRangeParams` now account for the new flag, so two params
  differing only by `excludeEmpty` are no longer considered equal.

## Testing
Unit tests cover flag emission and ordering (once, before `FILTER`), composition with other
range options, absence when unset, equality/hashCode distinction, and local rejection of the
`EXCLUDEEMPTY` + `GROUPBY` combination. Integration tests verify that empty series are omitted
from `TS.MRANGE` and `TS.MREVRANGE` (order preserved), composition with `AGGREGATION`, an
all-empty result yielding an empty top-level reply, and that a raw `GROUPBY` combination
propagates the server error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and command encoding for an optional flag; behavior is unchanged unless `excludeEmpty()` is used, with a clear client-side guard against invalid GROUPBY pairing.
> 
> **Overview**
> Adds RedisTimeSeries **`EXCLUDEEMPTY`** support for **`TS.MRANGE`** / **`TS.MREVRANGE`** via a new **`excludeEmpty()`** builder on **`TSMRangeParams`**, which emits the **`EXCLUDEEMPTY`** keyword once (before **`FILTER`**) so matching series with no samples in the queried range are omitted instead of returned with empty sample arrays.
> 
> **`EXCLUDEEMPTY`** + **`GROUPBY`** is rejected in **`addParams`** with **`IllegalArgumentException`**; **`equals`/`hashCode`** now include the flag. **`TimeSeriesProtocol`** gains the **`EXCLUDEEMPTY`** keyword.
> 
> Tests add wire-format and validation coverage, integration scenarios (including aggregation and raw server errors), a **`V8_10_0_RC2`** version constant, **`TestKeyRegistry.name()`** for unique label filters, and per-test key cleanup in **`UnifiedJedisCommandsTestBase`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bec2dec2f308043f4db6a08d48cd151b390fed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->