### PR TITLE
[Redis 8.10] Add TS.QUERYLABELS support to the client

### DIFF
--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -4729,6 +4729,22 @@ public class CommandObjects {
         .addObjects((Object[]) filters), BuilderFactory.STRING_LIST);
   }
 
+  public final CommandObject<List<String>> tsQueryLabels(String... filters) {
+    CommandArguments args = commandArguments(TimeSeriesCommand.QUERYLABELS).add(TimeSeriesKeyword.LABELS);
+    if (filters != null && filters.length > 0) {
+      args.add(TimeSeriesKeyword.FILTER).addObjects((Object[]) filters);
+    }
+    return new CommandObject<>(args, BuilderFactory.STRING_LIST);
+  }
+
+  public final CommandObject<List<String>> tsQueryLabelValues(String label, String... filters) {
+    CommandArguments args = commandArguments(TimeSeriesCommand.QUERYLABELS).add(TimeSeriesKeyword.VALUES).add(label);
+    if (filters != null && filters.length > 0) {
+      args.add(TimeSeriesKeyword.FILTER).addObjects((Object[]) filters);
+    }
+    return new CommandObject<>(args, BuilderFactory.STRING_LIST);
+  }
+
   public final CommandObject<TSInfo> tsInfo(String key) {
     return new CommandObject<>(commandArguments(TimeSeriesCommand.INFO).key(key), getTimeseriesInfoBuilder());
   }

--- a/src/main/java/redis/clients/jedis/PipeliningBase.java
+++ b/src/main/java/redis/clients/jedis/PipeliningBase.java
@@ -4733,6 +4733,16 @@ public abstract class PipeliningBase
   }
 
   @Override
+  public Response<List<String>> tsQueryLabels(String... filters) {
+    return appendCommand(commandObjects.tsQueryLabels(filters));
+  }
+
+  @Override
+  public Response<List<String>> tsQueryLabelValues(String label, String... filters) {
+    return appendCommand(commandObjects.tsQueryLabelValues(label, filters));
+  }
+
+  @Override
   public Response<TSInfo> tsInfo(String key) {
     return appendCommand(commandObjects.tsInfo(key));
   }

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -5515,6 +5515,16 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   @Override
+  public List<String> tsQueryLabels(String... filters) {
+    return executeCommand(commandObjects.tsQueryLabels(filters));
+  }
+
+  @Override
+  public List<String> tsQueryLabelValues(String label, String... filters) {
+    return executeCommand(commandObjects.tsQueryLabelValues(label, filters));
+  }
+
+  @Override
   public TSInfo tsInfo(String key) {
     return executeCommand(commandObjects.tsInfo(key));
   }

