### PR TITLE
 [Redis 8.10] Add support for the TS.READ time series command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -596,6 +596,7 @@
                         <include>src/test/java/redis/clients/jedis/commands/unified/**bloom/*.java</include>
                         <include>src/test/java/redis/clients/jedis/commands/unified/**json/*.java</include>
                         <include>src/test/java/redis/clients/jedis/commands/unified/**timeseries/*.java</include>
+                        <include>src/main/java/redis/clients/jedis/timeseries/TSReadParams.java</include>
                         <include>src/test/java/redis/clients/jedis/**/search/*.java</include>
 
 						<include>**/RespProtocol.java</include>

--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -4671,6 +4671,19 @@ public class CommandObjects {
         .addParams(rangeParams), TimeSeriesBuilderFactory.TIMESERIES_ELEMENT_LIST);
   }
 
+  public final CommandObject<List<TSElement>> tsRead(String key, long timestamp) {
+    return new CommandObject<>(commandArguments(TimeSeriesCommand.READ).key(key)
+        .add(timestamp), TimeSeriesBuilderFactory.TIMESERIES_ELEMENT_LIST);
+  }
+
+  public final CommandObject<List<TSElement>> tsRead(String key, TSReadParams readParams) {
+    CommandArguments args = commandArguments(TimeSeriesCommand.READ).key(key).addParams(readParams);
+    if (readParams.isBlocking()) {
+      args.blocking();
+    }
+    return new CommandObject<>(args, TimeSeriesBuilderFactory.TIMESERIES_ELEMENT_LIST);
+  }
+
   public final CommandObject<Map<String, TSMRangeElements>> tsMRange(long fromTimestamp, long toTimestamp, String... filters) {
     return new CommandObject<>(commandArguments(TimeSeriesCommand.MRANGE).add(fromTimestamp)
         .add(toTimestamp).add(TimeSeriesKeyword.FILTER).addObjects((Object[]) filters),

--- a/src/main/java/redis/clients/jedis/PipeliningBase.java
+++ b/src/main/java/redis/clients/jedis/PipeliningBase.java
@@ -4678,6 +4678,16 @@ public abstract class PipeliningBase
   }
 
   @Override
+  public Response<List<TSElement>> tsRead(String key, long timestamp) {
+    return appendCommand(commandObjects.tsRead(key, timestamp));
+  }
+
+  @Override
+  public Response<List<TSElement>> tsRead(String key, TSReadParams readParams) {
+    return appendCommand(commandObjects.tsRead(key, readParams));
+  }
+
+  @Override
   public Response<Map<String, TSMRangeElements>> tsMRange(long fromTimestamp, long toTimestamp, String... filters) {
     return appendCommand(commandObjects.tsMRange(fromTimestamp, toTimestamp, filters));
   }

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -5459,6 +5459,16 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   @Override
+  public List<TSElement> tsRead(String key, long timestamp) {
+    return executeCommand(commandObjects.tsRead(key, timestamp));
+  }
+
+  @Override
+  public List<TSElement> tsRead(String key, TSReadParams readParams) {
+    return executeCommand(commandObjects.tsRead(key, readParams));
+  }
+
+  @Override
   public Map<String, TSMRangeElements> tsMRange(long fromTimestamp, long toTimestamp, String... filters) {
     return executeCommand(commandObjects.tsMRange(fromTimestamp, toTimestamp, filters));
   }

--- a/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesCommands.java
+++ b/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesCommands.java
@@ -185,6 +185,35 @@ public interface RedisTimeSeriesCommands {
   List<TSElement> tsRevRange(String key, TSRangeParams rangeParams);
 
   /**
+   * {@code TS.READ key timestamp}
+   * <p>
+   * Non-blocking read of up to unlimited samples with timestamp greater than or equal to the given
+   * literal cursor, in ascending timestamp order. An empty list is a successful reply.
+   *
+   * @param key the time series key
+   * @param timestamp inclusive literal cursor (non-negative Unix milliseconds; {@code 0} reads from
+   *          the beginning)
+   * @return samples with timestamp {@code >= timestamp}
+   * @since 8.0
+   */
+  List<TSElement> tsRead(String key, long timestamp);
+
+  /**
+   * {@code TS.READ key timestamp [BLOCK milliseconds min_count] [MAX_COUNT max_count]}
+   * <p>
+   * Returns up to {@code max_count} samples with timestamp greater than or equal to the cursor, in
+   * ascending timestamp order. With {@code BLOCK} the call waits until at least {@code min_count}
+   * qualifying samples exist or until the timeout elapses; without it the call returns immediately.
+   * An empty list is a successful reply, including when a blocking call times out.
+   *
+   * @param key the time series key
+   * @param readParams the cursor and optional {@code BLOCK} / {@code MAX_COUNT} arguments
+   * @return samples with timestamp {@code >=} the resolved cursor
+   * @since 8.0
+   */
+  List<TSElement> tsRead(String key, TSReadParams readParams);
+
+  /**
    * {@code TS.MRANGE fromTimestamp toTimestamp FILTER filter...}
    *
    * @param fromTimestamp

--- a/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesPipelineCommands.java
+++ b/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesPipelineCommands.java
@@ -45,6 +45,10 @@ public interface RedisTimeSeriesPipelineCommands {
 
   Response<List<TSElement>> tsRevRange(String key, TSRangeParams rangeParams);
 
+  Response<List<TSElement>> tsRead(String key, long timestamp);
+
+  Response<List<TSElement>> tsRead(String key, TSReadParams readParams);
+
   Response<Map<String, TSMRangeElements>> tsMRange(long fromTimestamp, long toTimestamp, String... filters);
 
   Response<Map<String, TSMRangeElements>> tsMRange(TSMRangeParams multiRangeParams);

--- a/src/main/java/redis/clients/jedis/timeseries/TSReadParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSReadParams.java
@@ -1,0 +1,164 @@
+package redis.clients.jedis.timeseries;
+
+import static redis.clients.jedis.Protocol.toByteArray;
+import static redis.clients.jedis.timeseries.TimeSeriesProtocol.DOLLAR;
+import static redis.clients.jedis.timeseries.TimeSeriesProtocol.MINUS;
+import static redis.clients.jedis.timeseries.TimeSeriesProtocol.PLUS;
+import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeyword.BLOCK;
+import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeyword.MAX_COUNT;
+
+import java.util.Arrays;
+import java.util.Objects;
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.params.IParams;
+
+/**
+ * Represents the cursor and optional arguments of the {@code TS.READ} command.
+ * <p>
+ * Wire shape: {@code TS.READ key timestamp [BLOCK milliseconds min_count] [MAX_COUNT max_count]}.
+ * The cursor selects samples whose timestamp is greater than or equal to it, in ascending timestamp
+ * order. It is either a non-negative literal (Unix milliseconds) or one of the sentinels {@code -}
+ * (earliest), {@code +} (latest existing sample, inclusive) or {@code $} (only samples added after
+ * the call). The sentinels are sent as-is and resolved by the server.
+ * <p>
+ * The {@code BLOCK} group is all-or-nothing: whenever blocking is requested both
+ * {@code milliseconds} and {@code minCount} are emitted. {@code BLOCK 0} waits indefinitely.
+ * @since 8.0
+ */
+public class TSReadParams implements IParams {
+
+  // Cursor bytes; defaults to earliest ("-") when left unset.
+  private byte[] timestamp = MINUS;
+
+  private Long blockMilliseconds;
+  private Integer blockMinCount;
+
+  private Integer maxCount;
+
+  public TSReadParams() {
+  }
+
+  public static TSReadParams readParams() {
+    return new TSReadParams();
+  }
+
+  /**
+   * Literal cursor: samples with {@code sample_timestamp >= timestamp} qualify. {@code 0} reads
+   * from the beginning. Negative values are rejected by the server.
+   */
+  public TSReadParams timestamp(long timestamp) {
+    this.timestamp = toByteArray(timestamp);
+    return this;
+  }
+
+  /**
+   * Cursor sentinel {@code -}: no lower bound, read from the earliest sample.
+   */
+  public TSReadParams earliest() {
+    this.timestamp = MINUS;
+    return this;
+  }
+
+  /**
+   * Cursor sentinel {@code +}: the latest existing sample's timestamp, inclusive. On an empty or
+   * missing series it resolves to {@code 0}.
+   */
+  public TSReadParams latest() {
+    this.timestamp = PLUS;
+    return this;
+  }
+
+  /**
+   * Cursor sentinel {@code $}: the latest sample's timestamp + 1, so only samples added after the
+   * command is received qualify. Meaningful only together with {@link #block(long, int)}; without
+   * blocking it always yields an empty reply.
+   */
+  public TSReadParams newSamples() {
+    this.timestamp = DOLLAR;
+    return this;
+  }
+
+  /**
+   * Opt into blocking. Both values are always emitted on the wire inside the {@code BLOCK} group.
+   * @param milliseconds maximum wait, non-negative; {@code 0} means wait indefinitely
+   * @param minCount unblock threshold, positive; the call returns once this many samples qualify
+   * @return this
+   */
+  public TSReadParams block(long milliseconds, int minCount) {
+    if (milliseconds < 0) {
+      throw new IllegalArgumentException("BLOCK milliseconds must be a non-negative integer");
+    }
+    if (minCount <= 0) {
+      throw new IllegalArgumentException("BLOCK min_count must be a positive integer");
+    }
+    this.blockMilliseconds = milliseconds;
+    this.blockMinCount = minCount;
+    return this;
+  }
+
+  /**
+   * Reply cap. When more samples qualify than {@code maxCount}, the oldest {@code maxCount} are
+   * returned so callers can page forward. Omitted means unlimited.
+   * @param maxCount positive integer
+   * @return this
+   */
+  public TSReadParams maxCount(int maxCount) {
+    if (maxCount <= 0) {
+      throw new IllegalArgumentException("MAX_COUNT must be a positive integer");
+    }
+    this.maxCount = maxCount;
+    return this;
+  }
+
+  /**
+   * @return true when the {@code BLOCK} group is present, so the command must be issued with
+   *         blocking-command connection handling
+   */
+  public boolean isBlocking() {
+    return blockMilliseconds != null;
+  }
+
+  @Override
+  public void addParams(CommandArguments args) {
+
+    // min_count <= max_count is required by the server when both are set; validate locally too.
+    if (blockMinCount != null && maxCount != null && blockMinCount > maxCount) {
+      throw new IllegalArgumentException("BLOCK min_count must be <= MAX_COUNT");
+    }
+
+    args.add(timestamp);
+
+    if (blockMilliseconds != null) {
+      args.add(BLOCK).add(toByteArray(blockMilliseconds)).add(toByteArray(blockMinCount));
+    }
+
+    if (maxCount != null) {
+      args.add(MAX_COUNT).add(toByteArray(maxCount));
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TSReadParams that = (TSReadParams) o;
+    return Arrays.equals(timestamp, that.timestamp)
+        && Objects.equals(blockMilliseconds, that.blockMilliseconds)
+        && Objects.equals(blockMinCount, that.blockMinCount)
+        && Objects.equals(maxCount, that.maxCount);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Arrays.hashCode(timestamp);
+    result = 31 * result + Objects.hashCode(blockMilliseconds);
+    result = 31 * result + Objects.hashCode(blockMinCount);
+    result = 31 * result + Objects.hashCode(maxCount);
+    return result;
+  }
+}

--- a/src/main/java/redis/clients/jedis/timeseries/TimeSeriesProtocol.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TimeSeriesProtocol.java
@@ -8,10 +8,12 @@ public class TimeSeriesProtocol {
 
   public static final byte[] PLUS = SafeEncoder.encode("+");
   public static final byte[] MINUS = SafeEncoder.encode("-");
+  public static final byte[] DOLLAR = SafeEncoder.encode("$");
 
   public enum TimeSeriesCommand implements ProtocolCommand {
 
     CREATE("TS.CREATE"),
+    READ("TS.READ"),
     RANGE("TS.RANGE"),
     REVRANGE("TS.REVRANGE"),
     MRANGE("TS.MRANGE"),
@@ -67,7 +69,9 @@ public class TimeSeriesProtocol {
     DEBUG,
     LATEST,
     EMPTY,
-    BUCKETTIMESTAMP;
+    BUCKETTIMESTAMP,
+    BLOCK,
+    MAX_COUNT;
 
     private final byte[] raw;
 

--- a/src/test/java/redis/clients/jedis/commands/unified/cluster/timeseries/TimeSeriesClusterCommandsIT.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/cluster/timeseries/TimeSeriesClusterCommandsIT.java
@@ -109,4 +109,12 @@ public class TimeSeriesClusterCommandsIT extends TimeSeriesCommandsTestBase {
   public void mRevRangeMultipleAggregatorsEmptyResult() {
   }
 
+  // The producer client obtained via createTestClient() flushes the cluster on creation
+  // (getCleanCluster), which removes the key and wakes the blocked reader with an empty reply.
+  // The blocking-wake behavior is fully covered by the standalone runner.
+  @Disabled("Second cluster client flushes the cluster, waking the blocked reader")
+  @Override
+  public void readBlockingWakesOnAppend() {
+  }
+
 }

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static redis.clients.jedis.util.AssertUtil.assertEqualsByProtocol;
@@ -12,6 +13,7 @@ import static redis.clients.jedis.util.AssertUtil.assertEqualsByProtocol;
 import java.util.*;
 
 import io.redis.test.annotations.ConditionalOnEnv;
+import io.redis.test.annotations.EnabledOnCommand;
 import io.redis.test.annotations.SinceRedisVersion;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import org.junit.jupiter.api.Tag;
 
 import redis.clients.jedis.Endpoints;
 import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.commands.unified.UnifiedJedisCommandsTestBase;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.timeseries.*;
@@ -1575,5 +1578,149 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
         .filter("kind=mrevrange-multi-no-match"));
     assertNotNull(revRanges);
     assertTrue(revRanges.isEmpty());
+  }
+
+  /**
+   * Non-blocking TS.READ returns samples with timestamp {@code >=} the cursor, ascending; a cursor
+   * past the newest sample and a missing key both return an empty list, not an error.
+   */
+  @Test
+  @EnabledOnCommand("TS.READ")
+  public void read() {
+    jedis.tsCreate("read-series");
+    assertEquals(100L, jedis.tsAdd("read-series", 100L, 1.0));
+    assertEquals(200L, jedis.tsAdd("read-series", 200L, 2.0));
+    assertEquals(300L, jedis.tsAdd("read-series", 300L, 3.0));
+
+    List<TSElement> all = jedis.tsRead("read-series", 0L);
+    assertEquals(
+      Arrays.asList(new TSElement(100L, 1.0), new TSElement(200L, 2.0), new TSElement(300L, 3.0)),
+      all);
+
+    // A cursor after the newest sample yields an empty list.
+    assertTrue(jedis.tsRead("read-series", 301L).isEmpty());
+
+    // Missing key is not an error; it returns an empty list.
+    assertTrue(jedis.tsRead("read-missing", 0L).isEmpty());
+  }
+
+  /**
+   * MAX_COUNT caps the reply to the oldest N samples, enabling cursor-based paging with
+   * {@code lastTimestamp + 1}.
+   */
+  @Test
+  @EnabledOnCommand("TS.READ")
+  public void readPagingWithMaxCount() {
+    jedis.tsCreate("read-page");
+    jedis.tsAdd("read-page", 100L, 1.0);
+    jedis.tsAdd("read-page", 200L, 2.0);
+    jedis.tsAdd("read-page", 300L, 3.0);
+
+    List<TSElement> page1 = jedis.tsRead("read-page",
+      TSReadParams.readParams().earliest().maxCount(2));
+    assertEquals(Arrays.asList(new TSElement(100L, 1.0), new TSElement(200L, 2.0)), page1);
+
+    long next = page1.get(page1.size() - 1).getTimestamp() + 1;
+    List<TSElement> page2 = jedis.tsRead("read-page",
+      TSReadParams.readParams().timestamp(next).maxCount(2));
+    assertEquals(Collections.singletonList(new TSElement(300L, 3.0)), page2);
+  }
+
+  /**
+   * The {@code +} sentinel resolves to the latest existing sample, inclusive, so it is returned
+   * even without BLOCK; the {@code $} sentinel excludes all existing samples, so without BLOCK it
+   * yields an empty list.
+   */
+  @Test
+  @EnabledOnCommand("TS.READ")
+  public void readSentinels() {
+    jedis.tsCreate("read-sentinel");
+    jedis.tsAdd("read-sentinel", 100L, 1.0);
+    jedis.tsAdd("read-sentinel", 300L, 3.0);
+
+    assertEquals(Collections.singletonList(new TSElement(300L, 3.0)),
+      jedis.tsRead("read-sentinel", TSReadParams.readParams().latest()));
+
+    assertTrue(jedis.tsRead("read-sentinel", TSReadParams.readParams().newSamples()).isEmpty());
+  }
+
+  /**
+   * A blocking call whose {@code min_count} threshold cannot be reached returns the samples that
+   * are available once the timeout elapses (a successful, possibly-partial reply).
+   */
+  @Test
+  @EnabledOnCommand("TS.READ")
+  public void readBlockingTimeoutFlush() {
+    jedis.tsCreate("read-block");
+    jedis.tsAdd("read-block", 100L, 1.0);
+    jedis.tsAdd("read-block", 200L, 2.0);
+    jedis.tsAdd("read-block", 300L, 3.0);
+
+    // min_count 10 can never be met; after 500ms the two qualifying samples flush out.
+    List<TSElement> samples = jedis.tsRead("read-block",
+      TSReadParams.readParams().timestamp(101L).block(500L, 10));
+    assertEquals(Arrays.asList(new TSElement(200L, 2.0), new TSElement(300L, 3.0)), samples);
+  }
+
+  /**
+   * A blocking call returns immediately, without waiting, when {@code min_count} qualifying samples
+   * already exist at execution time.
+   */
+  @Test
+  @EnabledOnCommand("TS.READ")
+  public void readBlockingReturnsImmediatelyWhenThresholdMet() {
+    jedis.tsCreate("read-block-now");
+    jedis.tsAdd("read-block-now", 100L, 1.0);
+    jedis.tsAdd("read-block-now", 200L, 2.0);
+
+    List<TSElement> samples = jedis.tsRead("read-block-now",
+      TSReadParams.readParams().earliest().block(0L, 2));
+    assertEquals(Arrays.asList(new TSElement(100L, 1.0), new TSElement(200L, 2.0)), samples);
+  }
+
+  /**
+   * A client blocked on {@code $} wakes and returns a sample appended by another connection while
+   * it waits.
+   */
+  @Test
+  @EnabledOnCommand("TS.READ")
+  public void readBlockingWakesOnAppend() throws InterruptedException {
+    jedis.tsCreate("read-tail");
+    jedis.tsAdd("read-tail", 100L, 1.0);
+
+    Thread producer = new Thread(() -> {
+      try (UnifiedJedis other = createTestClient()) {
+        Thread.sleep(300L);
+        other.tsAdd("read-tail", 200L, 2.0);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    });
+    producer.start();
+
+    // Blocks on $ (only samples added after the call) until the producer appends 200.
+    List<TSElement> samples = jedis.tsRead("read-tail",
+      TSReadParams.readParams().newSamples().block(5000L, 1));
+    producer.join();
+
+    assertEquals(Collections.singletonList(new TSElement(200L, 2.0)), samples);
+  }
+
+  /**
+   * Server-side errors (invalid cursor, wrong key type) must be propagated as-is.
+   */
+  @Test
+  @EnabledOnCommand("TS.READ")
+  public void readErrorsPropagate() {
+    jedis.tsCreate("read-err");
+    jedis.tsAdd("read-err", 100L, 1.0);
+
+    // Negative literal cursor is rejected by the server.
+    assertThrows(JedisDataException.class,
+      () -> jedis.tsRead("read-err", TSReadParams.readParams().timestamp(-1L)));
+
+    // Reading a key that holds a non-timeseries value is a WRONGTYPE error.
+    jedis.set("read-str", "not a series");
+    assertThrows(JedisDataException.class, () -> jedis.tsRead("read-str", 0L));
   }
 }

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -1656,9 +1656,9 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
     jedis.tsAdd("read-block", 200L, 2.0);
     jedis.tsAdd("read-block", 300L, 3.0);
 
-    // min_count 10 can never be met; after 500ms the two qualifying samples flush out.
+    // min_count 10 can never be met; after 10ms the two qualifying samples flush out.
     List<TSElement> samples = jedis.tsRead("read-block",
-      TSReadParams.readParams().timestamp(101L).block(500L, 10));
+      TSReadParams.readParams().timestamp(101L).block(10L, 10));
     assertEquals(Arrays.asList(new TSElement(200L, 2.0), new TSElement(300L, 3.0)), samples);
   }
 

--- a/src/test/java/redis/clients/jedis/mocked/pipeline/PipeliningBaseTimeSeriesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/mocked/pipeline/PipeliningBaseTimeSeriesCommandsTest.java
@@ -375,4 +375,26 @@ public class PipeliningBaseTimeSeriesCommandsTest extends PipeliningBaseMockedTe
     assertThat(response, is(predefinedResponse));
   }
 
+  @Test
+  public void testTsRead() {
+    when(commandObjects.tsRead("myTimeSeries", 0L)).thenReturn(listTsElementCommandObject);
+
+    Response<List<TSElement>> response = pipeliningBase.tsRead("myTimeSeries", 0L);
+
+    assertThat(commands, contains(listTsElementCommandObject));
+    assertThat(response, is(predefinedResponse));
+  }
+
+  @Test
+  public void testTsReadWithParams() {
+    TSReadParams readParams = TSReadParams.readParams().timestamp(101L).block(1000L, 1);
+
+    when(commandObjects.tsRead("myTimeSeries", readParams)).thenReturn(listTsElementCommandObject);
+
+    Response<List<TSElement>> response = pipeliningBase.tsRead("myTimeSeries", readParams);
+
+    assertThat(commands, contains(listTsElementCommandObject));
+    assertThat(response, is(predefinedResponse));
+  }
+
 }

