### PR TITLE
[Redis 8.10] Regenerate command flags registry from Redis 8.10-rc2

### DIFF
--- a/src/main/java/redis/clients/jedis/StaticCommandFlagsRegistryInitializer.java
+++ b/src/main/java/redis/clients/jedis/StaticCommandFlagsRegistryInitializer.java
@@ -12,10 +12,10 @@ import static redis.clients.jedis.CommandFlagsRegistry.ResponsePolicy;
  * <p>
  * Generated from Redis Server:
  * <ul>
- * <li>Version: 8.8.1</li>
+ * <li>Version: 8.9.241</li>
  * <li>Mode: standalone</li>
- * <li>Loaded Modules: timeseries, search, vectorset, bf, ReJSON</li>
- * <li>Generated at: 2026-07-27 14:30:02 EEST</li>
+ * <li>Loaded Modules: search, bf, timeseries, vectorset, ReJSON</li>
+ * <li>Generated at: 2026-07-27 14:52:41 EEST</li>
  * </ul>
  */
 final class StaticCommandFlagsRegistryInitializer {
@@ -129,6 +129,14 @@ final class StaticCommandFlagsRegistryInitializer {
     builder.register("CONFIG", "SET",
       EnumSet.of(CommandFlag.ADMIN, CommandFlag.LOADING, CommandFlag.NOSCRIPT, CommandFlag.STALE),
       RequestPolicy.ALL_NODES, ResponsePolicy.ALL_SUCCEEDED);
+    builder.register("BACKUP", EMPTY_FLAGS);
+    // BACKUP subcommands
+    builder.register("BACKUP", "ABORT", EnumSet.of(CommandFlag.ADMIN, CommandFlag.NOSCRIPT));
+    builder.register("BACKUP", "CLEANUP", EnumSet.of(CommandFlag.ADMIN, CommandFlag.NOSCRIPT));
+    builder.register("BACKUP", "LIST", EnumSet.of(CommandFlag.ADMIN, CommandFlag.STALE));
+    builder.register("BACKUP", "SEAL", EnumSet.of(CommandFlag.ADMIN, CommandFlag.NOSCRIPT));
+    builder.register("BACKUP", "START", EnumSet.of(CommandFlag.ADMIN, CommandFlag.NOSCRIPT));
+    builder.register("BACKUP", "STATUS", EnumSet.of(CommandFlag.ADMIN, CommandFlag.STALE));
     builder.register("MODULE", EMPTY_FLAGS);
     // MODULE subcommands
     builder.register("MODULE", "LIST", EnumSet.of(CommandFlag.ADMIN, CommandFlag.NOSCRIPT));
@@ -200,6 +208,13 @@ final class StaticCommandFlagsRegistryInitializer {
     builder.register("FT.CURSOR", "GC", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("FT.CURSOR", "READ", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY),
       RequestPolicy.SPECIAL, null);
+    builder.register("HIMPORT", EMPTY_FLAGS);
+    // HIMPORT subcommands
+    builder.register("HIMPORT", "DISCARD", EMPTY_FLAGS, RequestPolicy.ALL_SHARDS, null);
+    builder.register("HIMPORT", "DISCARDALL", EMPTY_FLAGS, RequestPolicy.ALL_SHARDS, null);
+    builder.register("HIMPORT", "PREPARE", EnumSet.of(CommandFlag.DENYOOM),
+      RequestPolicy.ALL_SHARDS, null);
+    builder.register("HIMPORT", "SET", EnumSet.of(CommandFlag.DENYOOM, CommandFlag.WRITE));
     builder.register("COMMAND", EnumSet.of(CommandFlag.LOADING, CommandFlag.STALE));
     // COMMAND subcommands
     builder.register("COMMAND", "COUNT", EnumSet.of(CommandFlag.LOADING, CommandFlag.STALE));
@@ -396,7 +411,7 @@ final class StaticCommandFlagsRegistryInitializer {
     builder.register("MSET", EnumSet.of(CommandFlag.DENYOOM, CommandFlag.WRITE),
       RequestPolicy.MULTI_SHARD, ResponsePolicy.ALL_SUCCEEDED);
 
-    // 22 command(s) with: denyoom, write
+    // 23 command(s) with: denyoom, write
     builder.register("ARRING", EnumSet.of(CommandFlag.DENYOOM, CommandFlag.WRITE));
     builder.register("BITFIELD", EnumSet.of(CommandFlag.DENYOOM, CommandFlag.WRITE));
     builder.register("BITOP", EnumSet.of(CommandFlag.DENYOOM, CommandFlag.WRITE));
@@ -405,6 +420,7 @@ final class StaticCommandFlagsRegistryInitializer {
     builder.register("GEOSEARCHSTORE", EnumSet.of(CommandFlag.DENYOOM, CommandFlag.WRITE));
     builder.register("LINSERT", EnumSet.of(CommandFlag.DENYOOM, CommandFlag.WRITE));
     builder.register("LMOVE", EnumSet.of(CommandFlag.DENYOOM, CommandFlag.WRITE));
+    builder.register("LMOVEM", EnumSet.of(CommandFlag.DENYOOM, CommandFlag.WRITE));
     builder.register("LSET", EnumSet.of(CommandFlag.DENYOOM, CommandFlag.WRITE));
     builder.register("MSETNX", EnumSet.of(CommandFlag.DENYOOM, CommandFlag.WRITE));
     builder.register("PFMERGE", EnumSet.of(CommandFlag.DENYOOM, CommandFlag.WRITE));
@@ -520,10 +536,11 @@ final class StaticCommandFlagsRegistryInitializer {
     builder.register("INFO", EnumSet.of(CommandFlag.LOADING, CommandFlag.STALE),
       RequestPolicy.DEFAULT, ResponsePolicy.SPECIAL);
 
-    // 56 command(s) with: module, readonly
+    // 58 command(s) with: module, readonly
     builder.register("CMS.INFO", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("CMS.QUERY", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("FT.AGGREGATE", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
+    builder.register("FT.ALIASLIST", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("FT.DICTDUMP", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("FT.EXPLAIN", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("FT.EXPLAINCLI", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
@@ -541,7 +558,6 @@ final class StaticCommandFlagsRegistryInitializer {
     builder.register("FT._LIST", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("JSON.ARRINDEX", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("JSON.ARRLEN", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
-    builder.register("JSON.DEBUG", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("JSON.GET", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("JSON.MGET", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("JSON.OBJKEYS", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
@@ -569,7 +585,9 @@ final class StaticCommandFlagsRegistryInitializer {
     builder.register("TS.MRANGE", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("TS.MREVRANGE", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("TS.QUERYINDEX", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
+    builder.register("TS.QUERYLABELS", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("TS.RANGE", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
+    builder.register("TS.READ", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("TS.REVRANGE", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("VISMEMBER", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
     builder.register("VRANDMEMBER", EnumSet.of(CommandFlag.MODULE, CommandFlag.READONLY));
@@ -601,9 +619,11 @@ final class StaticCommandFlagsRegistryInitializer {
     builder.register("TS.DELETERULE", EnumSet.of(CommandFlag.MODULE, CommandFlag.WRITE));
     builder.register("VREM", EnumSet.of(CommandFlag.MODULE, CommandFlag.WRITE));
 
-    // 6 command(s) with: movablekeys, readonly
+    // 8 command(s) with: movablekeys, readonly
+    builder.register("SDIFFCARD", EnumSet.of(CommandFlag.MOVABLEKEYS, CommandFlag.READONLY));
     builder.register("SINTERCARD", EnumSet.of(CommandFlag.MOVABLEKEYS, CommandFlag.READONLY));
     builder.register("SORT_RO", EnumSet.of(CommandFlag.MOVABLEKEYS, CommandFlag.READONLY));
+    builder.register("SUNIONCARD", EnumSet.of(CommandFlag.MOVABLEKEYS, CommandFlag.READONLY));
     builder.register("ZDIFF", EnumSet.of(CommandFlag.MOVABLEKEYS, CommandFlag.READONLY));
     builder.register("ZINTER", EnumSet.of(CommandFlag.MOVABLEKEYS, CommandFlag.READONLY));
     builder.register("ZINTERCARD", EnumSet.of(CommandFlag.MOVABLEKEYS, CommandFlag.READONLY));
@@ -632,8 +652,10 @@ final class StaticCommandFlagsRegistryInitializer {
     builder.register("RESTORE-ASKING",
       EnumSet.of(CommandFlag.ASKING, CommandFlag.DENYOOM, CommandFlag.WRITE));
 
-    // 2 command(s) with: blocking, denyoom, write
+    // 3 command(s) with: blocking, denyoom, write
     builder.register("BLMOVE",
+      EnumSet.of(CommandFlag.BLOCKING, CommandFlag.DENYOOM, CommandFlag.WRITE));
+    builder.register("BLMOVEM",
       EnumSet.of(CommandFlag.BLOCKING, CommandFlag.DENYOOM, CommandFlag.WRITE));
     builder.register("BRPOPLPUSH",
       EnumSet.of(CommandFlag.BLOCKING, CommandFlag.DENYOOM, CommandFlag.WRITE));
@@ -878,6 +900,14 @@ final class StaticCommandFlagsRegistryInitializer {
       EnumSet.of(CommandFlag.FAST, CommandFlag.MODULE, CommandFlag.WRITE));
     builder.register("VSETATTR",
       EnumSet.of(CommandFlag.FAST, CommandFlag.MODULE, CommandFlag.WRITE));
+
+    // 3 command(s) with: module, movablekeys, readonly
+    builder.register("JSON.DEBUG",
+      EnumSet.of(CommandFlag.MODULE, CommandFlag.MOVABLEKEYS, CommandFlag.READONLY));
+    builder.register("TS.NRANGE",
+      EnumSet.of(CommandFlag.MODULE, CommandFlag.MOVABLEKEYS, CommandFlag.READONLY));
+    builder.register("TS.NREVRANGE",
+      EnumSet.of(CommandFlag.MODULE, CommandFlag.MOVABLEKEYS, CommandFlag.READONLY));
 
     // 3 command(s) with: module, noscript, readonly
     builder.register("SEARCH.CLUSTERREFRESH",

--- a/src/test/java/redis/clients/jedis/codegen/CommandFlagsRegistryGenerator.java
+++ b/src/test/java/redis/clients/jedis/codegen/CommandFlagsRegistryGenerator.java
@@ -107,9 +107,10 @@ public class CommandFlagsRegistryGenerator {
    * If a new Redis command with subcommands is added, add the parent command name to this set. The
    * generator will fail with a helpful error message if an unknown parent command is encountered.
    */
-  private static final Set<String> KNOWN_PARENT_COMMANDS = new HashSet<>(Arrays.asList("ACL",
-    "CLIENT", "CLUSTER", "COMMAND", "CONFIG", "FUNCTION", "HOTKEYS", "LATENCY", "MEMORY", "MODULE",
-    "OBJECT", "PUBSUB", "SCRIPT", "SLOWLOG", "XGROUP", "XINFO", "FT.CONFIG", "FT.CURSOR"));
+  private static final Set<String> KNOWN_PARENT_COMMANDS = new HashSet<>(
+      Arrays.asList("ACL", "BACKUP", "CLIENT", "CLUSTER", "COMMAND", "CONFIG", "FUNCTION",
+        "HIMPORT", "HOTKEYS", "LATENCY", "MEMORY", "MODULE", "OBJECT", "PUBSUB", "SCRIPT",
+        "SLOWLOG", "XGROUP", "XINFO", "FT.CONFIG", "FT.CURSOR"));
 
   public CommandFlagsRegistryGenerator(String host, int port) {
     this.redisHost = host;


### PR DESCRIPTION
## What
Regenerates `StaticCommandFlagsRegistryInitializer` with `CommandFlagsRegistryGenerator` against the official `redis:8.10-rc2` image (reports `redis_version` 8.9.241, all bundled modules loaded), followed by `mvn formatter:format`.

**Stacked on #4652** — this branch includes the 8.8 regeneration commit; please merge #4652 first, after which this PR reduces to the 8.10 delta.

## Why
Commands introduced after the registry's source server default to WRITE intent in `ConnectionResolver#getIntent`, so read-only commands are never distributed to replicas. This step brings the registry to the 8.10 surface — in particular the new TimeSeries commands from the in-flight 8.10 PRs (#4642 TS.READ already merged, #4651 TS.QUERYLABELS under review) get their correct `MODULE, READONLY` flags, matching the server-side `readonly` command registration.

## Changes
- New registrations: `TS.READ`, `TS.QUERYLABELS`, `TS.NRANGE`, `TS.NREVRANGE` (all `MODULE, READONLY`); `BACKUP` (+6 subcommands) and `HIMPORT` (+4 subcommands); `LMOVEM`/`BLMOVEM`, `SDIFFCARD`, `SUNIONCARD`; `FT.ALIASLIST`. Nothing removed (verified by diffing the full register-call sets).
- `CommandFlagsRegistryGenerator`: added `HIMPORT` and `BACKUP` to `KNOWN_PARENT_COMMANDS` — the generator fails fast on unknown container commands by design, and 8.10 introduces these two.
- Header metadata updated (source server 8.9.241).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect cluster/replica routing for every newly registered or re-flagged command; incorrect flags would misroute reads or writes, though the data is server-sourced and the generator change is minimal.
> 
> **Overview**
> Regenerates **`StaticCommandFlagsRegistryInitializer`** from **`redis:8.10-rc2`** (metadata shows server **8.9.241**) so Jedis command flags match the server and **`ConnectionResolver#getIntent`** can route read-only commands (e.g. to replicas) instead of defaulting unknown commands to **WRITE**.
> 
> New registrations include **`BACKUP`** (six subcommands) and **`HIMPORT`** (four subcommands); list commands **`LMOVEM`** / **`BLMOVEM`**, **`SDIFFCARD`**, **`SUNIONCARD`**, **`FT.ALIASLIST`**; TimeSeries **`TS.READ`**, **`TS.QUERYLABELS`**, **`TS.NRANGE`**, **`TS.NREVRANGE`**. **`JSON.DEBUG`** is reclassified from plain module readonly to **`MODULE, MOVABLEKEYS, READONLY`**.
> 
> **`CommandFlagsRegistryGenerator`** adds **`BACKUP`** and **`HIMPORT`** to **`KNOWN_PARENT_COMMANDS`** so subcommand generation does not fail on the new 8.10 parent commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f6ca5069bc11d2a29670a6c217f3d545162cf18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->