### PR TITLE
Silence RESP3 auto-negotiation warning in tests

### DIFF
--- a/src/main/java/redis/clients/jedis/builders/SentinelClientBuilder.java
+++ b/src/main/java/redis/clients/jedis/builders/SentinelClientBuilder.java
@@ -109,7 +109,9 @@ public abstract class SentinelClientBuilder<C>
   @Override
   public C build() {
     if (sentinelClientConfig == null) {
-      sentinelClientConfig = DefaultJedisClientConfig.builder().build();
+      // Sentinel connections use the legacy Jedis client which does not support RESP3
+      // auto-negotiation, so the default config must opt out to avoid a spurious warning.
+      sentinelClientConfig = DefaultJedisClientConfig.builder().serverDefaultProtocol().build();
     }
 
     return super.build();

--- a/src/test/java/redis/clients/jedis/ACLJedisTest.java
+++ b/src/test/java/redis/clients/jedis/ACLJedisTest.java
@@ -66,6 +66,10 @@ public class ACLJedisTest extends JedisCommandsTestBase {
   @Test
   public void connectWithConfigInterface() {
     try (Jedis jedis = new Jedis(endpoint.getHostAndPort(), new JedisClientConfig() {
+      @Override
+      public boolean isAutoNegotiateProtocol() {
+        return false;
+      }
     })) {
       jedis.auth(endpoint.getUsername(), endpoint.getPassword());
       assertEquals("PONG", jedis.ping());
@@ -79,6 +83,11 @@ public class ACLJedisTest extends JedisCommandsTestBase {
       @Override
       public String getPassword() {
         return endpoint.getPassword();
+      }
+
+      @Override
+      public boolean isAutoNegotiateProtocol() {
+        return false;
       }
     })) {
       assertEquals("PONG", jedis.ping());

--- a/src/test/java/redis/clients/jedis/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/JedisPoolTest.java
@@ -77,7 +77,8 @@ public class JedisPoolTest {
   public void checkResourceWithConfig() {
     EndpointConfig endpoint = Endpoints.getRedisEndpoint("standalone7-with-lfu-policy");
     try (JedisPool pool = new JedisPool(endpoint.getHostAndPort(),
-        endpoint.getClientConfigBuilder().socketTimeoutMillis(5000).build())) {
+        endpoint.getClientConfigBuilder().serverDefaultProtocol().socketTimeoutMillis(5000)
+            .build())) {
 
       try (Jedis jedis = pool.getResource()) {
         assertEquals("PONG", jedis.ping());
@@ -448,7 +449,8 @@ public class JedisPoolTest {
     DefaultRedisCredentialsProvider credentialsProvider
         = new DefaultRedisCredentialsProvider(new DefaultRedisCredentials(null, endpointStandalone0.getPassword()));
     JedisFactory factory = new JedisFactory(endpointStandalone0.getHostAndPort(), DefaultJedisClientConfig.builder()
-        .credentialsProvider(credentialsProvider).clientName("my_shiny_client_name").build());
+        .serverDefaultProtocol().credentialsProvider(credentialsProvider)
+        .clientName("my_shiny_client_name").build());
 
     try (JedisPool pool = new JedisPool(new JedisPoolConfig(), factory)) {
       Jedis obj1_ref;
@@ -479,7 +481,8 @@ public class JedisPoolTest {
     DefaultRedisCredentialsProvider credentialsProvider
         = new DefaultRedisCredentialsProvider(new DefaultRedisCredentials(null, "bad password"));
     JedisFactory factory = new JedisFactory(endpointStandalone0.getHostAndPort(), DefaultJedisClientConfig.builder()
-        .credentialsProvider(credentialsProvider).clientName("my_shiny_client_name").build());
+        .serverDefaultProtocol().credentialsProvider(credentialsProvider)
+        .clientName("my_shiny_client_name").build());
 
     try (JedisPool pool = new JedisPool(new JedisPoolConfig(), factory)) {
       try (Jedis obj1 = pool.getResource()) {
@@ -500,7 +503,7 @@ public class JedisPoolTest {
   @Test
   public void testWithResource() {
     try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHostAndPort(),
-        endpointStandalone0.getClientConfigBuilder().build())) {
+        endpointStandalone0.getClientConfigBuilder().serverDefaultProtocol().build())) {
 
       pool.withResource(jedis -> {
         jedis.set(testKey, testValue);
@@ -515,7 +518,7 @@ public class JedisPoolTest {
   @Test
   public void testWithResourceReturnsConnectionToPool() {
     try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHostAndPort(),
-        endpointStandalone0.getClientConfigBuilder().build())) {
+        endpointStandalone0.getClientConfigBuilder().serverDefaultProtocol().build())) {
 
       pool.withResource(jedis -> {
         assertThat(pool.getNumActive(), equalTo(1));
@@ -529,7 +532,7 @@ public class JedisPoolTest {
   @Test
   public void testWithResourceGet() {
     try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHostAndPort(),
-        endpointStandalone0.getClientConfigBuilder().build())) {
+        endpointStandalone0.getClientConfigBuilder().serverDefaultProtocol().build())) {
 
       String result = pool.withResourceGet(jedis -> {
         jedis.set(testKey, testValue);
@@ -543,7 +546,7 @@ public class JedisPoolTest {
   @Test
   public void testWithResourceGetReturnsConnectionToPool() {
     try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHostAndPort(),
-        endpointStandalone0.getClientConfigBuilder().build())) {
+        endpointStandalone0.getClientConfigBuilder().serverDefaultProtocol().build())) {
 
       String result = pool.withResourceGet(jedis -> {
         assertThat(pool.getNumActive(), equalTo(1));

--- a/src/test/java/redis/clients/jedis/JedisTest.java
+++ b/src/test/java/redis/clients/jedis/JedisTest.java
@@ -78,6 +78,10 @@ public class JedisTest extends JedisCommandsTestBase {
   @Test
   public void connectWithEmptyConfigInterface() {
     try (Jedis jedis = new Jedis(endpoint.getHostAndPort(), new JedisClientConfig() {
+      @Override
+      public boolean isAutoNegotiateProtocol() {
+        return false;
+      }
     })) {
       jedis.auth(endpoint.getPassword());
       assertEquals("PONG", jedis.ping());
@@ -90,6 +94,11 @@ public class JedisTest extends JedisCommandsTestBase {
       @Override
       public String getPassword() {
         return endpoint.getPassword();
+      }
+
+      @Override
+      public boolean isAutoNegotiateProtocol() {
+        return false;
       }
     })) {
       assertEquals("PONG", jedis.ping());
@@ -120,7 +129,7 @@ public class JedisTest extends JedisCommandsTestBase {
     final String TIMEOUT_STR = "timeout";
 
     Jedis jedis = new Jedis(endpoint.getHostAndPort(),
-        endpoint.getClientConfigBuilder().timeoutMillis(15000).build());
+        endpoint.getClientConfigBuilder().serverDefaultProtocol().timeoutMillis(15000).build());
 
     // read current config
     final String timeout = jedis.configGet(TIMEOUT_STR).get(TIMEOUT_STR);
@@ -136,7 +145,8 @@ public class JedisTest extends JedisCommandsTestBase {
       jedis.close();
     } finally {
       // reset config
-      jedis = new Jedis(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder().build());
+      jedis = new Jedis(endpoint.getHostAndPort(),
+          endpoint.getClientConfigBuilder().serverDefaultProtocol().build());
       jedis.configSet(TIMEOUT_STR, timeout);
       jedis.close();
     }
@@ -144,7 +154,9 @@ public class JedisTest extends JedisCommandsTestBase {
 
   @Test
   public void infiniteTimeout() throws Exception {
-    try (Jedis timeoutJedis = new Jedis(endpoint.getHost(), endpoint.getPort(), 200, 200, 200)) {
+    try (Jedis timeoutJedis = new Jedis(endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().serverDefaultProtocol().connectionTimeoutMillis(200)
+            .socketTimeoutMillis(200).blockingSocketTimeoutMillis(200).build())) {
       timeoutJedis.auth(endpoint.getPassword());
       try {
         timeoutJedis.blpop(0, "foo");
@@ -288,7 +300,8 @@ public class JedisTest extends JedisCommandsTestBase {
     Instant start = Instant.now();
 
     try (ServerSocket server = new ServerSocket(fakePort);
-        Jedis jedis = new Jedis(uri, timeoutMillis)) {
+        Jedis jedis = new Jedis(uri, DefaultJedisClientConfig.builder().serverDefaultProtocol()
+            .connectionTimeoutMillis(timeoutMillis).socketTimeoutMillis(timeoutMillis).build())) {
       fail("Jedis should fail to connect to a fake port");
     } catch (JedisConnectionException ex) {
       assertSame(SocketTimeoutException.class, ex.getCause().getClass());
@@ -328,7 +341,7 @@ public class JedisTest extends JedisCommandsTestBase {
   @SinceRedisVersion(value = "7.2.0", message = "see https://redis.io/docs/latest/commands/client-setinfo/")
   public void clientSetInfoDefault() {
     try (Jedis jedis = new Jedis(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder()
-        .clientSetInfoConfig(ClientSetInfoConfig.DEFAULT).build())) {
+        .serverDefaultProtocol().clientSetInfoConfig(ClientSetInfoConfig.DEFAULT).build())) {
       assertEquals("PONG", jedis.ping());
       String info = jedis.clientInfo();
       assertTrue(info.contains("lib-name=" + JedisMetaInfo.getArtifactId()));
@@ -339,7 +352,7 @@ public class JedisTest extends JedisCommandsTestBase {
   @Test
   public void clientSetInfoDisabled() {
     try (Jedis jedis = new Jedis(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder()
-        .clientSetInfoConfig(ClientSetInfoConfig.DISABLED).build())) {
+        .serverDefaultProtocol().clientSetInfoConfig(ClientSetInfoConfig.DISABLED).build())) {
       assertEquals("PONG", jedis.ping());
       String info = jedis.clientInfo();
       assertFalse(info.contains("lib-name=" + JedisMetaInfo.getArtifactId()));
@@ -353,7 +366,8 @@ public class JedisTest extends JedisCommandsTestBase {
     final String libNameSuffix = "for-redis";
     ClientSetInfoConfig setInfoConfig = ClientSetInfoConfig.withLibNameSuffix(libNameSuffix);
     try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
-        endpoint.getClientConfigBuilder().clientSetInfoConfig(setInfoConfig).build())) {
+        endpoint.getClientConfigBuilder().serverDefaultProtocol()
+            .clientSetInfoConfig(setInfoConfig).build())) {
       assertEquals("PONG", jedis.ping());
       String info = jedis.clientInfo();
       assertTrue(
@@ -369,7 +383,8 @@ public class JedisTest extends JedisCommandsTestBase {
         .build();
     ClientSetInfoConfig setInfoConfig = new ClientSetInfoConfig(driverInfo);
     try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
-        endpoint.getClientConfigBuilder().clientSetInfoConfig(setInfoConfig).build())) {
+        endpoint.getClientConfigBuilder().serverDefaultProtocol()
+            .clientSetInfoConfig(setInfoConfig).build())) {
       assertEquals("PONG", jedis.ping());
       String info = jedis.clientInfo();
       assertTrue(
@@ -385,7 +400,8 @@ public class JedisTest extends JedisCommandsTestBase {
         .addUpstreamDriver("lettuce-core", "6.4.1").addUpstreamDriver("redisson", "3.25.0").build();
     ClientSetInfoConfig setInfoConfig = new ClientSetInfoConfig(driverInfo);
     try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
-        endpoint.getClientConfigBuilder().clientSetInfoConfig(setInfoConfig).build())) {
+        endpoint.getClientConfigBuilder().serverDefaultProtocol()
+            .clientSetInfoConfig(setInfoConfig).build())) {
       assertEquals("PONG", jedis.ping());
       String info = jedis.clientInfo();
       assertTrue(info.contains("lib-name=" + JedisMetaInfo.getArtifactId()

--- a/src/test/java/redis/clients/jedis/MigratePipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/MigratePipeliningTest.java
@@ -70,7 +70,8 @@ public class MigratePipeliningTest extends JedisCommandsTestBase {
   public void setUp() throws Exception {
     super.setUp();
 
-    dest = new Jedis(host, port, 500);
+    dest = new Jedis(new HostAndPort(host, port),
+        DefaultJedisClientConfig.builder().serverDefaultProtocol().timeoutMillis(500).build());
     dest.flushAll();
     dest.select(db);
 

--- a/src/test/java/redis/clients/jedis/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/PipeliningTest.java
@@ -534,14 +534,16 @@ public class PipeliningTest extends JedisCommandsTestBase {
   @Test
   public void testSyncWithNoCommandQueued() {
     // we need to test with fresh instance of Jedis
-    Jedis jedis2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500);
+    Jedis jedis2 = new Jedis(endpoint.getHostAndPort(),
+        DefaultJedisClientConfig.builder().serverDefaultProtocol().timeoutMillis(500).build());
 
     Pipeline pipeline = jedis2.pipelined();
     pipeline.sync();
 
     jedis2.close();
 
-    jedis2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500);
+    jedis2 = new Jedis(endpoint.getHostAndPort(),
+        DefaultJedisClientConfig.builder().serverDefaultProtocol().timeoutMillis(500).build());
 
     pipeline = jedis2.pipelined();
     List<Object> resp = pipeline.syncAndReturnAll();
@@ -553,7 +555,8 @@ public class PipeliningTest extends JedisCommandsTestBase {
   @Test
   public void testCloseable() throws IOException {
     // we need to test with fresh instance of Jedis
-    Jedis jedis2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500);
+    Jedis jedis2 = new Jedis(endpoint.getHostAndPort(),
+        DefaultJedisClientConfig.builder().serverDefaultProtocol().timeoutMillis(500).build());
     jedis2.auth(endpoint.getPassword());
 
     Pipeline pipeline = jedis2.pipelined();

--- a/src/test/java/redis/clients/jedis/RedisClientTest.java
+++ b/src/test/java/redis/clients/jedis/RedisClientTest.java
@@ -41,7 +41,7 @@ public class RedisClientTest {
     endpointStandalone1 = Endpoints.getRedisEndpoint("standalone1");
 
     try (Jedis control = new Jedis(endpointStandalone1.getHostAndPort(),
-        endpointStandalone1.getClientConfigBuilder().build())) {
+        endpointStandalone1.getClientConfigBuilder().serverDefaultProtocol().build())) {
       control.flushAll();
     }
   }

--- a/src/test/java/redis/clients/jedis/SentineledConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/SentineledConnectionProviderTest.java
@@ -61,7 +61,7 @@ public class SentineledConnectionProviderTest {
 
       try (SentineledConnectionProvider provider = new SentineledConnectionProvider(MASTER_NAME,
           DefaultJedisClientConfig.builder().timeoutMillis(1000).password("foobared").database(2).build(),
-          sentinels, DefaultJedisClientConfig.builder().build())) {
+          sentinels, DefaultJedisClientConfig.builder().serverDefaultProtocol().build())) {
 
         provider.getConnection().close();
       }
@@ -80,7 +80,7 @@ public class SentineledConnectionProviderTest {
 
     try (SentineledConnectionProvider sut = new SentineledConnectionProvider(MASTER_NAME,
             primary.getClientConfigBuilder().build(), config, sentinels,
-            DefaultJedisClientConfig.builder().build())) {
+            DefaultJedisClientConfig.builder().serverDefaultProtocol().build())) {
 
       HostAndPort resolvedPrimary = sut.getCurrentMaster();
       ConnectionPool pool = ReflectionTestUtil.getField(sut,"pool");
@@ -110,7 +110,7 @@ public class SentineledConnectionProviderTest {
 
     try (SentineledConnectionProvider sut = new SentineledConnectionProvider(MASTER_NAME,
             primary.getClientConfigBuilder().build(), config, sentinels,
-            DefaultJedisClientConfig.builder().build())) {
+            DefaultJedisClientConfig.builder().serverDefaultProtocol().build())) {
 
       HostAndPort resolvedPrimary = sut.getCurrentMaster();
       ConnectionPool pool = ReflectionTestUtil.getField(sut,"pool");
@@ -137,7 +137,8 @@ public class SentineledConnectionProviderTest {
     wrongSentinels.add(new HostAndPort("localhost", 65431));
     assertThrows(JedisConnectionException.class, () -> {
       try (SentineledConnectionProvider provider = new SentineledConnectionProvider(MASTER_NAME,
-          DefaultJedisClientConfig.builder().build(), wrongSentinels, DefaultJedisClientConfig.builder().build())) {
+          DefaultJedisClientConfig.builder().build(), wrongSentinels,
+          DefaultJedisClientConfig.builder().serverDefaultProtocol().build())) {
       }
     });
   }
@@ -147,7 +148,8 @@ public class SentineledConnectionProviderTest {
     final String wrongMasterName = "wrongMasterName";
     assertThrows(JedisException.class, () -> {
       try (SentineledConnectionProvider provider = new SentineledConnectionProvider(wrongMasterName,
-          DefaultJedisClientConfig.builder().build(), sentinels, DefaultJedisClientConfig.builder().build())) {
+          DefaultJedisClientConfig.builder().build(), sentinels,
+          DefaultJedisClientConfig.builder().serverDefaultProtocol().build())) {
       }
     });
   }

--- a/src/test/java/redis/clients/jedis/commands/jedis/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/AllKindOfValuesCommandsTest.java
@@ -667,7 +667,8 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
     assertEquals(1000, jedis2.objectIdletime("bar1").longValue());
     jedis2.close();
 
-    Jedis lfuJedis = new Jedis(lfuEndpoint.getHostAndPort(), lfuEndpoint.getClientConfigBuilder().timeoutMillis(500).build());;
+    Jedis lfuJedis = new Jedis(lfuEndpoint.getHostAndPort(),
+        lfuEndpoint.getClientConfigBuilder().serverDefaultProtocol().timeoutMillis(500).build());
     lfuJedis.restore("bar1", 1000, serialized, RestoreParams.restoreParams().replace().frequency(90));
     assertEquals(90, lfuJedis.objectFreq("bar1").longValue());
     lfuJedis.close();

--- a/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedClass;
 
 import org.junit.jupiter.params.provider.MethodSource;
+import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.args.ClientAttributeOption;
@@ -54,7 +55,8 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    client = new Jedis(endpoint.getHost(), endpoint.getPort(), 500);
+    client = new Jedis(endpoint.getHostAndPort(),
+        DefaultJedisClientConfig.builder().serverDefaultProtocol().timeoutMillis(500).build());
     client.auth(endpoint.getPassword());
     client.clientSetname(clientName);
   }
@@ -120,7 +122,8 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
 
   @Test
   public void clientIdmultipleConnection() {
-    try (Jedis client2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500)) {
+    try (Jedis client2 = new Jedis(endpoint.getHostAndPort(),
+        DefaultJedisClientConfig.builder().serverDefaultProtocol().timeoutMillis(500).build())) {
       client2.auth(endpoint.getPassword());
       client2.clientSetname("fancy_jedis_another_name");
 
@@ -262,7 +265,8 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
   @ConditionalOnEnv(value = TestEnvUtil.ENV_REDIS_ENTERPRISE, enabled = false)
   public void killUser() {
     client.aclSetUser("test_kill", "on", "+acl", ">password1");
-    try (Jedis client2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500)) {
+    try (Jedis client2 = new Jedis(endpoint.getHostAndPort(),
+        DefaultJedisClientConfig.builder().serverDefaultProtocol().timeoutMillis(500).build())) {
       client2.auth("test_kill", "password1");
 
       assertEquals(1, jedis.clientKill(new ClientKillParams().user("test_kill")));
@@ -280,7 +284,8 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
     // sleep twice the maxAge, to be sure
     Thread.sleep(maxAge * 2 * 1000);
 
-    try (Jedis client2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500)) {
+    try (Jedis client2 = new Jedis(endpoint.getHostAndPort(),
+        DefaultJedisClientConfig.builder().serverDefaultProtocol().timeoutMillis(500).build())) {
       client2.auth(endpoint.getPassword());
 
       long killedClients = jedis.clientKill(new ClientKillParams().maxAge(maxAge));

--- a/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
@@ -142,7 +142,7 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
     EndpointConfig endpoint = Endpoints.getRedisEndpoint("standalone0");
 
     try (Jedis master = new Jedis(endpoint.getHostAndPort(),
-        endpoint.getClientConfigBuilder().build())) {
+        endpoint.getClientConfigBuilder().serverDefaultProtocol().build())) {
 
       List<Object> role = master.role();
       assertEquals("master", role.get(0));
@@ -165,7 +165,7 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
         "standalone4-replica-of-standalone1");
 
     try (Jedis slave = new Jedis(secondaryEndpoint.getHostAndPort(),
-        secondaryEndpoint.getClientConfigBuilder().build())) {
+        secondaryEndpoint.getClientConfigBuilder().serverDefaultProtocol().build())) {
 
       List<Object> role = slave.role();
       assertEquals("slave", role.get(0));

--- a/src/test/java/redis/clients/jedis/commands/jedis/FailoverCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/FailoverCommandsTest.java
@@ -35,10 +35,12 @@ public class FailoverCommandsTest {
   @BeforeEach
   public void prepare() {
     String role1, role2;
-    try (Jedis jedis1 = new Jedis(node1.getHostAndPort(), node1.getClientConfigBuilder().build())) {
+    try (Jedis jedis1 = new Jedis(node1.getHostAndPort(),
+        node1.getClientConfigBuilder().serverDefaultProtocol().build())) {
       role1 = (String) jedis1.role().get(0);
     }
-    try (Jedis jedis2 = new Jedis(node2.getHostAndPort(), node2.getClientConfigBuilder().build())) {
+    try (Jedis jedis2 = new Jedis(node2.getHostAndPort(),
+        node2.getClientConfigBuilder().serverDefaultProtocol().build())) {
       role2 = (String) jedis2.role().get(0);
     }
 

--- a/src/test/java/redis/clients/jedis/commands/jedis/MigrateTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/MigrateTest.java
@@ -68,12 +68,13 @@ public class MigrateTest extends JedisCommandsTestBase {
   public void setUp() throws Exception {
     super.setUp();
 
-    dest = new Jedis(host, port, 500);
+    dest = new Jedis(new HostAndPort(host, port),
+        DefaultJedisClientConfig.builder().serverDefaultProtocol().timeoutMillis(500).build());
     dest.flushAll();
     dest.select(db);
 
     destAuth = new Jedis(destEndpointWithAuth.getHostAndPort(),
-        destEndpointWithAuth.getClientConfigBuilder().build());
+        destEndpointWithAuth.getClientConfigBuilder().serverDefaultProtocol().build());
     destAuth.flushAll();
     destAuth.select(dbAuth);
   }

--- a/src/test/java/redis/clients/jedis/commands/jedis/TransactionCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/TransactionCommandsTest.java
@@ -63,7 +63,7 @@ public class TransactionCommandsTest extends JedisCommandsTestBase {
     super.setUp();
 
     nj = new Jedis(endpoint.getHostAndPort(),
-        endpoint.getClientConfigBuilder().timeoutMillis(500).build());
+        endpoint.getClientConfigBuilder().serverDefaultProtocol().timeoutMillis(500).build());
   }
 
   @AfterEach
@@ -382,7 +382,7 @@ public class TransactionCommandsTest extends JedisCommandsTestBase {
   public void testCloseable() {
     // we need to test with fresh instance of Jedis
     Jedis jedis2 = new Jedis(endpoint.getHostAndPort(),
-        endpoint.getClientConfigBuilder().timeoutMillis(500).build());;
+        endpoint.getClientConfigBuilder().serverDefaultProtocol().timeoutMillis(500).build());;
 
     Transaction transaction = jedis2.multi();
     transaction.set("a", "1");

--- a/src/test/java/redis/clients/jedis/commands/unified/sentinel/SentinelAllKindOfValuesCommandsIT.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/sentinel/SentinelAllKindOfValuesCommandsIT.java
@@ -23,7 +23,8 @@ public class SentinelAllKindOfValuesCommandsIT extends AllKindOfValuesCommandsTe
 
   static Set<HostAndPort> sentinels;
 
-  static final JedisClientConfig sentinelClientConfig = DefaultJedisClientConfig.builder().build();
+  static final JedisClientConfig sentinelClientConfig = DefaultJedisClientConfig.builder()
+      .serverDefaultProtocol().build();
 
   static EndpointConfig primary;
 

--- a/src/test/java/redis/clients/jedis/csc/SSLRedisClientSideCacheTest.java
+++ b/src/test/java/redis/clients/jedis/csc/SSLRedisClientSideCacheTest.java
@@ -30,7 +30,7 @@ public class SSLRedisClientSideCacheTest extends RedisClientSideCacheTestBase {
     TlsUtil.setCustomTrustStore(trustStorePath, "changeit");
 
     try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
-        endpoint.getClientConfigBuilder().build())) {
+        endpoint.getClientConfigBuilder().serverDefaultProtocol().build())) {
       assumeTrue(RedisVersionUtil.getRedisVersion(jedis).isGreaterThanOrEqualTo(RedisVersion.V7_4),
           "Jedis Client side caching is only supported with 'Redis 7.4' or later.");
     }

--- a/src/test/java/redis/clients/jedis/mcf/MultiDbConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiDbConnectionProviderTest.java
@@ -45,9 +45,9 @@ public class MultiDbConnectionProviderTest {
     endpointStandalone1 = Endpoints.getRedisEndpoint("standalone1");
 
     controlJedis0 = new Jedis(endpointStandalone0.getHostAndPort(),
-        endpointStandalone0.getClientConfigBuilder().build());
+        endpointStandalone0.getClientConfigBuilder().serverDefaultProtocol().build());
     controlJedis1 = new Jedis(endpointStandalone1.getHostAndPort(),
-        endpointStandalone1.getClientConfigBuilder().build());
+        endpointStandalone1.getClientConfigBuilder().serverDefaultProtocol().build());
   }
 
   @AfterAll

--- a/src/test/java/redis/clients/jedis/misc/AutomaticFailoverTest.java
+++ b/src/test/java/redis/clients/jedis/misc/AutomaticFailoverTest.java
@@ -71,7 +71,7 @@ public class AutomaticFailoverTest {
   @BeforeEach
   public void setUp() {
     jedis2 = new Jedis(workingEndpoint.getHostAndPort(),
-        workingEndpoint.getClientConfigBuilder().build());
+        workingEndpoint.getClientConfigBuilder().serverDefaultProtocol().build());
     jedis2.flushAll();
   }
 

--- a/src/test/java/redis/clients/jedis/prefix/RedisSentinelClientPrefixedKeysTest.java
+++ b/src/test/java/redis/clients/jedis/prefix/RedisSentinelClientPrefixedKeysTest.java
@@ -18,7 +18,8 @@ public class RedisSentinelClientPrefixedKeysTest extends PrefixedKeysTest<RedisS
   private static final String MASTER_NAME = "mymaster";
   private static final JedisClientConfig MASTER_CLIENT_CONFIG = DefaultJedisClientConfig.builder().password("foobared").build();
   private static Set<HostAndPort> SENTINEL_NODES;
-  private static final JedisClientConfig SENTINEL_CLIENT_CONFIG = DefaultJedisClientConfig.builder().build();
+  private static final JedisClientConfig SENTINEL_CLIENT_CONFIG = DefaultJedisClientConfig.builder()
+      .serverDefaultProtocol().build();
 
   @BeforeAll
   public static void prepareEndpoints() {

--- a/src/test/java/redis/clients/jedis/tls/ACLJedisIT.java
+++ b/src/test/java/redis/clients/jedis/tls/ACLJedisIT.java
@@ -20,7 +20,8 @@ public class ACLJedisIT extends JedisTlsTestBase {
    */
   @Test
   public void connectWithSsl() {
-    try (Jedis jedis = new Jedis(aclEndpoint.getHost(), aclEndpoint.getPort(), true)) {
+    try (Jedis jedis = new Jedis(aclEndpoint.getHostAndPort(),
+        DefaultJedisClientConfig.builder().serverDefaultProtocol().ssl(true).build())) {
       jedis.auth(aclEndpoint.getUsername(), aclEndpoint.getPassword());
       assertEquals("PONG", jedis.ping());
     }

--- a/src/test/java/redis/clients/jedis/tls/ACLRedisSentinelClientIT.java
+++ b/src/test/java/redis/clients/jedis/tls/ACLRedisSentinelClientIT.java
@@ -50,7 +50,7 @@ public class ACLRedisSentinelClientIT extends RedisSentinelTlsTestBase {
         .password(aclEndpoint.getPassword()).hostAndPortMapper(PRIMARY_SSL_PORT_MAPPER).build();
 
     DefaultJedisClientConfig sentinelConfig = Endpoints.getRedisEndpoint("sentinel-standalone0-tls")
-        .getClientConfigBuilder().clientName("sentinel-client").ssl(true)
+        .getClientConfigBuilder().serverDefaultProtocol().clientName("sentinel-client").ssl(true)
         .hostAndPortMapper(SENTINEL_SSL_PORT_MAPPER).build();
 
     try (RedisSentinelClient client = RedisSentinelClient.builder().masterName(MASTER_NAME)
@@ -69,7 +69,7 @@ public class ACLRedisSentinelClientIT extends RedisSentinelTlsTestBase {
         .clientName("master-client").ssl(true).hostAndPortMapper(PRIMARY_SSL_PORT_MAPPER).build();
 
     DefaultJedisClientConfig sentinelConfig = Endpoints.getRedisEndpoint("sentinel-standalone0-tls")
-        .getClientConfigBuilder().clientName("sentinel-client").ssl(true)
+        .getClientConfigBuilder().serverDefaultProtocol().clientName("sentinel-client").ssl(true)
         .hostAndPortMapper(SENTINEL_SSL_PORT_MAPPER).build();
 
     try (RedisSentinelClient client = RedisSentinelClient.builder().masterName(MASTER_NAME)

--- a/src/test/java/redis/clients/jedis/tls/ClientAuthJedisIT.java
+++ b/src/test/java/redis/clients/jedis/tls/ClientAuthJedisIT.java
@@ -33,8 +33,8 @@ public class ClientAuthJedisIT extends ClientAuthTestBase {
   public void connectWithMtlsUser1() {
     SslOptions sslOptions = createMtlsSslOptionsUser1();
 
-    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
-        DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())) {
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(), DefaultJedisClientConfig.builder()
+        .serverDefaultProtocol().sslOptions(sslOptions).build())) {
       assertEquals("PONG", jedis.ping());
       // Verify username based on Redis version
       assertExpectedUsername(jedis, jedis.aclWhoAmI(), MTLS_USER_1);
@@ -49,8 +49,8 @@ public class ClientAuthJedisIT extends ClientAuthTestBase {
   public void connectWithMtlsUser2() {
     SslOptions sslOptions = createMtlsSslOptionsUser2();
 
-    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
-        DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())) {
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(), DefaultJedisClientConfig.builder()
+        .serverDefaultProtocol().sslOptions(sslOptions).build())) {
       assertEquals("PONG", jedis.ping());
       // Verify username based on Redis version
       assertExpectedUsername(jedis, jedis.aclWhoAmI(), MTLS_USER_2);
@@ -66,8 +66,8 @@ public class ClientAuthJedisIT extends ClientAuthTestBase {
   public void connectWithMtlsUserWithoutAcl() {
     SslOptions sslOptions = createMtlsSslOptionsUserWithoutAcl();
 
-    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
-        DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())) {
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(), DefaultJedisClientConfig.builder()
+        .serverDefaultProtocol().sslOptions(sslOptions).build())) {
       assertEquals("PONG", jedis.ping());
       assertEquals("default", jedis.aclWhoAmI());
     }
@@ -80,8 +80,8 @@ public class ClientAuthJedisIT extends ClientAuthTestBase {
   public void connectWithHostAndPort() {
     SslOptions sslOptions = createMtlsSslOptionsUser1();
 
-    try (Jedis jedis = new Jedis(endpoint.getHost(), endpoint.getPort(),
-        DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())) {
+    try (Jedis jedis = new Jedis(endpoint.getHost(), endpoint.getPort(), DefaultJedisClientConfig
+        .builder().serverDefaultProtocol().sslOptions(sslOptions).build())) {
       assertEquals("PONG", jedis.ping());
       assertExpectedUsername(jedis, jedis.aclWhoAmI(), MTLS_USER_1);
     }
@@ -94,8 +94,8 @@ public class ClientAuthJedisIT extends ClientAuthTestBase {
   public void performBasicOperationsWithMtls() {
     SslOptions sslOptions = createMtlsSslOptionsUser1();
 
-    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
-        DefaultJedisClientConfig.builder().sslOptions(sslOptions).build())) {
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(), DefaultJedisClientConfig.builder()
+        .serverDefaultProtocol().sslOptions(sslOptions).build())) {
       // Test basic operations
       String key = "mtls-jedis-test-key";
       String value = "mtls-jedis-test-value";

--- a/src/test/java/redis/clients/jedis/tls/JedisIT.java
+++ b/src/test/java/redis/clients/jedis/tls/JedisIT.java
@@ -21,7 +21,8 @@ public class JedisIT extends JedisTlsTestBase {
 
   @Test
   public void connectWithSsl() {
-    try (Jedis jedis = new Jedis(endpoint.getHost(), endpoint.getPort(), true)) {
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
+        DefaultJedisClientConfig.builder().serverDefaultProtocol().ssl(true).build())) {
       jedis.auth(endpoint.getPassword());
       assertEquals("PONG", jedis.ping());
     }
@@ -42,6 +43,11 @@ public class JedisIT extends JedisTlsTestBase {
       @Override
       public boolean isSsl() {
         return true;
+      }
+
+      @Override
+      public boolean isAutoNegotiateProtocol() {
+        return false;
       }
     })) {
       jedis.auth(endpoint.getPassword());
@@ -79,8 +85,8 @@ public class JedisIT extends JedisTlsTestBase {
   @Test
   public void connectWrongHost() {
     // Connection with hostname mismatch should fail
-    assertThrows(JedisConnectionException.class,
-      () -> new Jedis(wrongHostEndpoint.getHost(), wrongHostEndpoint.getPort(), true));
+    assertThrows(JedisConnectionException.class, () -> new Jedis(wrongHostEndpoint.getHostAndPort(),
+        DefaultJedisClientConfig.builder().serverDefaultProtocol().ssl(true).build()));
 
     // Same test using URI
     assertThrows(JedisConnectionException.class, () -> new Jedis(wrongHostEndpoint.getURI()));
@@ -94,7 +100,7 @@ public class JedisIT extends JedisTlsTestBase {
   public void connectWrongHostWithSslParameters() {
     // Custom SSLParameters without endpoint identification allows connection despite hostname
     // mismatch
-    JedisClientConfig config = DefaultJedisClientConfig.builder().ssl(true)
+    JedisClientConfig config = DefaultJedisClientConfig.builder().serverDefaultProtocol().ssl(true)
         .sslParameters(new SSLParameters()).user(wrongHostEndpoint.getUsername())
         .password(wrongHostEndpoint.getPassword()).build();
     try (

--- a/src/test/java/redis/clients/jedis/tls/JedisSentinelPoolIT.java
+++ b/src/test/java/redis/clients/jedis/tls/JedisSentinelPoolIT.java
@@ -42,7 +42,8 @@ public class JedisSentinelPoolIT extends RedisSentinelTlsTestBase {
   @Test
   public void sentinelWithoutSslConnectsToRedisWithSsl() {
     DefaultJedisClientConfig masterConfig = aclTlsEndpoint.getClientConfigBuilder()
-        .clientName("master-client").hostAndPortMapper(PRIMARY_SSL_PORT_MAPPER).build();
+        .serverDefaultProtocol().clientName("master-client")
+        .hostAndPortMapper(PRIMARY_SSL_PORT_MAPPER).build();
 
     DefaultJedisClientConfig sentinelConfig = createSentinelConfigWithoutSsl();
 
@@ -63,10 +64,11 @@ public class JedisSentinelPoolIT extends RedisSentinelTlsTestBase {
   @Test
   public void sentinelWithSslConnectsToRedisWithoutSsl() {
     DefaultJedisClientConfig masterConfig = aclEndpoint.getClientConfigBuilder()
-        .clientName("master-client").build();
+        .serverDefaultProtocol().clientName("master-client").build();
 
     DefaultJedisClientConfig sentinelConfig = sentinelTlsEndpoint.getClientConfigBuilder()
-        .clientName("sentinel-client").hostAndPortMapper(SENTINEL_SSL_PORT_MAPPER).build();
+        .serverDefaultProtocol().clientName("sentinel-client")
+        .hostAndPortMapper(SENTINEL_SSL_PORT_MAPPER).build();
 
     try (JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels, masterConfig,
         sentinelConfig)) {
@@ -85,10 +87,12 @@ public class JedisSentinelPoolIT extends RedisSentinelTlsTestBase {
   @Test
   public void sentinelWithSslConnectsToRedisWithSsl() {
     DefaultJedisClientConfig masterConfig = aclTlsEndpoint.getClientConfigBuilder()
-        .clientName("master-client").hostAndPortMapper(PRIMARY_SSL_PORT_MAPPER).build();
+        .serverDefaultProtocol().clientName("master-client")
+        .hostAndPortMapper(PRIMARY_SSL_PORT_MAPPER).build();
 
     DefaultJedisClientConfig sentinelConfig = sentinelTlsEndpoint.getClientConfigBuilder()
-        .clientName("sentinel-client").hostAndPortMapper(SENTINEL_SSL_PORT_MAPPER).build();
+        .serverDefaultProtocol().clientName("sentinel-client")
+        .hostAndPortMapper(SENTINEL_SSL_PORT_MAPPER).build();
 
     try (JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels, masterConfig,
         sentinelConfig)) {

--- a/src/test/java/redis/clients/jedis/tls/RedisSentinelClientIT.java
+++ b/src/test/java/redis/clients/jedis/tls/RedisSentinelClientIT.java
@@ -66,8 +66,8 @@ public class RedisSentinelClientIT extends RedisSentinelTlsTestBase {
   public void connectWithWrongHost() {
     // Sentinel config with hostname mismatch should fail with default hostname verification
     DefaultJedisClientConfig sentinelConfig = DefaultJedisClientConfig.builder()
-        .user(sentinelWrongHost.getUsername()).password(sentinelWrongHost.getPassword()).ssl(true)
-        .build();
+        .serverDefaultProtocol().user(sentinelWrongHost.getUsername())
+        .password(sentinelWrongHost.getPassword()).ssl(true).build();
     assertThrows(JedisConnectionException.class, () -> {
       try (RedisSentinelClient client = RedisSentinelClient.builder().masterName(MASTER_NAME)
           .sentinels(sentinelsWrongHost).sentinelClientConfig(sentinelConfig).build()) {
@@ -84,7 +84,7 @@ public class RedisSentinelClientIT extends RedisSentinelTlsTestBase {
   public void connectWrongHostWithSslParameters() {
     // Custom SSLParameters without endpoint identification allows connection despite hostname
     // mismatch
-    JedisClientConfig sentinelConfig = DefaultJedisClientConfig.builder()
+    JedisClientConfig sentinelConfig = DefaultJedisClientConfig.builder().serverDefaultProtocol()
         .user(sentinelWrongHost.getUsername()).password(sentinelWrongHost.getPassword()).ssl(true)
         .sslParameters(new SSLParameters()).build();
 

--- a/src/test/java/redis/clients/jedis/tls/RedisSentinelTlsTestBase.java
+++ b/src/test/java/redis/clients/jedis/tls/RedisSentinelTlsTestBase.java
@@ -71,12 +71,13 @@ public abstract class RedisSentinelTlsTestBase {
 
   protected static DefaultJedisClientConfig createSentinelConfigWithSsl(SslOptions ssl) {
     return Endpoints.getRedisEndpoint("sentinel-standalone0-tls").getClientConfigBuilder()
-        .clientName("sentinel-client").sslOptions(ssl).hostAndPortMapper(SENTINEL_SSL_PORT_MAPPER)
-        .build();
+        .serverDefaultProtocol().clientName("sentinel-client").sslOptions(ssl)
+        .hostAndPortMapper(SENTINEL_SSL_PORT_MAPPER).build();
   }
 
   protected static DefaultJedisClientConfig createSentinelConfigWithoutSsl() {
-    return sentinel.getClientConfigBuilder().clientName("sentinel-client").build();
+    return sentinel.getClientConfigBuilder().serverDefaultProtocol().clientName("sentinel-client")
+        .build();
   }
 
   protected static Stream<Arguments> sslOptionsProvider() {

--- a/src/test/java/redis/clients/jedis/tls/SSLOptionsJedisIT.java
+++ b/src/test/java/redis/clients/jedis/tls/SSLOptionsJedisIT.java
@@ -43,7 +43,7 @@ public class SSLOptionsJedisIT extends JedisTlsTestBase {
   @MethodSource("sslOptionsProvider")
   void connectWithClientConfig(String testName, SslOptions ssl) {
     try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
-        endpoint.getClientConfigBuilder().sslOptions(ssl).build())) {
+        endpoint.getClientConfigBuilder().serverDefaultProtocol().sslOptions(ssl).build())) {
       assertEquals("PONG", jedis.ping());
     }
   }
@@ -53,8 +53,8 @@ public class SSLOptionsJedisIT extends JedisTlsTestBase {
    */
   @Test
   public void connectWithAcl() {
-    try (Jedis jedis = new Jedis(aclEndpoint.getHostAndPort(),
-        aclEndpoint.getClientConfigBuilder().sslOptions(sslOptions).build())) {
+    try (Jedis jedis = new Jedis(aclEndpoint.getHostAndPort(), aclEndpoint.getClientConfigBuilder()
+        .serverDefaultProtocol().sslOptions(sslOptions).build())) {
       assertEquals("PONG", jedis.ping());
     }
   }

--- a/src/test/java/redis/clients/jedis/tls/SSLOptionsJedisSentinelPoolIT.java
+++ b/src/test/java/redis/clients/jedis/tls/SSLOptionsJedisSentinelPoolIT.java
@@ -42,7 +42,7 @@ public class SSLOptionsJedisSentinelPoolIT extends RedisSentinelTlsTestBase {
   @Test
   public void sentinelWithoutSslConnectsToRedisWithSsl() {
     DefaultJedisClientConfig masterConfig = aclTlsEndpoint.getClientConfigBuilder()
-        .clientName("master-client").sslOptions(sslOptions)
+        .serverDefaultProtocol().clientName("master-client").sslOptions(sslOptions)
         .hostAndPortMapper(PRIMARY_SSL_PORT_MAPPER).build();
 
     DefaultJedisClientConfig sentinelConfig = createSentinelConfigWithoutSsl();
@@ -64,10 +64,11 @@ public class SSLOptionsJedisSentinelPoolIT extends RedisSentinelTlsTestBase {
   @Test
   public void sentinelWithSslConnectsToRedisWithoutSsl() {
     DefaultJedisClientConfig masterConfig = aclEndpoint.getClientConfigBuilder()
-        .clientName("master-client").build();
+        .serverDefaultProtocol().clientName("master-client").build();
 
     DefaultJedisClientConfig sentinelConfig = sentinelTlsEndpoint.getClientConfigBuilder()
-        .sslOptions(sslOptions).hostAndPortMapper(SENTINEL_SSL_PORT_MAPPER).build();
+        .serverDefaultProtocol().sslOptions(sslOptions).hostAndPortMapper(SENTINEL_SSL_PORT_MAPPER)
+        .build();
 
     try (JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels, masterConfig,
         sentinelConfig)) {
@@ -86,7 +87,7 @@ public class SSLOptionsJedisSentinelPoolIT extends RedisSentinelTlsTestBase {
   @Test
   public void sentinelWithSslConnectsToRedisWithSsl() {
     DefaultJedisClientConfig masterConfig = aclTlsEndpoint.getClientConfigBuilder()
-        .clientName("master-client").sslOptions(sslOptions)
+        .serverDefaultProtocol().clientName("master-client").sslOptions(sslOptions)
         .hostAndPortMapper(PRIMARY_SSL_PORT_MAPPER).build();
 
     DefaultJedisClientConfig sentinelConfig = createSentinelConfigWithSsl(sslOptions);


### PR DESCRIPTION
## Summary

Since RESP3 became the default protocol (#4468), the legacy `Jedis` client logs a warning whenever it is constructed with a `JedisClientConfig` that neither sets an explicit protocol nor opts out of auto-negotiation:

> `WARN redis.clients.jedis.Jedis - Jedis does not support RESP3 protocol auto-negotiation. Auto-negotiation will be disabled and the connection will assume RESP2. ...`

A CI test-run log contained **773** of these warnings across ~26 test classes (`SentinelAllKindOfValuesCommandsIT`, `SentineledConnectionProviderTest`, `ClientCommandsTest`, `MigrateTest`, `TransactionCommandsTest`, TLS suites, etc.). This PR removes all of them.

## Changes

### Tests
- Add `.serverDefaultProtocol()` to test client configs passed to legacy `Jedis`, `JedisPool`, `JedisFactory`, `JedisSentinelPool` (both master and sentinel configs), and to `sentinelClientConfig` of `RedisSentinelClient` / `SentineledConnectionProvider` — following the pattern already established in #4468 for other tests.
- Replace legacy timeout/ssl convenience constructors (e.g. `new Jedis(host, port, 500)`, `new Jedis(host, port, true)`) with the equivalent explicit-config constructors, since the internally-built configs always trigger the warning.
- Override `isAutoNegotiateProtocol()` to `false` in tests that exercise raw `JedisClientConfig` interface implementations.

### Production (one small fix)
- `SentinelClientBuilder`: the default `sentinelClientConfig` is now built with `.serverDefaultProtocol()`. Sentinel connections use the legacy `Jedis` client internally, so every `RedisSentinelClient` user who didn't explicitly configure sentinel connections was getting a spurious warning they did nothing to cause. No behavior change — auto-negotiation was already force-disabled by `Jedis` for these connections; this only stops the warning.

## Testing

- `mvn test-compile` passes (JDK 8), formatter validation passes.
- Ran the affected non-TLS test classes locally against the Docker test env: 595 tests, **0 RESP3 auto-negotiation warnings** in the output (previously dozens per class). Remaining local errors were unrelated environment gaps (sentinel/TLS endpoints not available locally); TLS suites are covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only churn plus a default-config tweak that matches existing runtime sanitization; no protocol or auth behavior change.
> 
> **Overview**
> Stops noisy **RESP3 auto-negotiation** warnings from legacy `Jedis` when configs leave protocol unset but auto-negotiation enabled (behavior unchanged; `Jedis` still forces RESP2).
> 
> **Production:** `SentinelClientBuilder` now builds the default `sentinelClientConfig` with `.serverDefaultProtocol()` so `RedisSentinelClient` users who omit sentinel client config no longer get a spurious warning.
> 
> **Tests:** Broad updates add `.serverDefaultProtocol()` to `DefaultJedisClientConfig` / endpoint builders for `Jedis`, pools, factories, sentinel providers, and TLS suites; anonymous `JedisClientConfig` stubs override `isAutoNegotiateProtocol()` to `false`; legacy `new Jedis(host, port, timeout|ssl)` calls move to `HostAndPort` + explicit config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7feadbdd5ea99acc8bf4764a2cbb5c93f74d36d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->