--- a/src/test/java/redis/clients/jedis/mocked/unified/UnifiedJedisTimeSeriesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/mocked/unified/UnifiedJedisTimeSeriesCommandsTest.java
@@ -580,4 +580,40 @@ public class UnifiedJedisTimeSeriesCommandsTest extends UnifiedJedisMockedTestBa
     verify(commandObjects).tsRevRange(key, rangeParams);
   }
 
+  @Test
+  public void testTsRead() {
+    String key = "testKey";
+    long timestamp = 0L;
+    List<TSElement> expectedResponse = Arrays.asList(
+        new TSElement(100L, 1.0),
+        new TSElement(200L, 2.0));
+
+    when(commandObjects.tsRead(key, timestamp)).thenReturn(listTsElementCommandObject);
+    when(commandExecutor.executeCommand(listTsElementCommandObject)).thenReturn(expectedResponse);
+
+    List<TSElement> result = jedis.tsRead(key, timestamp);
+
+    assertEquals(expectedResponse, result);
+
+    verify(commandExecutor).executeCommand(listTsElementCommandObject);
+    verify(commandObjects).tsRead(key, timestamp);
+  }
+
+  @Test
+  public void testTsReadWithParams() {
+    String key = "testKey";
+    TSReadParams readParams = TSReadParams.readParams().timestamp(101L).block(1000L, 1).maxCount(10);
+    List<TSElement> expectedResponse = Collections.singletonList(new TSElement(200L, 2.0));
+
+    when(commandObjects.tsRead(key, readParams)).thenReturn(listTsElementCommandObject);
+    when(commandExecutor.executeCommand(listTsElementCommandObject)).thenReturn(expectedResponse);
+
+    List<TSElement> result = jedis.tsRead(key, readParams);
+
+    assertEquals(expectedResponse, result);
+
+    verify(commandExecutor).executeCommand(listTsElementCommandObject);
+    verify(commandObjects).tsRead(key, readParams);
+  }
+
 }

