### PR TITLE
Skip javadoc generation in integration test workflows

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -143,11 +143,12 @@ runs:
         export TEST_WORK_FOLDER=$REDIS_ENV_WORK_DIR
         echo $TEST_WORK_FOLDER
 
-        # Unit tests are run in a separate workflow (unit-tests.yml), skip them here
+        # Unit tests are run in a separate workflow (unit-tests.yml), skip them here.
+        # Javadoc generation is skipped to speed up test runs; it is validated in unit-tests.yml.
         if [ -z "$TESTS" ]; then
-          mvn -B -DskipUnitTests=true clean compile verify
+          mvn -B -DskipUnitTests=true -Dmaven.javadoc.skip=true clean compile verify
         else
-          mvn -B -DskipUnitTests=true -Dtest=$TESTS clean verify
+          mvn -B -DskipUnitTests=true -Dmaven.javadoc.skip=true -Dtest=$TESTS clean verify
         fi
       env:
         REDIS_ENV_WORK_DIR: ${{ steps.args.outputs.redis_env_work_dir }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,13 +47,12 @@ jobs:
       - name: Maven offline
         run: |
           mvn -q dependency:go-offline
-      - name: Build docs
-        run: |
-          mvn javadoc:jar
       - name: Run tests
         run: |
           export TEST_ENV_PROVIDER=oss-local
           make test-local
         env:
           JVM_OPTS: -Xmx3200m
+          # Skip javadoc generation to speed up test runs; it is validated in unit-tests.yml
+          MAVEN_OPTS: -Dmaven.javadoc.skip=true
           TERM: dumb


### PR DESCRIPTION
## Summary

Javadoc jars were being built on every integration test run, adding avoidable time to CI:

- `integration.yml` had an explicit "Build docs" step running `mvn javadoc:jar`.
- The `attach-javadoc` execution in `pom.xml` is bound to the `package` phase, so every `mvn clean verify` also rebuilt the javadoc jar — both in `integration.yml` (via `make test-local`) and in the `run-tests` composite action used by every matrix job of `test-on-docker.yml`.

## Changes

- **`.github/workflows/integration.yml`** — removed the "Build docs" step and set `MAVEN_OPTS: -Dmaven.javadoc.skip=true` on the test step (the property has to come in via the environment because `mvn` is invoked through `make`).
- **`.github/actions/run-tests/action.yml`** — added `-Dmaven.javadoc.skip=true` to both `mvn clean verify` invocations, covering all `test-on-docker.yml` matrix jobs.

No changes needed elsewhere: `spring-data-redis-integration.yml` already skips javadoc, `doctests.yml`/`benchmarks.yml` stop at the `test` phase, and `unit-tests.yml` intentionally keeps `mvn javadoc:jar` so javadoc build breakage is still caught in CI — once, in the cheap workflow, instead of in every integration job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow tuning with no application or runtime behavior changes; Javadoc validation remains in unit-tests.yml.
> 
> **Overview**
> **Speeds up integration CI** by not building Javadoc on every integration run. Javadoc is still built in `unit-tests.yml`, so doc breakage stays covered once in the cheaper workflow.
> 
> In **`integration.yml`**, the dedicated **Build docs** step (`mvn javadoc:jar`) is removed, and the test step sets **`MAVEN_OPTS: -Dmaven.javadoc.skip=true`** so `make test-local` skips Javadoc during `verify`/`package`.
> 
> In **`run-tests`** (used by Docker matrix jobs), both Maven invocations add **`-Dmaven.javadoc.skip=true`**, with comments noting validation happens in unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dda90c7337b622b9c7ca61c289218406a972411. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->