### PR TITLE
test: Fix flaky touch assertions comparing OBJECT IDLETIME to exactly 0

### DIFF
--- a/src/test/java/redis/clients/jedis/commands/jedis/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/AllKindOfValuesCommandsTest.java
@@ -2,6 +2,8 @@ package redis.clients.jedis.commands.jedis;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -27,7 +29,6 @@ import java.util.*;
 import io.redis.test.annotations.ConditionalOnEnv;
 import io.redis.test.annotations.EnabledOnCommand;
 import io.redis.test.annotations.SinceRedisVersion;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -415,9 +416,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
     assertTrue(jedis.objectIdletime("foo1") >= 0);
 
     assertEquals(1, jedis.touch("foo1"));
-    // OBJECT IDLETIME is derived from the LRU clock, whose resolution is one second, so a
-    // second boundary crossed between TOUCH and the read reports 1 rather than 0.
-    assertThat(jedis.objectIdletime("foo1"), Matchers.lessThanOrEqualTo(1L));
+    assertThat(jedis.objectIdletime("foo1"), lessThanOrEqualTo(1L));
 
     assertEquals(1, jedis.touch("foo1", "foo2", "foo3"));
 
@@ -435,7 +434,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
     assertTrue(jedis.objectIdletime(bfoo1) >= 0);
 
     assertEquals(1, jedis.touch(bfoo1));
-    assertThat(jedis.objectIdletime(bfoo1), Matchers.lessThanOrEqualTo(1L));
+    assertThat(jedis.objectIdletime(bfoo1), lessThanOrEqualTo(1L));
 
     assertEquals(1, jedis.touch(bfoo1, bfoo2, bfoo3));
 
@@ -661,7 +660,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
     assertTrue(jedis2.pttl("foo") <= 1000);
 
     jedis2.restore("bar", System.currentTimeMillis() + 1000, serialized, RestoreParams.restoreParams().replace().absTtl());
-    assertThat(jedis2.pttl("bar"), Matchers.lessThanOrEqualTo(1000l + TIME_SKEW));
+    assertThat(jedis2.pttl("bar"), lessThanOrEqualTo(1000l + TIME_SKEW));
 
 
     jedis2.restore("bar1", 1000, serialized, RestoreParams.restoreParams().replace().idleTime(1000));
@@ -1036,7 +1035,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
 
     assertEquals(4, encodeObj.size());
     entries.forEach((k, v) -> {
-      assertThat((Iterable<String>) encodeObj, Matchers.hasItem(k));
+      assertThat((Iterable<String>) encodeObj, hasItem(k));
       assertEquals(v, findValueFromMapAsList(encodeObj, k));
     });
   }
@@ -1054,7 +1053,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
 
     assertEquals(2, encodeObj.size());
     encodeObj.forEach(kv -> {
-      assertThat(entries, Matchers.hasEntry(kv.getKey(), kv.getValue()));
+      assertThat(entries, hasEntry(kv.getKey(), kv.getValue()));
     });
   }
 
@@ -1071,7 +1070,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
 
     List encodeObj = (List) SafeEncoder.encodeObject(obj);
 
-    assertThat(encodeObj.size(), Matchers.greaterThanOrEqualTo(14));
+    assertThat(encodeObj.size(), greaterThanOrEqualTo(14));
     assertEquals( 0, encodeObj.size() % 2, "must have even number of elements"); // must be even
 
     assertEquals(1L, findValueFromMapAsList(encodeObj, "length"));
@@ -1098,7 +1097,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
 
     List<KeyValue> encodeObj = (List<KeyValue>) SafeEncoder.encodeObject(obj);
 
-    assertThat(encodeObj.size(), Matchers.greaterThanOrEqualTo(7));
+    assertThat(encodeObj.size(), greaterThanOrEqualTo(7));
 
     assertEquals(1L, findValueFromMapAsKeyValueList(encodeObj, "length"));
     assertEquals(entryID.toString(), findValueFromMapAsKeyValueList(encodeObj, "last-generated-id"));

--- a/src/test/java/redis/clients/jedis/commands/jedis/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/AllKindOfValuesCommandsTest.java
@@ -415,7 +415,9 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
     assertTrue(jedis.objectIdletime("foo1") >= 0);
 
     assertEquals(1, jedis.touch("foo1"));
-    assertEquals(0L, jedis.objectIdletime("foo1").longValue());
+    // OBJECT IDLETIME is derived from the LRU clock, whose resolution is one second, so a
+    // second boundary crossed between TOUCH and the read reports 1 rather than 0.
+    assertThat(jedis.objectIdletime("foo1"), Matchers.lessThanOrEqualTo(1L));
 
     assertEquals(1, jedis.touch("foo1", "foo2", "foo3"));
 