--- a/src/test/java/redis/clients/jedis/timeseries/TSReadParamsTest.java
+++ b/src/test/java/redis/clients/jedis/timeseries/TSReadParamsTest.java
@@ -1,0 +1,181 @@
+package redis.clients.jedis.timeseries;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static redis.clients.jedis.timeseries.TimeSeriesProtocol.DOLLAR;
+import static redis.clients.jedis.timeseries.TimeSeriesProtocol.MINUS;
+import static redis.clients.jedis.timeseries.TimeSeriesProtocol.PLUS;
+import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeyword.BLOCK;
+import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeyword.MAX_COUNT;
+import static redis.clients.jedis.util.CommandArgumentsMatchers.hasArgumentCount;
+import static redis.clients.jedis.util.CommandArgumentsMatchers.hasArguments;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.args.RawableFactory;
+import redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesCommand;
+
+public class TSReadParamsTest {
+
+  private static CommandArguments args() {
+    return new CommandArguments(TimeSeriesCommand.READ);
+  }
+
+  @Nested
+  class ValidationTests {
+
+    @Test
+    public void negativeBlockMillisecondsThrowsException() {
+      assertThrows(IllegalArgumentException.class, () -> TSReadParams.readParams().block(-1L, 1));
+    }
+
+    @Test
+    public void zeroBlockMillisecondsIsAllowed() {
+      // BLOCK 0 means "wait indefinitely" and must be supported.
+      assertTrue(TSReadParams.readParams().block(0L, 1).isBlocking());
+    }
+
+    @Test
+    public void nonPositiveBlockMinCountThrowsException() {
+      assertThrows(IllegalArgumentException.class, () -> TSReadParams.readParams().block(1000L, 0));
+      assertThrows(IllegalArgumentException.class,
+        () -> TSReadParams.readParams().block(1000L, -3));
+    }
+
+    @Test
+    public void nonPositiveMaxCountThrowsException() {
+      assertThrows(IllegalArgumentException.class, () -> TSReadParams.readParams().maxCount(0));
+      assertThrows(IllegalArgumentException.class, () -> TSReadParams.readParams().maxCount(-2));
+    }
+
+    @Test
+    public void minCountGreaterThanMaxCountThrowsAtSerialization() {
+      TSReadParams params = TSReadParams.readParams().block(1000L, 5).maxCount(2);
+      assertThrows(IllegalArgumentException.class, () -> params.addParams(args()));
+    }
+  }
+
+  @Nested
+  class BlockingClassificationTests {
+
+    @Test
+    public void notBlockingByDefault() {
+      assertFalse(TSReadParams.readParams().isBlocking());
+      assertFalse(TSReadParams.readParams().timestamp(100L).maxCount(10).isBlocking());
+    }
+
+    @Test
+    public void blockingWhenBlockGroupPresent() {
+      assertTrue(TSReadParams.readParams().block(1000L, 1).isBlocking());
+    }
+  }
+
+  @Nested
+  class AddParamsTests {
+
+    @Test
+    public void defaultsToEarliestCursor() {
+      TSReadParams params = TSReadParams.readParams();
+      CommandArguments args = args();
+      params.addParams(args);
+
+      // Expected: TS.READ -
+      assertThat(args, hasArgumentCount(2));
+      assertThat(args, hasArguments(TimeSeriesCommand.READ, RawableFactory.from(MINUS)));
+    }
+
+    @Test
+    public void literalCursorZeroIsEmitted() {
+      TSReadParams params = TSReadParams.readParams().timestamp(0L);
+      CommandArguments args = args();
+      params.addParams(args);
+
+      // Expected: TS.READ 0
+      assertThat(args, hasArgumentCount(2));
+      assertThat(args, hasArguments(TimeSeriesCommand.READ, RawableFactory.from(0L)));
+    }
+
+    @Test
+    public void latestSentinel() {
+      CommandArguments args = args();
+      TSReadParams.readParams().latest().addParams(args);
+
+      // Expected: TS.READ +
+      assertThat(args, hasArgumentCount(2));
+      assertThat(args, hasArguments(TimeSeriesCommand.READ, RawableFactory.from(PLUS)));
+    }
+
+    @Test
+    public void newSamplesSentinel() {
+      CommandArguments args = args();
+      TSReadParams.readParams().newSamples().addParams(args);
+
+      // Expected: TS.READ $
+      assertThat(args, hasArgumentCount(2));
+      assertThat(args, hasArguments(TimeSeriesCommand.READ, RawableFactory.from(DOLLAR)));
+    }
+
+    @Test
+    public void blockGroupEmitsKeywordAndBothValues() {
+      CommandArguments args = args();
+      TSReadParams.readParams().timestamp(101L).block(1000L, 10).addParams(args);
+
+      // Expected: TS.READ 101 BLOCK 1000 10
+      assertThat(args, hasArgumentCount(5));
+      assertThat(args, hasArguments(TimeSeriesCommand.READ, RawableFactory.from(101L), BLOCK,
+        RawableFactory.from(1000L), RawableFactory.from(10L)));
+    }
+
+    @Test
+    public void maxCountEmitsKeywordAndValue() {
+      CommandArguments args = args();
+      TSReadParams.readParams().timestamp(200L).maxCount(2).addParams(args);
+
+      // Expected: TS.READ 200 MAX_COUNT 2
+      assertThat(args, hasArgumentCount(4));
+      assertThat(args, hasArguments(TimeSeriesCommand.READ, RawableFactory.from(200L), MAX_COUNT,
+        RawableFactory.from(2L)));
+    }
+
+    @Test
+    public void canonicalOrderBlockBeforeMaxCount() {
+      CommandArguments args = args();
+      TSReadParams.readParams().newSamples().block(5000L, 1).maxCount(100).addParams(args);
+
+      // Expected: TS.READ $ BLOCK 5000 1 MAX_COUNT 100
+      assertThat(args, hasArgumentCount(7));
+      assertThat(args, hasArguments(TimeSeriesCommand.READ, RawableFactory.from(DOLLAR), BLOCK,
+        RawableFactory.from(5000L), RawableFactory.from(1L), MAX_COUNT, RawableFactory.from(100L)));
+    }
+  }
+
+  @Nested
+  class EqualsHashCodeTests {
+
+    @Test
+    public void equalWhenSameConfiguration() {
+      TSReadParams a = TSReadParams.readParams().timestamp(100L).block(1000L, 5).maxCount(10);
+      TSReadParams b = TSReadParams.readParams().timestamp(100L).block(1000L, 5).maxCount(10);
+      assertEquals(a, b);
+      assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void notEqualWhenCursorDiffers() {
+      assertNotEquals(TSReadParams.readParams().timestamp(100L),
+        TSReadParams.readParams().timestamp(200L));
+      assertNotEquals(TSReadParams.readParams().earliest(), TSReadParams.readParams().latest());
+    }
+
+    @Test
+    public void notEqualWhenBlockDiffers() {
+      assertNotEquals(TSReadParams.readParams().block(1000L, 1),
+        TSReadParams.readParams().block(2000L, 1));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds the RedisTimeSeries `TS.READ` command to the Jedis client across all execution surfaces. `TS.READ` performs a non-blocking (or optionally blocking) forward read of samples whose timestamp is greater than or equal to a cursor, in ascending order, enabling cursor-based paging and tailing of a time series. Two overloads are exposed: a simple `tsRead(key, timestamp)` and a full `tsRead(key, TSReadParams)` supporting `BLOCK` and `MAX_COUNT`.

## Key Decisions & Assumptions
- New `TSReadParams` models the cursor plus optional `BLOCK milliseconds min_count` and `MAX_COUNT max_count` arguments. The cursor is either a non-negative literal (Unix ms) or one of the server-resolved sentinels `-` (earliest), `+` (latest existing sample), or `$` (only samples added after the call).
- The `BLOCK` group is all-or-nothing: requesting blocking always emits both `milliseconds` and `min_count`.
- When `BLOCK` is present, the command is issued through blocking-command connection handling (`args.blocking()`); the simple overload never blocks.
- Client-side validation rejects negative `BLOCK` milliseconds, non-positive `min_count`/`max_count`, and `min_count > max_count`, mirroring server constraints to fail fast.
- The default cursor when none is set is `-` (earliest).

## Behavioral / Conceptual Changes
- `tsRead` is added to `RedisTimeSeriesCommands` / `RedisTimeSeriesPipelineCommands` and wired through `CommandObjects`, `UnifiedJedis`, and `PipeliningBase`.
- Adds `TS.READ` protocol command and the `BLOCK` / `MAX_COUNT` keywords plus the `$` cursor byte to `TimeSeriesProtocol`.
- An empty list is a valid successful reply, including when a blocking call times out.

## Testing
Adds `TSReadParamsTest` covering argument validation, blocking classification, wire-serialization order (`BLOCK` before `MAX_COUNT`), and equals/hashCode. Integration coverage is added to the time series command test base and cluster IT, plus pipeline and unified-jedis command tests exercising both overloads.

## Notes
- New public API is annotated `@since 8.0`.
- `TSReadParams.java` is added to the formatter's included-sources list in `pom.xml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API and protocol wiring following existing time-series and blocking-command patterns; no changes to auth or core connection logic beyond marking TS.READ as blocking when requested.
> 
> **Overview**
> Adds **RedisTimeSeries `TS.READ`** to Jedis so clients can read samples with timestamp **≥** a cursor in ascending order, with optional paging and tailing.
> 
> New **`tsRead(key, timestamp)`** and **`tsRead(key, TSReadParams)`** are wired through command interfaces, `CommandObjects`, `UnifiedJedis`, and pipelines. **`TSReadParams`** builds the wire form (`BLOCK`, `MAX_COUNT`, cursor literals `-` / `+` / `$`) and validates argument constraints client-side. When **`BLOCK`** is set, **`CommandObjects`** marks the command blocking so connections use infinite-timeout read handling (same pattern as other blocking Redis commands). Protocol gains **`TS.READ`**, **`BLOCK`**, **`MAX_COUNT`**, and the **`$`** cursor byte.
> 
> Integration tests cover non-blocking reads, **`MAX_COUNT`** paging, sentinels, blocking timeout/immediate return, and cross-connection wake; cluster IT disables the flaky blocking-wake case. Unit tests cover params serialization and mocked command routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 893eb977c67b5df77887c1904cd17b56f7dc05d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->