--- a/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesCommands.java
+++ b/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesCommands.java
@@ -299,6 +299,49 @@ public interface RedisTimeSeriesCommands {
    */
   List<String> tsQueryIndex(String... filters);
 
+  /**
+   * <b><a href="https://redis.io/commands/ts.querylabels/">TS.QUERYLABELS LABELS</a></b>
+   * <p>
+   * Returns the set of all label names, each present on at least one time series that matches the
+   * given filters. When no filters are supplied the label names of all indexed series are returned.
+   * The reply is a collection of unique strings with no ordering guarantee, and an empty reply is a
+   * normal successful result.
+   * <p>
+   * Filters use the same expression language as {@link #tsQueryIndex(String...)}; expressions are
+   * passed to the server verbatim. Passing no filters (or an empty array) queries all indexed series.
+   * <p>
+   * Time complexity: O(n) where n is the number of time series that match the filters (all indexed
+   * series when no filter is given).
+   *
+   * @param filters optional filter expressions (e.g. {@code type=sensor}); omit to query all series
+   * @return unique label names across the matching series (unordered)
+   * @since 8.0
+   */
+  List<String> tsQueryLabels(String... filters);
+
+  /**
+   * <b><a href="https://redis.io/commands/ts.querylabels/">TS.QUERYLABELS VALUES</a></b>
+   * <p>
+   * Returns the set of all values assigned to {@code label}, each assigned on at least one time
+   * series that matches the given filters. Matching series that do not carry {@code label}
+   * contribute nothing; a label that exists on no matching series yields an empty reply, not an
+   * error. When no filters are supplied the values are collected across all indexed series. The
+   * reply is a collection of unique strings with no ordering guarantee.
+   * <p>
+   * Filters use the same expression language as {@link #tsQueryIndex(String...)}; expressions are
+   * passed to the server verbatim. The {@code label} name is matched byte-exactly and is not
+   * normalized. Passing no filters (or an empty array) queries all indexed series.
+   * <p>
+   * Time complexity: O(n) where n is the number of time series that match the filters (all indexed
+   * series when no filter is given).
+   *
+   * @param label the label name whose values are collected (matched byte-exactly)
+   * @param filters optional filter expressions (e.g. {@code type=sensor}); omit to query all series
+   * @return unique values of {@code label} across the matching series (unordered)
+   * @since 8.0
+   */
+  List<String> tsQueryLabelValues(String label, String... filters);
+
   TSInfo tsInfo(String key);
 
   TSInfo tsInfoDebug(String key);

--- a/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesPipelineCommands.java
+++ b/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesPipelineCommands.java
@@ -67,6 +67,20 @@ public interface RedisTimeSeriesPipelineCommands {
 
   Response<List<String>> tsQueryIndex(String... filters);
 
+  /**
+   * Pipeline variant of {@link RedisTimeSeriesCommands#tsQueryLabels(String...)}.
+   *
+   * @since 8.0
+   */
+  Response<List<String>> tsQueryLabels(String... filters);
+
+  /**
+   * Pipeline variant of {@link RedisTimeSeriesCommands#tsQueryLabelValues(String, String...)}.
+   *
+   * @since 8.0
+   */
+  Response<List<String>> tsQueryLabelValues(String label, String... filters);
+
   Response<TSInfo> tsInfo(String key);
 
   Response<TSInfo> tsInfoDebug(String key);

--- a/src/main/java/redis/clients/jedis/timeseries/TimeSeriesProtocol.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TimeSeriesProtocol.java
@@ -27,7 +27,8 @@ public class TimeSeriesProtocol {
     GET("TS.GET"),
     MGET("TS.MGET"),
     ALTER("TS.ALTER"),
-    QUERYINDEX("TS.QUERYINDEX");
+    QUERYINDEX("TS.QUERYINDEX"),
+    QUERYLABELS("TS.QUERYLABELS");
 
     private final byte[] raw;
 
@@ -67,7 +68,8 @@ public class TimeSeriesProtocol {
     DEBUG,
     LATEST,
     EMPTY,
-    BUCKETTIMESTAMP;
+    BUCKETTIMESTAMP,
+    VALUES;
 
     private final byte[] raw;
 

--- a/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsModulesTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsModulesTestBase.java
@@ -3,13 +3,19 @@ package redis.clients.jedis.commands.commandobjects;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import redis.clients.jedis.Endpoints;
 import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.util.EnabledOnCommandCondition;
 import redis.clients.jedis.util.EnvCondition;
+import redis.clients.jedis.util.RedisVersionCondition;
 
 /**
  * Base class for tests that need a Redis Stack server.
  */
 public abstract class CommandObjectsModulesTestBase extends CommandObjectsTestBase {
 
+  @RegisterExtension
+  RedisVersionCondition redisVersionCondition = new RedisVersionCondition(() -> endpoint);
+  @RegisterExtension
+  EnabledOnCommandCondition enabledOnCommandCondition = new EnabledOnCommandCondition(() -> endpoint);
   @RegisterExtension
   static EnvCondition envCondition = new EnvCondition();
 

--- a/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsTimeSeriesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsTimeSeriesCommandsTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import io.redis.test.annotations.ConditionalOnEnv;
+import io.redis.test.annotations.SinceRedisVersion;
 import org.junit.jupiter.api.Test;
 import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.timeseries.AggregationType;
@@ -579,6 +580,34 @@ public class CommandObjectsTimeSeriesCommandsTest extends CommandObjectsModulesT
     List<String> matchingKeys = exec(commandObjects.tsQueryIndex(filters));
 
     assertThat(matchingKeys, containsInAnyOrder(key1, key2));
+  }
+
+  @Test
+  @SinceRedisVersion("8.9.241")
+  public void testTsQueryLabelsAndValues() {
+    exec(commandObjects.tsCreate("ql:temp:living",
+        new TSCreateParams().label("type", "sensor").label("sensortype", "temperature").label("location", "LivingRoom")));
+    exec(commandObjects.tsCreate("ql:temp:kitchen",
+        new TSCreateParams().label("type", "sensor").label("sensortype", "temperature").label("location", "Kitchen")));
+    exec(commandObjects.tsCreate("ql:hum:bedroom",
+        new TSCreateParams().label("type", "sensor").label("sensortype", "humidity").label("location", "BedRoom")));
+    exec(commandObjects.tsCreate("ql:cpu:server",
+        new TSCreateParams().label("type", "metric").label("unit", "percent")));
+
+    // LABELS with a filter: distinct label names across the sensor group.
+    assertThat(exec(commandObjects.tsQueryLabels("type=sensor")),
+        containsInAnyOrder("type", "sensortype", "location"));
+
+    // LABELS without a filter: all indexed series, so "unit" appears too.
+    assertThat(exec(commandObjects.tsQueryLabels()),
+        containsInAnyOrder("type", "sensortype", "location", "unit"));
+
+    // VALUES of a chosen label within the sensor group.
+    assertThat(exec(commandObjects.tsQueryLabelValues("location", "type=sensor")),
+        containsInAnyOrder("LivingRoom", "Kitchen", "BedRoom"));
+
+    // A label carried by no matching series yields an empty reply, not an error.
+    assertThat(exec(commandObjects.tsQueryLabelValues("nonexistent", "type=sensor")), empty());
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsTimeSeriesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsTimeSeriesCommandsTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static io.redis.test.utils.RedisVersion.V8_10_0_RC2_STRING;
 
 import java.util.AbstractMap;
 import java.util.List;
@@ -586,7 +587,7 @@ public class CommandObjectsTimeSeriesCommandsTest extends CommandObjectsModulesT
   }
 
   @Test
-  @SinceRedisVersion("8.9.241")
+  @SinceRedisVersion(V8_10_0_RC2_STRING)
   public void testTsQueryLabelsAndValues(TestInfo testInfo) {
     // Keys are obtained from (and tracked by) the registry so they can be cleared afterwards
     // instead of relying on a wholesale flush. Label names/values drive the assertions, so the

--- a/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsTimeSeriesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsTimeSeriesCommandsTest.java
@@ -20,6 +20,8 @@ import java.util.stream.Collectors;
 import io.redis.test.annotations.ConditionalOnEnv;
 import io.redis.test.annotations.SinceRedisVersion;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import redis.clients.jedis.RedisClient;
 import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.timeseries.AggregationType;
 import redis.clients.jedis.timeseries.TSAlterParams;
@@ -33,6 +35,7 @@ import redis.clients.jedis.timeseries.TSMRangeElements;
 import redis.clients.jedis.timeseries.TSMRangeParams;
 import redis.clients.jedis.timeseries.TSRangeParams;
 import redis.clients.jedis.util.TestEnvUtil;
+import redis.clients.jedis.util.TestKeyRegistry;
 
 /**
  * Tests related to <a href="https://redis.io/commands/?group=timeseries">Time series</a> commands.
@@ -584,30 +587,41 @@ public class CommandObjectsTimeSeriesCommandsTest extends CommandObjectsModulesT
 
   @Test
   @SinceRedisVersion("8.9.241")
-  public void testTsQueryLabelsAndValues() {
-    exec(commandObjects.tsCreate("ql:temp:living",
-        new TSCreateParams().label("type", "sensor").label("sensortype", "temperature").label("location", "LivingRoom")));
-    exec(commandObjects.tsCreate("ql:temp:kitchen",
-        new TSCreateParams().label("type", "sensor").label("sensortype", "temperature").label("location", "Kitchen")));
-    exec(commandObjects.tsCreate("ql:hum:bedroom",
-        new TSCreateParams().label("type", "sensor").label("sensortype", "humidity").label("location", "BedRoom")));
-    exec(commandObjects.tsCreate("ql:cpu:server",
-        new TSCreateParams().label("type", "metric").label("unit", "percent")));
+  public void testTsQueryLabelsAndValues(TestInfo testInfo) {
+    // Keys are obtained from (and tracked by) the registry so they can be cleared afterwards
+    // instead of relying on a wholesale flush. Label names/values drive the assertions, so the
+    // registry-namespaced key names do not affect the results.
+    TestKeyRegistry keys = TestKeyRegistry.create(testInfo);
+    try {
+      exec(commandObjects.tsCreate(keys.key("temp:living"),
+          new TSCreateParams().label("type", "sensor").label("sensortype", "temperature").label("location", "LivingRoom")));
+      exec(commandObjects.tsCreate(keys.key("temp:kitchen"),
+          new TSCreateParams().label("type", "sensor").label("sensortype", "temperature").label("location", "Kitchen")));
+      exec(commandObjects.tsCreate(keys.key("hum:bedroom"),
+          new TSCreateParams().label("type", "sensor").label("sensortype", "humidity").label("location", "BedRoom")));
+      exec(commandObjects.tsCreate(keys.key("cpu:server"),
+          new TSCreateParams().label("type", "metric").label("unit", "percent")));
 
-    // LABELS with a filter: distinct label names across the sensor group.
-    assertThat(exec(commandObjects.tsQueryLabels("type=sensor")),
-        containsInAnyOrder("type", "sensortype", "location"));
+      // LABELS with a filter: distinct label names across the sensor group.
+      assertThat(exec(commandObjects.tsQueryLabels("type=sensor")),
+          containsInAnyOrder("type", "sensortype", "location"));
 
-    // LABELS without a filter: all indexed series, so "unit" appears too.
-    assertThat(exec(commandObjects.tsQueryLabels()),
-        containsInAnyOrder("type", "sensortype", "location", "unit"));
+      // LABELS without a filter: all indexed series, so "unit" appears too.
+      assertThat(exec(commandObjects.tsQueryLabels()),
+          containsInAnyOrder("type", "sensortype", "location", "unit"));
 
-    // VALUES of a chosen label within the sensor group.
-    assertThat(exec(commandObjects.tsQueryLabelValues("location", "type=sensor")),
-        containsInAnyOrder("LivingRoom", "Kitchen", "BedRoom"));
+      // VALUES of a chosen label within the sensor group.
+      assertThat(exec(commandObjects.tsQueryLabelValues("location", "type=sensor")),
+          containsInAnyOrder("LivingRoom", "Kitchen", "BedRoom"));
 
-    // A label carried by no matching series yields an empty reply, not an error.
-    assertThat(exec(commandObjects.tsQueryLabelValues("nonexistent", "type=sensor")), empty());
+      // A label carried by no matching series yields an empty reply, not an error.
+      assertThat(exec(commandObjects.tsQueryLabelValues("nonexistent", "type=sensor")), empty());
+    } finally {
+      try (RedisClient client = RedisClient.builder().hostAndPort(endpoint.getHostAndPort())
+          .clientConfig(endpoint.getClientConfigBuilder().protocol(protocol).build()).build()) {
+        keys.cleanup(client);
+      }
+    }
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -724,6 +724,63 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
     assertEquals(Arrays.asList("seriesQueryIndex2"), jedis.tsQueryIndex("l2=v22"));
   }
 
+  /**
+   * Sets up a small sensor dashboard dataset used by the TS.QUERYLABELS examples. Keys are
+   * hash-tagged so they share a slot in cluster mode (the command itself is keyless).
+   */
+  private void setupQueryLabelsSeries() {
+    jedis.tsCreate("{ql}temp:living", TSCreateParams.createParams()
+        .labels(mapOf("type", "sensor", "sensortype", "temperature", "location", "LivingRoom")));
+    jedis.tsCreate("{ql}temp:kitchen", TSCreateParams.createParams()
+        .labels(mapOf("type", "sensor", "sensortype", "temperature", "location", "Kitchen")));
+    jedis.tsCreate("{ql}hum:bedroom", TSCreateParams.createParams()
+        .labels(mapOf("type", "sensor", "sensortype", "humidity", "location", "BedRoom")));
+    jedis.tsCreate("{ql}cpu:server",
+      TSCreateParams.createParams().labels(mapOf("type", "metric", "unit", "percent")));
+  }
+
+  private static Map<String, String> mapOf(String... kvs) {
+    Map<String, String> map = new HashMap<>();
+    for (int i = 0; i < kvs.length; i += 2) {
+      map.put(kvs[i], kvs[i + 1]);
+    }
+    return map;
+  }
+
+  @Test
+  @SinceRedisVersion("8.9.241")
+  public void testQueryLabels() {
+    setupQueryLabelsSeries();
+
+    // LABELS with a filter: distinct label names across the sensor group (unordered set).
+    assertEquals(new HashSet<>(Arrays.asList("type", "sensortype", "location")),
+      new HashSet<>(jedis.tsQueryLabels("type=sensor")));
+
+    // LABELS without a filter: metadata across all indexed series, so "unit" appears too.
+    assertEquals(new HashSet<>(Arrays.asList("type", "sensortype", "location", "unit")),
+      new HashSet<>(jedis.tsQueryLabels()));
+
+    // A filter matching nothing yields an empty reply, not an error.
+    assertEquals(Collections.emptyList(), jedis.tsQueryLabels("type=nonexistent"));
+  }
+
+  @Test
+  @SinceRedisVersion("8.9.241")
+  public void testQueryLabelValues() {
+    setupQueryLabelsSeries();
+
+    // VALUES of a chosen label within the sensor group (unordered set).
+    assertEquals(new HashSet<>(Arrays.asList("LivingRoom", "Kitchen", "BedRoom")),
+      new HashSet<>(jedis.tsQueryLabelValues("location", "type=sensor")));
+
+    // VALUES without a filter: collected across all indexed series.
+    assertEquals(new HashSet<>(Arrays.asList("temperature", "humidity")),
+      new HashSet<>(jedis.tsQueryLabelValues("sensortype")));
+
+    // A label carried by no matching series yields an empty reply, not an error.
+    assertEquals(Collections.emptyList(), jedis.tsQueryLabelValues("nonexistent", "type=sensor"));
+  }
+
   @Test
   public void testInfo() {
     Map<String, String> labels = new HashMap<>();

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -732,21 +732,6 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
     assertEquals(Arrays.asList("seriesQueryIndex2"), jedis.tsQueryIndex("l2=v22"));
   }
 
-  /** Tracks the TS.QUERYLABELS test keys so they can be cleared without a cluster-wide flush. */
-  private TestKeyRegistry queryLabelsKeys;
-
-  @BeforeEach
-  void initQueryLabelsKeys(TestInfo testInfo) {
-    queryLabelsKeys = TestKeyRegistry.create(testInfo);
-  }
-
-  @AfterEach
-  void cleanupQueryLabelsKeys() {
-    if (queryLabelsKeys != null && jedis != null) {
-      queryLabelsKeys.cleanup(jedis);
-    }
-  }
-
   /**
    * Sets up a small sensor dashboard dataset used by the TS.QUERYLABELS examples. Keys are obtained
    * from {@link TestKeyRegistry} (registered for cleanup) and deliberately NOT hash-tagged, so in
@@ -755,13 +740,13 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
    * fan-out itself (no client-side aggregation).
    */
   private void setupQueryLabelsSeries() {
-    jedis.tsCreate(queryLabelsKeys.key("temp:living"), TSCreateParams.createParams()
+    jedis.tsCreate(keys.key("temp:living"), TSCreateParams.createParams()
         .labels(mapOf("type", "sensor", "sensortype", "temperature", "location", "LivingRoom")));
-    jedis.tsCreate(queryLabelsKeys.key("temp:kitchen"), TSCreateParams.createParams()
+    jedis.tsCreate(keys.key("temp:kitchen"), TSCreateParams.createParams()
         .labels(mapOf("type", "sensor", "sensortype", "temperature", "location", "Kitchen")));
-    jedis.tsCreate(queryLabelsKeys.key("hum:bedroom"), TSCreateParams.createParams()
+    jedis.tsCreate(keys.key("hum:bedroom"), TSCreateParams.createParams()
         .labels(mapOf("type", "sensor", "sensortype", "humidity", "location", "BedRoom")));
-    jedis.tsCreate(queryLabelsKeys.key("cpu:server"),
+    jedis.tsCreate(keys.key("cpu:server"),
       TSCreateParams.createParams().labels(mapOf("type", "metric", "unit", "percent")));
   }
 
@@ -774,7 +759,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   }
 
   @Test
-  @SinceRedisVersion("8.9.241")
+  @SinceRedisVersion(V8_10_0_RC2_STRING)
   public void testQueryLabels() {
     setupQueryLabelsSeries();
 
@@ -791,7 +776,7 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   }
 
   @Test
-  @SinceRedisVersion("8.9.241")
+  @SinceRedisVersion(V8_10_0_RC2_STRING)
   public void testQueryLabelValues() {
     setupQueryLabelsSeries();
 

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -729,16 +729,18 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
 
   /**
    * Sets up a small sensor dashboard dataset used by the TS.QUERYLABELS examples. Keys are
-   * hash-tagged so they share a slot in cluster mode (the command itself is keyless).
+   * deliberately NOT hash-tagged, so in cluster mode they scatter across shards: TS.QUERYLABELS is
+   * keyless and routes to a single arbitrary node, and asserting a complete reply proves the server
+   * coordinates the cluster-wide fan-out itself (no client-side aggregation).
    */
   private void setupQueryLabelsSeries() {
-    jedis.tsCreate("{ql}temp:living", TSCreateParams.createParams()
+    jedis.tsCreate("ql:temp:living", TSCreateParams.createParams()
         .labels(mapOf("type", "sensor", "sensortype", "temperature", "location", "LivingRoom")));
-    jedis.tsCreate("{ql}temp:kitchen", TSCreateParams.createParams()
+    jedis.tsCreate("ql:temp:kitchen", TSCreateParams.createParams()
         .labels(mapOf("type", "sensor", "sensortype", "temperature", "location", "Kitchen")));
-    jedis.tsCreate("{ql}hum:bedroom", TSCreateParams.createParams()
+    jedis.tsCreate("ql:hum:bedroom", TSCreateParams.createParams()
         .labels(mapOf("type", "sensor", "sensortype", "humidity", "location", "BedRoom")));
-    jedis.tsCreate("{ql}cpu:server",
+    jedis.tsCreate("ql:cpu:server",
       TSCreateParams.createParams().labels(mapOf("type", "metric", "unit", "percent")));
   }
 

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -15,9 +15,12 @@ import java.util.*;
 import io.redis.test.annotations.ConditionalOnEnv;
 import io.redis.test.annotations.EnabledOnCommand;
 import io.redis.test.annotations.SinceRedisVersion;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
 
 import redis.clients.jedis.Endpoints;
 import redis.clients.jedis.RedisProtocol;
@@ -28,6 +31,7 @@ import redis.clients.jedis.timeseries.*;
 import redis.clients.jedis.util.AssertUtil;
 import redis.clients.jedis.util.KeyValue;
 import redis.clients.jedis.util.TestEnvUtil;
+import redis.clients.jedis.util.TestKeyRegistry;
 
 /**
  * Base test class for Time Series commands using the UnifiedJedis pattern.
@@ -727,20 +731,36 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
     assertEquals(Arrays.asList("seriesQueryIndex2"), jedis.tsQueryIndex("l2=v22"));
   }
 
+  /** Tracks the TS.QUERYLABELS test keys so they can be cleared without a cluster-wide flush. */
+  private TestKeyRegistry queryLabelsKeys;
+
+  @BeforeEach
+  void initQueryLabelsKeys(TestInfo testInfo) {
+    queryLabelsKeys = TestKeyRegistry.create(testInfo);
+  }
+
+  @AfterEach
+  void cleanupQueryLabelsKeys() {
+    if (queryLabelsKeys != null && jedis != null) {
+      queryLabelsKeys.cleanup(jedis);
+    }
+  }
+
   /**
-   * Sets up a small sensor dashboard dataset used by the TS.QUERYLABELS examples. Keys are
-   * deliberately NOT hash-tagged, so in cluster mode they scatter across shards: TS.QUERYLABELS is
-   * keyless and routes to a single arbitrary node, and asserting a complete reply proves the server
-   * coordinates the cluster-wide fan-out itself (no client-side aggregation).
+   * Sets up a small sensor dashboard dataset used by the TS.QUERYLABELS examples. Keys are obtained
+   * from {@link TestKeyRegistry} (registered for cleanup) and deliberately NOT hash-tagged, so in
+   * cluster mode they scatter across shards: TS.QUERYLABELS is keyless and routes to a single
+   * arbitrary node, and asserting a complete reply proves the server coordinates the cluster-wide
+   * fan-out itself (no client-side aggregation).
    */
   private void setupQueryLabelsSeries() {
-    jedis.tsCreate("ql:temp:living", TSCreateParams.createParams()
+    jedis.tsCreate(queryLabelsKeys.key("temp:living"), TSCreateParams.createParams()
         .labels(mapOf("type", "sensor", "sensortype", "temperature", "location", "LivingRoom")));
-    jedis.tsCreate("ql:temp:kitchen", TSCreateParams.createParams()
+    jedis.tsCreate(queryLabelsKeys.key("temp:kitchen"), TSCreateParams.createParams()
         .labels(mapOf("type", "sensor", "sensortype", "temperature", "location", "Kitchen")));
-    jedis.tsCreate("ql:hum:bedroom", TSCreateParams.createParams()
+    jedis.tsCreate(queryLabelsKeys.key("hum:bedroom"), TSCreateParams.createParams()
         .labels(mapOf("type", "sensor", "sensortype", "humidity", "location", "BedRoom")));
-    jedis.tsCreate("ql:cpu:server",
+    jedis.tsCreate(queryLabelsKeys.key("cpu:server"),
       TSCreateParams.createParams().labels(mapOf("type", "metric", "unit", "percent")));
   }
 

--- a/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/timeseries/TimeSeriesCommandsTestBase.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static io.redis.test.utils.RedisVersion.V8_10_0_RC2_STRING;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
 import static org.junit.jupiter.api.Assertions.fail;
 import static redis.clients.jedis.util.AssertUtil.assertEqualsByProtocol;
 
@@ -16,13 +18,9 @@ import java.util.*;
 import io.redis.test.annotations.ConditionalOnEnv;
 import io.redis.test.annotations.EnabledOnCommand;
 import io.redis.test.annotations.SinceRedisVersion;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestInfo;
-
 import redis.clients.jedis.Endpoints;
 import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.UnifiedJedis;
@@ -763,13 +761,14 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   public void testQueryLabels() {
     setupQueryLabelsSeries();
 
-    // LABELS with a filter: distinct label names across the sensor group (unordered set).
-    assertEquals(new HashSet<>(Arrays.asList("type", "sensortype", "location")),
-      new HashSet<>(jedis.tsQueryLabels("type=sensor")));
+    // LABELS with a filter: distinct label names across the sensor group. The filter is a label
+    // value shared across the DB, not a namespaced key, so other tests may contribute series with
+    // "type=sensor"; assert our labels are present without requiring an exact match.
+    assertThat(jedis.tsQueryLabels("type=sensor"), hasItems("type", "sensortype", "location"));
 
-    // LABELS without a filter: metadata across all indexed series, so "unit" appears too.
-    assertEquals(new HashSet<>(Arrays.asList("type", "sensortype", "location", "unit")),
-      new HashSet<>(jedis.tsQueryLabels()));
+    // LABELS without a filter: metadata across all indexed series in the DB, so "unit" appears
+    // too. Other tests may add series concurrently, so assert our labels are present.
+    assertThat(jedis.tsQueryLabels(), hasItems("type", "sensortype", "location", "unit"));
 
     // A filter matching nothing yields an empty reply, not an error.
     assertEquals(Collections.emptyList(), jedis.tsQueryLabels("type=nonexistent"));
@@ -780,13 +779,14 @@ public abstract class TimeSeriesCommandsTestBase extends UnifiedJedisCommandsTes
   public void testQueryLabelValues() {
     setupQueryLabelsSeries();
 
-    // VALUES of a chosen label within the sensor group (unordered set).
-    assertEquals(new HashSet<>(Arrays.asList("LivingRoom", "Kitchen", "BedRoom")),
-      new HashSet<>(jedis.tsQueryLabelValues("location", "type=sensor")));
+    // VALUES of a chosen label within the sensor group. Same shared-filter caveat as above:
+    // other tests' "type=sensor" series may add location values, so assert ours are present.
+    assertThat(jedis.tsQueryLabelValues("location", "type=sensor"),
+      hasItems("LivingRoom", "Kitchen", "BedRoom"));
 
-    // VALUES without a filter: collected across all indexed series.
-    assertEquals(new HashSet<>(Arrays.asList("temperature", "humidity")),
-      new HashSet<>(jedis.tsQueryLabelValues("sensortype")));
+    // VALUES without a filter: collected across all indexed series in the DB. Other tests may
+    // add "sensortype" values, so assert ours are present.
+    assertThat(jedis.tsQueryLabelValues("sensortype"), hasItems("temperature", "humidity"));
 
     // A label carried by no matching series yields an empty reply, not an error.
     assertEquals(Collections.emptyList(), jedis.tsQueryLabelValues("nonexistent", "type=sensor"));

--- a/src/test/java/redis/clients/jedis/mocked/pipeline/PipeliningBaseTimeSeriesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/mocked/pipeline/PipeliningBaseTimeSeriesCommandsTest.java
@@ -332,6 +332,31 @@ public class PipeliningBaseTimeSeriesCommandsTest extends PipeliningBaseMockedTe
   }
 
   @Test
+  public void testTsQueryLabels() {
+    String[] filters = { "type=sensor" };
+
+    when(commandObjects.tsQueryLabels(filters)).thenReturn(listStringCommandObject);
+
+    Response<List<String>> response = pipeliningBase.tsQueryLabels(filters);
+
+    assertThat(commands, contains(listStringCommandObject));
+    assertThat(response, is(predefinedResponse));
+  }
+
+  @Test
+  public void testTsQueryLabelValues() {
+    String label = "location";
+    String[] filters = { "type=sensor" };
+
+    when(commandObjects.tsQueryLabelValues(label, filters)).thenReturn(listStringCommandObject);
+
+    Response<List<String>> response = pipeliningBase.tsQueryLabelValues(label, filters);
+
+    assertThat(commands, contains(listStringCommandObject));
+    assertThat(response, is(predefinedResponse));
+  }
+
+  @Test
   public void testTsRange() {
     when(commandObjects.tsRange("myTimeSeries", 1000L, 2000L)).thenReturn(listTsElementCommandObject);
 

--- a/src/test/java/redis/clients/jedis/mocked/unified/UnifiedJedisTimeSeriesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/mocked/unified/UnifiedJedisTimeSeriesCommandsTest.java
@@ -507,6 +507,39 @@ public class UnifiedJedisTimeSeriesCommandsTest extends UnifiedJedisMockedTestBa
   }
 
   @Test
+  public void testTsQueryLabels() {
+    String[] filters = { "type=sensor" };
+    List<String> expectedResponse = Arrays.asList("location", "sensortype", "type");
+
+    when(commandObjects.tsQueryLabels(filters)).thenReturn(listStringCommandObject);
+    when(commandExecutor.executeCommand(listStringCommandObject)).thenReturn(expectedResponse);
+
+    List<String> result = jedis.tsQueryLabels(filters);
+
+    assertThat(result, sameInstance(expectedResponse));
+
+    verify(commandExecutor).executeCommand(listStringCommandObject);
+    verify(commandObjects).tsQueryLabels(filters);
+  }
+
+  @Test
+  public void testTsQueryLabelValues() {
+    String label = "location";
+    String[] filters = { "type=sensor" };
+    List<String> expectedResponse = Arrays.asList("LivingRoom", "Kitchen", "BedRoom");
+
+    when(commandObjects.tsQueryLabelValues(label, filters)).thenReturn(listStringCommandObject);
+    when(commandExecutor.executeCommand(listStringCommandObject)).thenReturn(expectedResponse);
+
+    List<String> result = jedis.tsQueryLabelValues(label, filters);
+
+    assertThat(result, sameInstance(expectedResponse));
+
+    verify(commandExecutor).executeCommand(listStringCommandObject);
+    verify(commandObjects).tsQueryLabelValues(label, filters);
+  }
+
+  @Test
   public void testTsRange() {
     String key = "testKey";
     long fromTimestamp = 1582600000000L;


### PR DESCRIPTION
## Summary
Adds client support for the `TS.QUERYLABELS` command across the TimeSeries API. Exposes two methods — `tsQueryLabels(filters...)` returning the distinct label names on series matching the filters, and `tsQueryLabelValues(label, filters...)` returning the distinct values assigned to a given label. Both are wired through the full command matrix (interfaces, `CommandObjects`, `UnifiedJedis`, `PipeliningBase`) so they work in direct and pipelined execution.

## Key Decisions & Assumptions
- `filters` is optional/varargs — omitting it (or passing an empty array) queries all indexed series rather than sending an empty `FILTER` clause.
- Both commands are keyless; filter expressions reuse the same language as `tsQueryIndex` and are passed to the server verbatim.
- Replies are treated as unordered sets of unique strings; an empty reply is a normal success, not an error.

## Behavioral / Conceptual Changes
- New `QUERYLABELS` command and `VALUES` keyword added to `TimeSeriesProtocol`; the existing `LABELS`/`FILTER` keywords are reused.
- `tsQueryLabelValues` matches the label name byte-exactly (no normalization).

## Testing
Adds mocked unit tests for `UnifiedJedis`, `PipeliningBase`, and `CommandObjects` verifying delegation and argument construction. Adds integration tests in `TimeSeriesCommandsTestBase` (gated with `@SinceRedisVersion("8.9.241")`) that build a small sensor dataset and assert label-name and label-value results with and without filters, including the empty-reply case. Integration keys are hash-tagged for cluster-mode slot affinity.

## Notes
Public API annotated `@since 8.0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only TimeSeries API mirroring existing `tsQueryIndex` patterns; no changes to auth, data mutation, or core connection handling.
> 
> **Overview**
> Adds **Redis TimeSeries `TS.QUERYLABELS`** to the public API so clients can discover label metadata across indexed series without listing keys.
> 
> **`tsQueryLabels(filters...)`** issues `TS.QUERYLABELS LABELS` with optional `FILTER` clauses (same filter language as `tsQueryIndex`); omitting filters queries all indexed series. **`tsQueryLabelValues(label, filters...)`** issues `TS.QUERYLABELS VALUES` for distinct values of a given label name. Both return `List<String>` and are wired through `CommandObjects`, `UnifiedJedis`, and `PipeliningBase`, with `QUERYLABELS` and `VALUES` added to `TimeSeriesProtocol`.
> 
> Integration tests are gated with `@SinceRedisVersion` for Redis 8.10; module test base gains version/command availability extensions. Mocked tests cover delegation for unified and pipeline paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97e86b2ed34398918281e5e7fd22c40397fae815. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->