### PR TITLE
fix: reject malformed RESP length fields in RedisInputStream

### DIFF
--- a/src/main/java/redis/clients/jedis/util/RedisInputStream.java
+++ b/src/main/java/redis/clients/jedis/util/RedisInputStream.java
@@ -29,6 +29,8 @@ public class RedisInputStream extends FilterInputStream {
       System.getProperty("jedis.bufferSize.input",
           System.getProperty("jedis.bufferSize", "8192")));
 
+  private static final long MIN_VALUE_DIV_10 = Long.MIN_VALUE / 10;
+
   protected final byte[] buf;
 
   protected int count, limit;
@@ -194,7 +196,11 @@ public class RedisInputStream extends FilterInputStream {
   }
 
   public int readIntCrLf() {
-    return (int) readLongCrLf();
+    final long value = readLongCrLf();
+    if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+      throw new JedisConnectionException("Number is out of int range: " + value);
+    }
+    return (int) value;
   }
 
   public long readLongCrLf() {
@@ -207,6 +213,8 @@ public class RedisInputStream extends FilterInputStream {
       ++count;
     }
 
+    // Accumulate negated so that Long.MIN_VALUE stays representable.
+    final long limit = isNeg ? Long.MIN_VALUE : -Long.MAX_VALUE;
     long value = 0;
     while (true) {
       ensureFill();
@@ -221,11 +229,22 @@ public class RedisInputStream extends FilterInputStream {
 
         break;
       } else {
-        value = value * 10 + b - '0';
+        final int digit = b - '0';
+        if (digit < 0 || digit > 9) {
+          throw new JedisConnectionException("Unexpected character!");
+        }
+        if (value < MIN_VALUE_DIV_10) {
+          throw new JedisConnectionException("Number is out of range.");
+        }
+        value *= 10;
+        if (value < limit + digit) {
+          throw new JedisConnectionException("Number is out of range.");
+        }
+        value -= digit;
       }
     }
 
-    return (isNeg ? -value : value);
+    return (isNeg ? value : -value);
   }
 
   public double readDoubleCrLf() {

--- a/src/test/java/redis/clients/jedis/ProtocolTest.java
+++ b/src/test/java/redis/clients/jedis/ProtocolTest.java
@@ -130,6 +130,41 @@ public class ProtocolTest {
   }
 
   @Test
+  public void bulkReplyLengthOutOfIntRange() {
+    // 2^32 truncates to 0, which used to be accepted as an empty bulk reply and left the
+    // rest of the payload in the buffer to be framed as the next reply.
+    InputStream is = new ByteArrayInputStream("$4294967296\r\n\r\n+OK\r\n".getBytes());
+    assertThrows(JedisConnectionException.class, () -> Protocol.read(new RedisInputStream(is)));
+  }
+
+  @Test
+  public void bulkReplyLengthWithNonDigit() {
+    // ':' is '0' + 10, so "0:" used to be read as the length 10 and ten bytes of
+    // whatever followed were returned as the value.
+    InputStream is = new ByteArrayInputStream("$0:\r\n0123456789\r\n".getBytes());
+    assertThrows(JedisConnectionException.class, () -> Protocol.read(new RedisInputStream(is)));
+  }
+
+  @Test
+  public void multiBulkReplyCountOutOfIntRange() {
+    InputStream is = new ByteArrayInputStream("*4294967297\r\n+OK\r\n".getBytes());
+    assertThrows(JedisConnectionException.class, () -> Protocol.read(new RedisInputStream(is)));
+  }
+
+  @Test
+  public void integerReplyAtLongBoundaries() {
+    InputStream max = new ByteArrayInputStream(":9223372036854775807\r\n".getBytes());
+    assertEquals(Long.MAX_VALUE, (long) (Long) Protocol.read(new RedisInputStream(max)));
+
+    InputStream min = new ByteArrayInputStream(":-9223372036854775808\r\n".getBytes());
+    assertEquals(Long.MIN_VALUE, (long) (Long) Protocol.read(new RedisInputStream(min)));
+
+    InputStream tooLarge = new ByteArrayInputStream(":9223372036854775808\r\n".getBytes());
+    assertThrows(JedisConnectionException.class,
+      () -> Protocol.read(new RedisInputStream(tooLarge)));
+  }
+
+  @Test
   public void busyReply() {
     final String busyMessage = "BUSY Redis is busy running a script.";
     final InputStream is = new ByteArrayInputStream(('-' + busyMessage + "\r\n").getBytes());


### PR DESCRIPTION
Feeding `$4294967296\r\n\r\n+INJECTED\r\n` to `Protocol.read` twice, on master:

    reply 1 -> byte[0] ""
    reply 2 -> byte[8] "INJECTED"

`readIntCrLf()` narrows `readLongCrLf()` with a plain cast, so 2^32 lands as 0: the header is consumed as an empty bulk reply and the remainder stays framed as a fresh reply, which the next command on that pooled connection collects. The `len < skipBytes` guard in `processBulkReply` only catches the sign-flip case, `$2147483648`.

`readLongCrLf` widens it. The accumulator takes any byte as a digit, so `$0:` reads as length 10, and with no overflow check a 20-digit length wraps modulo 2^64 back into range.

Validating the digits, the accumulation overflow and the int range turns all three into `JedisConnectionException`, so the pool drops the connection rather than serving misframed replies from it. Accumulation is negated to keep `Long.MIN_VALUE` representable, so `:-9223372036854775808` and `:9223372036854775807` parse exactly as before.

Closes #4646

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level protocol parsing on every Redis read; behavior changes for previously accepted malformed input, but the change is defensive and should only surface bad streams as connection errors.
> 
> **Overview**
> Hardens RESP numeric parsing in **`RedisInputStream`** so malformed bulk/array lengths and integer replies fail fast instead of desynchronizing the byte stream on pooled connections.
> 
> **`readIntCrLf()`** now checks the parsed value fits in `int` before casting, so lengths like `4294967296` (2³²) no longer truncate to `0` and leave trailing bytes to be read as the next reply.
> 
> **`readLongCrLf()`** only accepts decimal digits, enforces overflow bounds while accumulating (using negated accumulation so **`Long.MIN_VALUE`** still parses), and rejects out-of-range values. Non-digit characters (e.g. `$0:` misread as length 10) and overflow now raise **`JedisConnectionException`**, which should cause the pool to drop the bad connection.
> 
> **`ProtocolTest`** adds coverage for out-of-int-range bulk/multi lengths, non-digit length fields, and long boundary integer replies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f04191fd2e482647d2c1d2377e0e3aa6cc6db1f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->