@@ -433,7 +435,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
     assertTrue(jedis.objectIdletime(bfoo1) >= 0);
 
     assertEquals(1, jedis.touch(bfoo1));
-    assertEquals(0L, jedis.objectIdletime(bfoo1).longValue());
+    assertThat(jedis.objectIdletime(bfoo1), Matchers.lessThanOrEqualTo(1L));
 
     assertEquals(1, jedis.touch(bfoo1, bfoo2, bfoo3));
 

--- a/src/test/java/redis/clients/jedis/commands/unified/AllKindOfValuesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/AllKindOfValuesCommandsTestBase.java
@@ -378,7 +378,9 @@ public abstract class AllKindOfValuesCommandsTestBase extends UnifiedJedisComman
     assertTrue(jedis.objectIdletime("foo1") >= 0);
 
     assertEquals(1, jedis.touch("foo1"));
-    assertEquals(0L, jedis.objectIdletime("foo1").longValue());
+    // OBJECT IDLETIME is derived from the LRU clock, whose resolution is one second, so a
+    // second boundary crossed between TOUCH and the read reports 1 rather than 0.
+    assertThat(jedis.objectIdletime("foo1"), Matchers.lessThanOrEqualTo(1L));
 
     assertEquals(1, jedis.touch("foo1", "foo2", "foo3"));
 
@@ -396,7 +398,7 @@ public abstract class AllKindOfValuesCommandsTestBase extends UnifiedJedisComman
     assertTrue(jedis.objectIdletime(bfoo1) >= 0);
 
     assertEquals(1, jedis.touch(bfoo1));
-    assertEquals(0L, jedis.objectIdletime(bfoo1).longValue());
+    assertThat(jedis.objectIdletime(bfoo1), Matchers.lessThanOrEqualTo(1L));
 
     assertEquals(1, jedis.touch(bfoo1, bfoo2, bfoo3));
 

--- a/src/test/java/redis/clients/jedis/commands/unified/AllKindOfValuesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/AllKindOfValuesCommandsTestBase.java
@@ -2,6 +2,7 @@ package redis.clients.jedis.commands.unified;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -378,9 +379,7 @@ public abstract class AllKindOfValuesCommandsTestBase extends UnifiedJedisComman
     assertTrue(jedis.objectIdletime("foo1") >= 0);
 
     assertEquals(1, jedis.touch("foo1"));
-    // OBJECT IDLETIME is derived from the LRU clock, whose resolution is one second, so a
-    // second boundary crossed between TOUCH and the read reports 1 rather than 0.
-    assertThat(jedis.objectIdletime("foo1"), Matchers.lessThanOrEqualTo(1L));
+    assertThat(jedis.objectIdletime("foo1"), lessThanOrEqualTo(1L));
 
     assertEquals(1, jedis.touch("foo1", "foo2", "foo3"));
 
@@ -398,7 +397,7 @@ public abstract class AllKindOfValuesCommandsTestBase extends UnifiedJedisComman
     assertTrue(jedis.objectIdletime(bfoo1) >= 0);
 
     assertEquals(1, jedis.touch(bfoo1));
-    assertThat(jedis.objectIdletime(bfoo1), Matchers.lessThanOrEqualTo(1L));
+    assertThat(jedis.objectIdletime(bfoo1), lessThanOrEqualTo(1L));
 
     assertEquals(1, jedis.touch(bfoo1, bfoo2, bfoo3));
 

--- a/src/test/java/redis/clients/jedis/commands/unified/cluster/ClusterAllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/cluster/ClusterAllKindOfValuesCommandsTest.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis.commands.unified.cluster;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -12,6 +13,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
@@ -162,7 +164,9 @@ public class ClusterAllKindOfValuesCommandsTest extends AllKindOfValuesCommandsT
     assertTrue(jedis.objectIdletime("{foo}1") >= 0);
 
     assertEquals(1, jedis.touch("{foo}1"));
-    assertEquals(0L, jedis.objectIdletime("{foo}1").longValue());
+    // OBJECT IDLETIME is derived from the LRU clock, whose resolution is one second, so a
+    // second boundary crossed between TOUCH and the read reports 1 rather than 0.
+    assertThat(jedis.objectIdletime("{foo}1"), Matchers.lessThanOrEqualTo(1L));
 
     assertEquals(1, jedis.touch("{foo}1", "{foo}2", "{foo}3"));
 

--- a/src/test/java/redis/clients/jedis/commands/unified/cluster/ClusterAllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/cluster/ClusterAllKindOfValuesCommandsTest.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis.commands.unified.cluster;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -13,7 +14,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
@@ -164,9 +164,7 @@ public class ClusterAllKindOfValuesCommandsTest extends AllKindOfValuesCommandsT
     assertTrue(jedis.objectIdletime("{foo}1") >= 0);
 
     assertEquals(1, jedis.touch("{foo}1"));
