### PR TITLE
Evaluate JUnit test conditions before opening a Redis connection

### DIFF
--- a/src/test/java/redis/clients/jedis/util/EnabledOnCommandCondition.java
+++ b/src/test/java/redis/clients/jedis/util/EnabledOnCommandCondition.java
@@ -40,11 +40,14 @@ public class EnabledOnCommandCondition implements ExecutionCondition {
 
   @Override
   public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    String[] command = getCommandFromAnnotations(context);
+    if (command == null) {
+      return ConditionEvaluationResult.enabled("No command constraint present");
+    }
+
     ensureInitialized();
     try (Jedis jedisClient = new Jedis(hostPort, config)) {
-      String[] command = getCommandFromAnnotations(context);
-
-      if (command != null && !isCommandAvailable(jedisClient, command[0], command[1])) {
+      if (!isCommandAvailable(jedisClient, command[0], command[1])) {
         return ConditionEvaluationResult.disabled(
             "Test requires Redis command '" + command[0] + " " + command[1]
                 + "' to be available on " + hostPort + ", but it was not found.");

--- a/src/test/java/redis/clients/jedis/util/RedisVersionCondition.java
+++ b/src/test/java/redis/clients/jedis/util/RedisVersionCondition.java
@@ -48,23 +48,25 @@ public class RedisVersionCondition implements ExecutionCondition {
 
   @Override
   public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    RedisVersion minRequiredVersion = getMaxRequiredVersion(context);
+    if (minRequiredVersion == null) {
+      return ConditionEvaluationResult.enabled("No version constraint present");
+    }
+
+    if (forcedVersion != null) {
+      logger.info("Using forced Redis server version from environment variable: " + forcedVersion);
+      if (forcedVersion.isLessThan(minRequiredVersion)) {
+        return ConditionEvaluationResult.disabled("Test requires Redis version " + minRequiredVersion + " or later, but found " + forcedVersion);
+      }
+      return ConditionEvaluationResult.enabled("Redis version is sufficient");
+    }
+
     ensureInitialized();
     try (Jedis jedisClient = new Jedis(hostPort, config)) {
-      RedisVersion minRequiredVersion = getMaxRequiredVersion(context);
-      if (minRequiredVersion != null) {
-        RedisVersion currentVersion;
-
-        if (forcedVersion != null) {
-          logger.info("Using forced Redis server version from environment variable: " + forcedVersion);
-          currentVersion = forcedVersion;
-        } else {
-          RedisInfo info = RedisInfo.parseInfoServer(jedisClient.info("server"));
-          currentVersion = RedisVersion.of(info.getRedisVersion());
-        }
-
-        if (currentVersion.isLessThan(minRequiredVersion)) {
-          return ConditionEvaluationResult.disabled("Test requires Redis version " + minRequiredVersion + " or later, but found " + currentVersion);
-        }
+      RedisInfo info = RedisInfo.parseInfoServer(jedisClient.info("server"));
+      RedisVersion currentVersion = RedisVersion.of(info.getRedisVersion());
+      if (currentVersion.isLessThan(minRequiredVersion)) {
+        return ConditionEvaluationResult.disabled("Test requires Redis version " + minRequiredVersion + " or later, but found " + currentVersion);
       }
     } catch (Exception e) {
       return ConditionEvaluationResult.disabled("Failed to check Redis version: " + e.getMessage());


### PR DESCRIPTION
## Summary
`RedisVersionCondition` and `EnabledOnCommandCondition` both opened a Redis connection before checking whether their annotation (`@SinceRedisVersion` / `@EnabledOnCommand`) was even present, and converted any connection failure into a `disabled` result. This meant a broken or unreachable Redis environment silently disabled every test — including tests that carry neither annotation — turning an unusable test environment into a false-green run. Both conditions now short-circuit to `enabled` when their annotation is absent, connecting only when a constraint actually needs to be checked.

## Behavioral / Conceptual Changes
- Tests without the relevant annotation are no longer gated on a reachable Redis; they evaluate as enabled without connecting.
- Connection or check failures now disable only the annotated tests that require the check, so a broken environment surfaces as targeted failures instead of a blanket silent skip.
- `RedisVersionCondition` resolves the forced-version path entirely in memory and no longer opens an unused connection when `forcedVersion` is set.

## Notes
- Behavior for annotated tests against a healthy Redis is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only JUnit extension logic; no production client behavior changes, only when integration tests connect during condition evaluation.
> 
> **Overview**
> **`EnabledOnCommandCondition`** and **`RedisVersionCondition`** no longer open a Redis client before deciding whether `@EnabledOnCommand` or `@SinceRedisVersion` applies. When the annotation is missing, each condition returns **enabled** immediately instead of treating connection failures as a blanket disable.
> 
> For annotated tests, behavior against a healthy Redis is unchanged: command availability and server version are still checked over a live connection. **`RedisVersionCondition`** also evaluates the env-forced version path without connecting when `forcedVersion` is set.
> 
> This fixes unreachable Redis silently disabling **all** tests in classes that register these extensions—including tests with no version/command constraint—so broken environments show as real failures on unannotated tests rather than a false-green skip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cbe8297f5eaf40809078de05cec6c6b83367019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->