### PR TITLE
test: namespace streams test fixtures via TestKeyRegistry

### DIFF
--- a/src/test/java/redis/clients/jedis/commands/unified/StreamsBinaryCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/StreamsBinaryCommandsTestBase.java
@@ -18,6 +18,7 @@ import redis.clients.jedis.params.XReadParams;
 import redis.clients.jedis.params.XTrimParams;
 import redis.clients.jedis.resps.StreamEntryBinary;
 import redis.clients.jedis.resps.StreamEntryDeletionResult;
+import redis.clients.jedis.util.SafeEncoder;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,10 +44,12 @@ import static redis.clients.jedis.util.StreamEntryBinaryListMatcher.equalsStream
 @Tag("integration")
 public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommandsTestBase {
 
-  protected static final byte[] STREAM_KEY_1 = "{binary-stream}-1".getBytes();
-  protected static final byte[] STREAM_KEY_2 = "{binary-stream}-2".getBytes();
-  protected static final byte[] GROUP_NAME = "group-1".getBytes();
-  protected static final byte[] CONSUMER_NAME = "consumer-1".getBytes();
+  // Registry-namespaced per test in setUpTestStream(); the hash-tagged prefix keeps both
+  // streams in one cluster slot. Names are kept constant-style to leave call sites untouched.
+  protected byte[] STREAM_KEY_1;
+  protected byte[] STREAM_KEY_2;
+  protected byte[] GROUP_NAME;
+  protected byte[] CONSUMER_NAME;
 
   protected static final byte[] FIELD_KEY_1 = "binary-field-1".getBytes();
   // Test with invalid UTF-8 characters
@@ -103,6 +106,10 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
 
   @BeforeEach
   public void setUpTestStream() {
+    STREAM_KEY_1 = keys.bKey("{%test%}:binary-stream-1");
+    STREAM_KEY_2 = keys.bKey("{%test%}:binary-stream-2");
+    GROUP_NAME = SafeEncoder.encode(keys.name("group-1"));
+    CONSUMER_NAME = SafeEncoder.encode(keys.name("consumer-1"));
     setUpTestStream(StreamEntryID.XGROUP_LAST_ENTRY.toString().getBytes());
   }
 

--- a/src/test/java/redis/clients/jedis/commands/unified/StreamsBinaryCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/StreamsBinaryCommandsTestBase.java
@@ -43,9 +43,6 @@ import static redis.clients.jedis.util.StreamEntryBinaryListMatcher.equalsStream
 
 @Tag("integration")
 public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommandsTestBase {
-
-  // Registry-namespaced per test in setUpTestStream(); the hash-tagged prefix keeps both
-  // streams in one cluster slot. Names are kept constant-style to leave call sites untouched.
   protected byte[] STREAM_KEY_1;
   protected byte[] STREAM_KEY_2;
   protected byte[] GROUP_NAME;
@@ -105,7 +102,7 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   }
 
   @BeforeEach
-  public void setUpTestStream() {
+  public void setUp() {
     STREAM_KEY_1 = keys.bKey("{%test%}:binary-stream-1");
     STREAM_KEY_2 = keys.bKey("{%test%}:binary-stream-2");
     GROUP_NAME = SafeEncoder.encode(keys.name("group-1"));
@@ -142,7 +139,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
 
   @Test
   public void xreadBinary() {
-
     stream1Entries.forEach(
         entry -> jedis.xadd(STREAM_KEY_1, new XAddParams().id(entry.getID()), entry.getFields()));
 
@@ -156,7 +152,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
 
   @Test
   public void xreadBinaryCount() {
-
     stream1Entries.forEach(
         entry -> jedis.xadd(STREAM_KEY_1, new XAddParams().id(entry.getID()), entry.getFields()));
 
@@ -171,7 +166,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion(RedisVersion.V8_10_0_RC2_STRING)
   public void xreadBinaryMaxCountAndMaxSize() {
-
     stream1Entries.forEach(
         entry -> jedis.xadd(STREAM_KEY_1, new XAddParams().id(entry.getID()), entry.getFields()));
 
@@ -193,7 +187,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
 
   @Test
   public void xreadBinaryAsMap() {
-
     stream1Entries.forEach(
         entry -> jedis.xadd(STREAM_KEY_1, new XAddParams().id(entry.getID()), entry.getFields()));
 
@@ -206,7 +199,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
 
   @Test
   public void xreadBinaryAsMapCount() {
-
     stream1Entries.forEach(
         entry -> jedis.xadd(STREAM_KEY_1, new XAddParams().id(entry.getID()), entry.getFields()));
 
@@ -219,7 +211,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
 
   @Test
   public void xreadBinaryAsMapWithMultipleStreams() {
-
     // Add entries to the streams
     stream1Entries.forEach(
         entry -> jedis.xadd(STREAM_KEY_1, new XAddParams().id(entry.getID()), entry.getFields()));
@@ -256,7 +247,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion(RedisVersion.V8_10_0_RC2_STRING)
   public void xreadGroupBinaryMaxCountAndMaxSize() {
-
     stream1Entries.forEach(
         entry -> jedis.xadd(STREAM_KEY_1, new XAddParams().id(entry.getID()), entry.getFields()));
 
@@ -307,8 +297,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.1.240")
   public void testXackdel() {
-    setUpTestStream();
-
     // Add a message to the stream
     byte[] messageId = jedis.xadd(STREAM_KEY_1, new XAddParams().id("1-0"), HASH_1);
     assertNotNull(messageId);
@@ -335,8 +323,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.1.240")
   public void testXackdelWithTrimMode() {
-    setUpTestStream();
-
     // Add multiple messages
     jedis.xadd(STREAM_KEY_1, new XAddParams().id("1-0"), HASH_1);
     jedis.xadd(STREAM_KEY_1, new XAddParams().id("2-0"), HASH_2);
@@ -363,8 +349,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.1.240")
   public void testXackdelUnreadMessages() {
-    setUpTestStream();
-
     // Add test entries but don't read them
     byte[] id1 = jedis.xadd(STREAM_KEY_1, new XAddParams().id("1-0"), HASH_1);
 
@@ -382,8 +366,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.1.240")
   public void testXackdelMultipleMessages() {
-    setUpTestStream();
-
     // Add multiple messages
     jedis.xadd(STREAM_KEY_1, new XAddParams().id("1-0"), HASH_1);
     jedis.xadd(STREAM_KEY_1, new XAddParams().id("2-0"), HASH_2);
@@ -415,8 +397,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.7.225")
   public void xnackBasicSilent() {
-    setUpTestStream();
-
     // Add and read a message
     jedis.xadd(STREAM_KEY_1, new XAddParams().id("1-0"), HASH_1);
     Map<byte[], StreamEntryID> streams = offsets(STREAM_KEY_1, XREADGROUP_UNDELIVERED_ENTRY);
@@ -433,8 +413,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.7.225")
   public void xnackBasicFail() {
-    setUpTestStream();
-
     jedis.xadd(STREAM_KEY_1, new XAddParams().id("1-0"), HASH_1);
     Map<byte[], StreamEntryID> streams = offsets(STREAM_KEY_1, XREADGROUP_UNDELIVERED_ENTRY);
     List<Map.Entry<byte[], List<StreamEntryBinary>>> messages = jedis.xreadGroupBinary(
@@ -449,8 +427,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.7.225")
   public void xnackBasicFatal() {
-    setUpTestStream();
-
     jedis.xadd(STREAM_KEY_1, new XAddParams().id("1-0"), HASH_1);
     Map<byte[], StreamEntryID> streams = offsets(STREAM_KEY_1, XREADGROUP_UNDELIVERED_ENTRY);
     List<Map.Entry<byte[], List<StreamEntryBinary>>> messages = jedis.xreadGroupBinary(
@@ -465,8 +441,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.7.225")
   public void xnackMultipleMessages() {
-    setUpTestStream();
-
     jedis.xadd(STREAM_KEY_1, new XAddParams().id("1-0"), HASH_1);
     jedis.xadd(STREAM_KEY_1, new XAddParams().id("2-0"), HASH_2);
     Map<byte[], StreamEntryID> streams = offsets(STREAM_KEY_1, XREADGROUP_UNDELIVERED_ENTRY);
@@ -483,8 +457,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.7.225")
   public void xnackNonExistentMessage() {
-    setUpTestStream();
-
     byte[] nonExistentId = "999-0".getBytes();
     long nacked = jedis.xnack(STREAM_KEY_1, GROUP_NAME, XNackMode.SILENT, nonExistentId);
     assertEquals(0L, nacked);
@@ -495,8 +467,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.1.240")
   public void testXdelex() {
-    setUpTestStream();
-
     // Add test entries
     byte[] id1 = jedis.xadd(STREAM_KEY_1, new XAddParams().id("1-0"), HASH_1);
     jedis.xadd(STREAM_KEY_1, new XAddParams().id("2-0"), HASH_2);
@@ -514,8 +484,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.1.240")
   public void testXdelexWithTrimMode() {
-    setUpTestStream();
-
     // Add test entries
     byte[] id1 = jedis.xadd(STREAM_KEY_1, new XAddParams().id("1-0"), HASH_1);
     jedis.xadd(STREAM_KEY_1, new XAddParams().id("2-0"), HASH_2);
@@ -532,8 +500,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.1.240")
   public void testXdelexMultipleEntries() {
-    setUpTestStream();
-
     // Add test entries
     byte[] id1 = jedis.xadd(STREAM_KEY_1, new XAddParams().id("1-0"), HASH_1);
     jedis.xadd(STREAM_KEY_1, new XAddParams().id("2-0"), HASH_2);
@@ -553,8 +519,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.1.240")
   public void testXdelexNonExistentEntries() {
-    setUpTestStream();
-
     // Add one entry
     byte[] id1 = jedis.xadd(STREAM_KEY_1, new XAddParams().id("1-0"), HASH_1);
     assertEquals(1L, jedis.xlen(STREAM_KEY_1));
@@ -573,8 +537,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.1.240")
   public void testXdelexWithConsumerGroups() {
-    setUpTestStream();
-
     // Add test entries
     jedis.xadd(STREAM_KEY_1, new XAddParams().id("1-0"), HASH_1);
     jedis.xadd(STREAM_KEY_1, new XAddParams().id("2-0"), HASH_2);
@@ -606,8 +568,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.1.240")
   public void testXdelexEmptyStream() {
-    setUpTestStream();
-
     // Test XDELEX on empty stream
     byte[] nonExistentId = "1-0".getBytes();
     List<StreamEntryDeletionResult> results = jedis.xdelex(STREAM_KEY_1, nonExistentId);
@@ -620,8 +580,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.1.240")
   public void testXtrimWithKeepReferences() {
-    setUpTestStream();
-
     // Add test entries
     for (int i = 1; i <= 5; i++) {
       jedis.xadd(STREAM_KEY_1, new XAddParams().id(i + "-0"), HASH_1);
@@ -642,8 +600,6 @@ public abstract class StreamsBinaryCommandsTestBase extends UnifiedJedisCommands
   @Test
   @SinceRedisVersion("8.1.240")
   public void testXtrimWithAcknowledged() {
-    setUpTestStream();
-
     // Add test entries
     for (int i = 1; i <= 5; i++) {
       jedis.xadd(STREAM_KEY_1, new XAddParams().id(i + "-0"), HASH_1);

--- a/src/test/java/redis/clients/jedis/commands/unified/StreamsCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/StreamsCommandsTestBase.java
@@ -38,10 +38,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Tag("integration")
 public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBase {
 
-  protected static final String STREAM_KEY_1 = "{stream}-1";
-  protected static final String STREAM_KEY_2 = "{stream}-2";
-  protected static final String GROUP_NAME = "group-1";
-  protected static final String CONSUMER_NAME = "consumer-1";
+  protected String STREAM_KEY_1;
+  protected String STREAM_KEY_2;
+  protected String GROUP_NAME;
+  protected String CONSUMER_NAME;
 
   protected static final String FIELD_KEY_1 = "field-1";
   protected static final String VALUE_1 = "value-1";
@@ -70,6 +70,10 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @BeforeEach
   public void setUp() {
+    STREAM_KEY_1 = keys.key("{%test%}:stream-1");
+    STREAM_KEY_2 = keys.key("{%test%}:stream-2");
+    GROUP_NAME = keys.name("group-1");
+    CONSUMER_NAME = keys.name("consumer-1");
     setUpTestStream();
   }
 

--- a/src/test/java/redis/clients/jedis/commands/unified/StreamsCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/StreamsCommandsTestBase.java
@@ -37,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag("integration")
 public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBase {
-
   protected String STREAM_KEY_1;
   protected String STREAM_KEY_2;
   protected String GROUP_NAME;
@@ -104,8 +103,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @Test
   public void xaddBasic() {
-    setUpTestStream();
-
     // Test basic XADD with auto-generated ID
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1, StreamEntryID.NEW_ENTRY, HASH_1);
     assertNotNull(id1);
@@ -125,8 +122,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @Test
   public void xaddWithSpecificId() {
-    setUpTestStream();
-
     // Test XADD with specific ID
     StreamEntryID specificId = new StreamEntryID("1000-0");
     StreamEntryID resultId = jedis.xadd(STREAM_KEY_1, specificId, HASH_1);
@@ -142,8 +137,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @Test
   public void xaddWithParams() {
-    setUpTestStream();
-
     // Test XADD with maxLen parameter
     populateTestStreamWithValues(STREAM_KEY_1, 5, HASH_1);
 
@@ -156,8 +149,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @Test
   public void xaddErrorCases() {
-    setUpTestStream();
-
     // Test XADD with empty hash should fail
     try {
       Map<String, String> emptyHash = new HashMap<>();
@@ -177,7 +168,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @CsvSource({ "KEEP_REFERENCES,3", "DELETE_REFERENCES,0" })
   @SinceRedisVersion("8.1.240")
   public void xaddWithTrimmingMode(StreamDeletionPolicy trimMode, int expected) {
-    setUpTestStream();
     Map<String, String> map = singletonMap("field", "value");
 
     // Add initial entries to the stream
@@ -210,7 +200,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xaddWithTrimmingModeAcknowledged() {
-    setUpTestStream();
     Map<String, String> map = singletonMap("field", "value");
 
     // Add initial entries to the stream
@@ -252,8 +241,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @Test
   public void xtrimBasic() {
-    setUpTestStream();
-
     // Add test entries
     populateTestStreamWithValues(STREAM_KEY_1, 5, HASH_1);
 
@@ -265,8 +252,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @Test
   public void xtrimWithParams() {
-    setUpTestStream();
-
     // Add test entries with specific IDs
     populateTestStreamWithValues(STREAM_KEY_1, 5, HASH_1);
 
@@ -284,8 +269,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @Test
   public void xtrimApproximate() {
-    setUpTestStream();
-
     // Add many entries
     populateTestStreamWithValues(STREAM_KEY_1, 10, HASH_1);
 
@@ -299,7 +282,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @CsvSource({ "KEEP_REFERENCES,3", "DELETE_REFERENCES,1" })
   @SinceRedisVersion("8.1.240")
   public void xaddWithMinIdTrimmingMode(StreamDeletionPolicy trimMode, int expected) {
-    setUpTestStream();
     Map<String, String> map = singletonMap("field", "value");
 
     // Add initial entries with specific IDs
@@ -335,7 +317,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xaddWithApproximateTrimmingAndTrimmingMode() {
-    setUpTestStream();
     Map<String, String> map = singletonMap("field", "value");
 
     // Add initial entries
@@ -367,7 +348,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xaddWithExactTrimmingAndTrimmingMode() {
-    setUpTestStream();
     Map<String, String> map = singletonMap("field", "value");
 
     // Add initial entries
@@ -399,7 +379,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xaddWithLimitAndTrimmingMode() {
-    setUpTestStream();
     Map<String, String> map = singletonMap("field", "value");
 
     // Add initial entries
@@ -436,8 +415,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @Test
   public void xackBasic() {
-    setUpTestStream();
-
     // Add a message to the stream
     StreamEntryID messageId = jedis.xadd(STREAM_KEY_1, StreamEntryID.NEW_ENTRY, HASH_1);
     assertNotNull(messageId);
@@ -459,8 +436,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @Test
   public void xackMultipleMessages() {
-    setUpTestStream();
-
     // Add multiple messages
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     StreamEntryID id2 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("2-0"), HASH_2);
@@ -483,8 +458,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @Test
   public void xackNonExistentMessage() {
-    setUpTestStream();
-
     // Consumer group already created in setUpTestStream()
     // Test XACK with non-existent message ID
     StreamEntryID nonExistentId = new StreamEntryID("999-0");
@@ -496,8 +469,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @Test
   public void xdelBasic() {
-    setUpTestStream();
-
     // Add test entries
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     StreamEntryID id2 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("2-0"), HASH_2);
@@ -511,8 +482,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @Test
   public void xdelMultipleEntries() {
-    setUpTestStream();
-
     // Add test entries
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     StreamEntryID id2 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("2-0"), HASH_2);
@@ -527,8 +496,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @Test
   public void xdelNonExistentEntries() {
-    setUpTestStream();
-
     // Add one entry
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     assertEquals(1L, jedis.xlen(STREAM_KEY_1));
@@ -542,8 +509,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
 
   @Test
   public void xdelEmptyStream() {
-    setUpTestStream();
-
     // Test XDEL on empty stream
     StreamEntryID nonExistentId = new StreamEntryID("1-0");
     long deleted = jedis.xdel(STREAM_KEY_1, nonExistentId);
@@ -555,8 +520,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xackdelBasic() {
-    setUpTestStream();
-
     // Add a message to the stream
     StreamEntryID messageId = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     assertNotNull(messageId);
@@ -584,8 +547,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xackdelWithTrimMode() {
-    setUpTestStream();
-
     // Add multiple messages
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     StreamEntryID id2 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("2-0"), HASH_2);
@@ -613,8 +574,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xackdelUnreadMessages() {
-    setUpTestStream();
-
     // Add test entries but don't read them
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
 
@@ -632,8 +591,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xackdelMultipleMessages() {
-    setUpTestStream();
-
     // Add multiple messages
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     StreamEntryID id2 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("2-0"), HASH_2);
@@ -666,8 +623,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.7.225")
   public void xnackBasicSilent() {
-    setUpTestStream();
-
     // Add and read a message
     StreamEntryID messageId = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     Map<String, StreamEntryID> streams = singletonMap(STREAM_KEY_1,
@@ -683,8 +638,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.7.225")
   public void xnackBasicFail() {
-    setUpTestStream();
-
     StreamEntryID messageId = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     Map<String, StreamEntryID> streams = singletonMap(STREAM_KEY_1,
       StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
@@ -698,8 +651,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.7.225")
   public void xnackBasicFatal() {
-    setUpTestStream();
-
     StreamEntryID messageId = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     Map<String, StreamEntryID> streams = singletonMap(STREAM_KEY_1,
       StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
@@ -713,8 +664,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.7.225")
   public void xnackMultipleMessages() {
-    setUpTestStream();
-
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     StreamEntryID id2 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("2-0"), HASH_2);
     Map<String, StreamEntryID> streams = singletonMap(STREAM_KEY_1,
@@ -729,8 +678,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.7.225")
   public void xnackNonExistentMessage() {
-    setUpTestStream();
-
     StreamEntryID nonExistentId = new StreamEntryID("999-0");
     long nacked = jedis.xnack(STREAM_KEY_1, GROUP_NAME, XNackMode.SILENT, nonExistentId);
     assertEquals(0L, nacked);
@@ -741,8 +688,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xdelexBasic() {
-    setUpTestStream();
-
     // Add test entries
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     StreamEntryID id2 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("2-0"), HASH_2);
@@ -760,8 +705,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xdelexWithTrimMode() {
-    setUpTestStream();
-
     // Add test entries
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     StreamEntryID id2 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("2-0"), HASH_2);
@@ -779,8 +722,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xdelexMultipleEntries() {
-    setUpTestStream();
-
     // Add test entries
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     StreamEntryID id2 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("2-0"), HASH_2);
@@ -800,8 +741,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xdelexNonExistentEntries() {
-    setUpTestStream();
-
     // Add one entry
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     assertEquals(1L, jedis.xlen(STREAM_KEY_1));
@@ -820,8 +759,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xdelexWithConsumerGroups() {
-    setUpTestStream();
-
     // Add test entries
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("1-0"), HASH_1);
     StreamEntryID id2 = jedis.xadd(STREAM_KEY_1, new StreamEntryID("2-0"), HASH_2);
@@ -856,8 +793,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xdelexEmptyStream() {
-    setUpTestStream();
-
     // Test XDELEX on empty stream
     StreamEntryID nonExistentId = new StreamEntryID("1-0");
     List<StreamEntryDeletionResult> results = jedis.xdelex(STREAM_KEY_1, nonExistentId);
@@ -868,8 +803,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @SinceRedisVersion("8.1.240")
   public void xdelexNotAcknowledged() {
-    setUpTestStream();
-
     String groupName = "test_group";
 
     // Add initial entries and create consumer group
@@ -1263,7 +1196,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @EnabledOnCommand("XCFGSET")
   public void testXaddIdmpAuto() {
-
     // Add entry with IDMPAUTO
     Map<String, String> message = new HashMap<>();
     message.put("order", "12345");
@@ -1300,7 +1232,6 @@ public abstract class StreamsCommandsTestBase extends UnifiedJedisCommandsTestBa
   @Test
   @EnabledOnCommand("XCFGSET")
   public void testXaddIdmp() {
-
     // Add entry with explicit idempotent ID
     StreamEntryID id1 = jedis.xadd(STREAM_KEY_1,
         XAddParams.xAddParams().idmp("producer-1", "iid-001"), HASH_1);


### PR DESCRIPTION
## What

Migrates the shared stream fixture keys in `StreamsCommandsTestBase` and `StreamsBinaryCommandsTestBase` from static constants (`{stream}-1`, `{binary-stream}-1`, `group-1`, `consumer-1`) to per-test values derived from the inherited `TestKeyRegistry`, and removes the per-test `setUpTestStream()` calls that duplicated the `@BeforeEach` fixture.

## Why

The fixture keys are shared, well-known names on test endpoints used by the whole suite — the collision pattern that caused the flakes fixed in #4644. With the registry, every streams test works on uniquely namespaced keys (`{ClassName.testName}:stream-1`) that are deleted automatically in teardown, instead of relying on well-known names plus the blanket flush. Follows the conventions in `docs/integration-testing.md` ("Test data & structure conventions") already applied to the list (#4635) and set (#4638) tests, and covers the streams tests added by #4627.

## Changes

- The four fixture constants per base become instance fields initialized in the existing `@BeforeEach`: `keys.key("{%test%}:stream-1")` / `keys.bKey(...)` for stream keys, `keys.name(...)` for group/consumer names (test-unique values, not keys, so nothing is registered for cleanup), `SafeEncoder.encode(...)` on the binary side.
- The hash-tagged per-test prefix preserves the property the old `{stream}` tag provided: both streams of a test share one cluster slot.
- Field names keep their constant style (`STREAM_KEY_1`) so none of the ~90 test methods change.
- 53 leading `setUpTestStream()` calls removed — they repeated the `@BeforeEach` work (`DEL` + 2× `XGROUP CREATE`) on every test; only the two `startId` variants remain callable from tests, and the binary base's lifecycle method is renamed `setUp()` so it can no longer be invoked directly.
- Verified against the 8.10 docker env: full streams suites green — 364 runs (55 + 36 methods × standalone/cluster × RESP2/RESP3), 0 failures, 0 skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production API changes; behavior is equivalent aside from unique key names and registry teardown.
> 
> **Overview**
> Stream integration tests no longer use **shared static** Redis keys (`{stream}-1`, `group-1`, etc.). Fixture stream keys, groups, and consumers are now **per-test instance fields** set in `@BeforeEach` from the inherited `TestKeyRegistry` (`keys.key` / `keys.bKey` with `{%test%}:…` hash tags, `keys.name` for group/consumer names; binary paths use `SafeEncoder`).
> 
> That aligns streams bases with list/set test conventions and avoids cross-test collisions on shared Redis. **~50+ redundant `setUpTestStream()` calls** were removed from individual tests because `@BeforeEach` already deletes streams and creates consumer groups; the binary base’s lifecycle hook is renamed to `setUp()` so it isn’t callable from tests like the old public `setUpTestStream()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76e560827dd27f84fcb951e0f1da9a22bc7493d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->