-    // OBJECT IDLETIME is derived from the LRU clock, whose resolution is one second, so a
-    // second boundary crossed between TOUCH and the read reports 1 rather than 0.
-    assertThat(jedis.objectIdletime("{foo}1"), Matchers.lessThanOrEqualTo(1L));
+    assertThat(jedis.objectIdletime("{foo}1"), lessThanOrEqualTo(1L));
 
     assertEquals(1, jedis.touch("{foo}1", "{foo}2", "{foo}3"));
 


### PR DESCRIPTION
## What

Fixes the sporadic `touch` failure reported in #4591, and the same assertion in the sibling copies of that test.

## Why

The reported failure is:

```
SentinelAllKindOfValuesCommandsIT.touch()[2] -- Time elapsed: 0.012 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <0> but was: <1>
	at redis.clients.jedis.commands.unified.AllKindOfValuesCommandsTestBase.touch(AllKindOfValuesCommandsTestBase.java:399)
```

Line 399 is the `OBJECT IDLETIME` read immediately after `TOUCH`:

```java
assertEquals(1, jedis.touch(bfoo1));
assertEquals(0L, jedis.objectIdletime(bfoo1).longValue());
```

`OBJECT IDLETIME` is derived from the LRU clock, whose resolution is one second. `TOUCH` stamps the key with the current clock value and the read then subtracts two second-granular values, so when the clock ticks between the two commands the result is 1 rather than 0. How closely the commands are issued does not matter — only whether a tick falls between them. The client is behaving correctly here; the assertion is simply stricter than what the command guarantees.

Reproduced against the 8.8 test environment by repeating that same back-to-back `TOUCH` / `OBJECT IDLETIME` pair, with nothing between the two calls, until one pair straddled a tick:

```
REPRO_HIT after 1542 iterations: objectIdletime=1
REPRO_HIT after 2654 iterations: objectIdletime=1
```

which is the value the assertion sees on a CI failure.

## Changes

Assert `<= 1` instead of `== 0`. The reported failure is the binary half of the unified test, but the same assertion exists in four other places, so all five are updated:

- `commands/unified/AllKindOfValuesCommandsTestBase#touch` — String and binary
- `commands/unified/cluster/ClusterAllKindOfValuesCommandsTest#touch` — overrides the base test
- `commands/jedis/AllKindOfValuesCommandsTest#touch` — String and binary in the legacy copy

The tolerant form matches what `ObjectCommandsTest#objectIdletime` already does for the same command (`assertThat(time, lessThanOrEqualTo(10L))`).

The surrounding assertions are untouched, so `TOUCH` return values are still checked exactly, and the idle time is still asserted to be at (or next to) zero rather than merely non-negative.

## Verification

`make start version=8.8`, then the four classes that run this test, in full rather than just the one method:

| Class | Per-run result |
| --- | --- |
| `SentinelAllKindOfValuesCommandsIT` | 45 run, 0 failures, 3 skipped |
| `ClusterAllKindOfValuesCommandsTest` | 45 run, 0 failures, 3 skipped |
| `RedisClientAllKindOfValuesCommandsTest` | 45 run, 0 failures, 3 skipped |
| `AllKindOfValuesCommandsTest` (legacy) | 54 run, 0 failures, 3 skipped |

`432 run, 0 failures, 0 errors, 27 skipped` in total across the RESP parameterizations, `BUILD SUCCESS`.

## One note

`dumpAndRestore` has the same shape a bit further down — `RESTORE ... IDLETIME 1000` followed by `assertEquals(1000, objectIdletime(...))` — in both the unified base and the legacy copy. It is exposed to the same tick, though I have not seen it reported. I left it alone to keep this focused on #4591; happy to fold it in here or send it separately, whichever you prefer.

Fixes #4591

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion and import changes; no library or runtime behavior is modified.
> 
> **Overview**
> Fixes intermittent CI failures in **`touch`** integration tests (#4591) by aligning assertions with Redis’s **one-second LRU clock** for `OBJECT IDLETIME`.
> 
> After **`TOUCH`**, tests no longer require idle time to be exactly **0**; they assert **`<= 1`** via Hamcrest **`lessThanOrEqualTo`**, so a clock tick between `TOUCH` and `OBJECT IDLETIME` does not fail the run. The same change is applied across the unified base, cluster override, and legacy **`AllKindOfValuesCommandsTest`** (string and binary keys).
> 
> The legacy jedis test class also switches several Hamcrest matchers to static imports (e.g. **`hasItem`**, **`greaterThanOrEqualTo`**) instead of **`Matchers.*`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5008f32fdd288d48137a57c29bd21aec9ca79374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->