### PR TITLE
Fix cache instance divergence when custom ConnectionProvider is used with client builders

### DIFF
--- a/src/main/java/redis/clients/jedis/ConnectionFactory.java
+++ b/src/main/java/redis/clients/jedis/ConnectionFactory.java
@@ -152,6 +152,13 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
     }
   }
 
+  /**
+   * Returns the client-side {@link Cache} this factory uses when creating connections,
+   * or {@code null} if caching is not enabled.
+   *
+   * @return the cache instance, or {@code null}
+   * @since 8.0
+   */
   public Cache getCache() {
     return cache;
   }

--- a/src/main/java/redis/clients/jedis/ConnectionFactory.java
+++ b/src/main/java/redis/clients/jedis/ConnectionFactory.java
@@ -111,6 +111,7 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
   private final JedisClientConfig clientConfig;
   private Supplier<Connection> objectMaker;
   private Connection.Builder connectionBuilder;
+  private final Cache cache;
 
   private AuthXEventListener authXEventListener;
 
@@ -134,6 +135,7 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
   public ConnectionFactory(Builder builder) {
     this.clientConfig = builder.getClientConfig();
     this.connectionBuilder = builder.getConnectionBuilder();
+    this.cache = builder.getCache();
 
     initAuthXManager();
   }
@@ -148,6 +150,10 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
       this.authXEventListener = authXManager.getListener();
       authXManager.start();
     }
+  }
+
+  public Cache getCache() {
+    return cache;
   }
 
   private Connection build() {

--- a/src/main/java/redis/clients/jedis/builders/AbstractClientBuilder.java
+++ b/src/main/java/redis/clients/jedis/builders/AbstractClientBuilder.java
@@ -183,6 +183,14 @@ public abstract class AbstractClientBuilder<T extends AbstractClientBuilder<T, C
       this.connectionProvider = createDefaultConnectionProvider();
     }
 
+    // Sync cache from the provider when the builder was not explicitly given one.
+    // A custom ConnectionProvider may carry a Cache internally (e.g. a pre-built
+    // PooledConnectionProvider or MultiDbConnectionProvider); without this, the
+    // provider uses caching while UnifiedJedis.getCache() returns null.
+    if (this.cache == null) {
+      this.cache = this.connectionProvider.getCache();
+    }
+
     // Create default command executor if not set
     if (this.commandExecutor == null) {
       this.commandExecutor = createDefaultCommandExecutor();

--- a/src/main/java/redis/clients/jedis/mcf/MultiDbConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/mcf/MultiDbConnectionProvider.java
@@ -762,6 +762,11 @@ public class MultiDbConnectionProvider implements ConnectionProvider {
   }
 
   @Override
+  public Cache getCache() {
+    return cache;
+  }
+
+  @Override
   public Connection getConnection() {
     return activeDatabase.getConnection();
   }

--- a/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
@@ -26,21 +26,25 @@ import static redis.clients.jedis.RedisClusterClient.INIT_NO_ERROR_PROPERTY;
 public class ClusterConnectionProvider implements ConnectionProvider {
 
   protected final JedisClusterInfoCache cache;
+  private final Cache clientSideCache;
 
   public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig) {
     this.cache = new JedisClusterInfoCache(clientConfig, clusterNodes);
+    this.clientSideCache = null;
     initializeSlotsCache(clusterNodes, clientConfig);
   }
 
   @Experimental
   public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig, Cache clientSideCache) {
     this.cache = new JedisClusterInfoCache(clientConfig, clientSideCache, clusterNodes);
+    this.clientSideCache = clientSideCache;
     initializeSlotsCache(clusterNodes, clientConfig);
   }
 
   public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig,
       GenericObjectPoolConfig<Connection> poolConfig) {
     this.cache = new JedisClusterInfoCache(clientConfig, poolConfig, clusterNodes);
+    this.clientSideCache = null;
     initializeSlotsCache(clusterNodes, clientConfig);
   }
 
@@ -48,12 +52,14 @@ public class ClusterConnectionProvider implements ConnectionProvider {
   public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig, Cache clientSideCache,
       GenericObjectPoolConfig<Connection> poolConfig) {
     this.cache = new JedisClusterInfoCache(clientConfig, clientSideCache, poolConfig, clusterNodes);
+    this.clientSideCache = clientSideCache;
     initializeSlotsCache(clusterNodes, clientConfig);
   }
 
   public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig,
       GenericObjectPoolConfig<Connection> poolConfig, Duration topologyRefreshPeriod) {
     this.cache = new JedisClusterInfoCache(clientConfig, poolConfig, clusterNodes, topologyRefreshPeriod);
+    this.clientSideCache = null;
     initializeSlotsCache(clusterNodes, clientConfig);
   }
 
@@ -61,6 +67,7 @@ public class ClusterConnectionProvider implements ConnectionProvider {
   public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig, Cache clientSideCache,
       GenericObjectPoolConfig<Connection> poolConfig, Duration topologyRefreshPeriod) {
     this.cache = new JedisClusterInfoCache(clientConfig, clientSideCache, poolConfig, clusterNodes, topologyRefreshPeriod);
+    this.clientSideCache = clientSideCache;
     initializeSlotsCache(clusterNodes, clientConfig);
   }
 
@@ -97,6 +104,11 @@ public class ClusterConnectionProvider implements ConnectionProvider {
   @Override
   public void close() {
     cache.close();
+  }
+
+  @Override
+  public Cache getCache() {
+    return clientSideCache;
   }
 
   public void renewSlotCache() {

--- a/src/main/java/redis/clients/jedis/providers/ConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ConnectionProvider.java
@@ -4,12 +4,17 @@ import java.util.Collections;
 import java.util.Map;
 import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.Connection;
+import redis.clients.jedis.csc.Cache;
 
 public interface ConnectionProvider extends AutoCloseable {
 
   Connection getConnection();
 
   Connection getConnection(CommandArguments args);
+
+  default Cache getCache() {
+    return null;
+  }
 
   default Map<?, ?> getConnectionMap() {
     final Connection c = getConnection();

--- a/src/main/java/redis/clients/jedis/providers/ConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ConnectionProvider.java
@@ -12,6 +12,13 @@ public interface ConnectionProvider extends AutoCloseable {
 
   Connection getConnection(CommandArguments args);
 
+  /**
+   * Returns the client-side {@link Cache} used by this provider, or {@code null} if caching is not
+   * enabled.
+   *
+   * @return the cache instance, or {@code null}
+   * @since 8.0
+   */
   default Cache getCache() {
     return null;
   }

--- a/src/main/java/redis/clients/jedis/providers/PooledConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/PooledConnectionProvider.java
@@ -18,6 +18,7 @@ import redis.clients.jedis.util.Pool;
 public class PooledConnectionProvider implements ConnectionProvider {
 
   private final Pool<Connection> pool;
+  private final Cache cache;
   private Object connectionMapKey = "";
 
   public PooledConnectionProvider(HostAndPort hostAndPort) {
@@ -32,7 +33,7 @@ public class PooledConnectionProvider implements ConnectionProvider {
 
   @Experimental
   public PooledConnectionProvider(HostAndPort hostAndPort, JedisClientConfig clientConfig, Cache clientSideCache) {
-    this(new ConnectionPool(hostAndPort, clientConfig, clientSideCache));
+    this(new ConnectionPool(hostAndPort, clientConfig, clientSideCache), clientSideCache);
     this.connectionMapKey = hostAndPort;
   }
 
@@ -45,7 +46,7 @@ public class PooledConnectionProvider implements ConnectionProvider {
   @Experimental
   public PooledConnectionProvider(HostAndPort hostAndPort, JedisClientConfig clientConfig, Cache clientSideCache,
       GenericObjectPoolConfig<Connection> poolConfig) {
-    this(new ConnectionPool(hostAndPort, clientConfig, clientSideCache, poolConfig));
+    this(new ConnectionPool(hostAndPort, clientConfig, clientSideCache, poolConfig), clientSideCache);
     this.connectionMapKey = hostAndPort;
   }
 
@@ -61,12 +62,22 @@ public class PooledConnectionProvider implements ConnectionProvider {
   }
 
   private PooledConnectionProvider(Pool<Connection> pool) {
+    this(pool, null);
+  }
+
+  private PooledConnectionProvider(Pool<Connection> pool, Cache cache) {
     this.pool = pool;
+    this.cache = cache;
   }
 
   @Override
   public void close() {
     pool.close();
+  }
+
+  @Override
+  public Cache getCache() {
+    return cache;
   }
 
   public final Pool<Connection> getPool() {

--- a/src/main/java/redis/clients/jedis/providers/PooledConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/PooledConnectionProvider.java
@@ -51,14 +51,18 @@ public class PooledConnectionProvider implements ConnectionProvider {
   }
 
   public PooledConnectionProvider(PooledObjectFactory<Connection> factory) {
-    this(new ConnectionPool(factory));
+    this(new ConnectionPool(factory), getCacheOrNull(factory));
     this.connectionMapKey = factory;
   }
 
   public PooledConnectionProvider(PooledObjectFactory<Connection> factory,
       GenericObjectPoolConfig<Connection> poolConfig) {
-    this(new ConnectionPool(factory, poolConfig));
+    this(new ConnectionPool(factory, poolConfig), getCacheOrNull(factory));
     this.connectionMapKey = factory;
+  }
+
+  private static Cache getCacheOrNull(PooledObjectFactory<Connection> factory) {
+    return factory instanceof ConnectionFactory ? ((ConnectionFactory) factory).getCache() : null;
   }
 
   private PooledConnectionProvider(Pool<Connection> pool) {

--- a/src/main/java/redis/clients/jedis/providers/SentineledConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/SentineledConnectionProvider.java
@@ -169,6 +169,11 @@ public class SentineledConnectionProvider implements ConnectionProvider {
   }
 
   @Override
+  public Cache getCache() {
+    return clientSideCache;
+  }
+
+  @Override
   public Connection getConnection() {
     return pool.getResource();
   }

--- a/src/test/java/redis/clients/jedis/CustomProviderCacheTest.java
+++ b/src/test/java/redis/clients/jedis/CustomProviderCacheTest.java
@@ -1,0 +1,106 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.csc.Cache;
+import redis.clients.jedis.csc.CacheConfig;
+import redis.clients.jedis.csc.CacheFactory;
+import redis.clients.jedis.executors.CommandExecutor;
+import redis.clients.jedis.providers.ConnectionProvider;
+
+class CustomProviderCacheTest {
+
+  private CommandExecutor exec;
+
+  @BeforeEach
+  void setUp() {
+    exec = new CommandExecutor() {
+      @Override
+      public <T> T executeCommand(CommandObject<T> commandObject) {
+        return null;
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  @Test
+  void redisClientWithCustomProviderExposesCache() {
+    Cache cache = CacheFactory.getCache(CacheConfig.builder().build());
+
+    ConnectionProvider provider = new ConnectionProvider() {
+      @Override
+      public Connection getConnection() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Connection getConnection(CommandArguments args) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void close() {
+      }
+
+      @Override
+      public Cache getCache() {
+        return cache;
+      }
+    };
+
+    try (RedisClient client = RedisClient.builder()
+        .commandExecutor(exec)
+        .connectionProvider(provider)
+        .clientConfig(DefaultJedisClientConfig.builder().protocol(RedisProtocol.RESP3).build())
+        .build()) {
+
+      assertNotNull(client.getCache(), "Cache should not be null when provider carries one");
+      assertSame(cache, client.getCache(),
+          "getCache() should return the same Cache instance the provider holds");
+    }
+  }
+
+  @Test
+  void multiDbClientWithCustomProviderExposesCache() {
+    Cache cache = CacheFactory.getCache(CacheConfig.builder().build());
+
+    ConnectionProvider provider = new ConnectionProvider() {
+      @Override
+      public Connection getConnection() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Connection getConnection(CommandArguments args) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void close() {
+      }
+
+      @Override
+      public Cache getCache() {
+        return cache;
+      }
+    };
+
+    try (MultiDbClient client = MultiDbClient.builder()
+        .commandExecutor(exec)
+        .connectionProvider(provider)
+        .clientConfig(DefaultJedisClientConfig.builder().protocol(RedisProtocol.RESP3).build())
+        .build()) {
+
+      assertNotNull(client.getCache(), "Cache should not be null when provider carries one");
+      assertSame(cache, client.getCache(),
+          "getCache() should return the same Cache instance the provider holds");
+    }
+  }
+}

--- a/src/test/java/redis/clients/jedis/mcf/MultiDbCSCTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiDbCSCTest.java
@@ -54,6 +54,7 @@ public class MultiDbCSCTest {
     MultiDbConnectionProvider p = twoDbProvider(active, standby, true, cache);
     MultiDbClient client = MultiDbClient.builder().connectionProvider(p).build();
     try {
+      assertSame(cache, client.getCache(), "Cache should be exposed through getCache()");
       Database standbyDb = p.getDatabase(standby);
 
       client.set("foo", "bar");
@@ -84,6 +85,7 @@ public class MultiDbCSCTest {
     MultiDbClient client = MultiDbClient.builder().connectionProvider(p).build();
 
     try {
+      assertSame(cache, client.getCache(), "Cache should be exposed through getCache()");
       reset(cache);
       assertThrows(JedisConnectionException.class, () -> client.set("foo", "bar"));
 
@@ -105,6 +107,7 @@ public class MultiDbCSCTest {
     MultiDbConnectionProvider p = twoDbProvider(active, standby, false, cache);
     MultiDbClient client = MultiDbClient.builder().connectionProvider(p).build();
     try {
+      assertSame(cache, client.getCache(), "Cache should be exposed through getCache()");
       Database standbyDb = p.getDatabase(standby);
       client.set("foo", "bar");
 


### PR DESCRIPTION
Fixes #4588

## What was the issue

When a custom `ConnectionProvider` is passed to a client builder (e.g. `MultiDbClient.builder().connectionProvider(myProvider).build()` or `RedisClient.builder().connectionProvider(p).build()`), and that provider internally carries a `Cache`, `UnifiedJedis.getCache()` returns `null`. The connections use client-side caching, but the client API reports none — the cache instance diverges.

## Where was the issue

In `AbstractClientBuilder.build()`. The builder's `cache` field is only populated via `.cache()` / `.cacheConfig()`. When a custom provider is injected via `.connectionProvider(...)`, the builder skips `createDefaultConnectionProvider()` (which would have passed the builder's cache) and passes `this.cache` (still `null`) directly to the client constructor. Meanwhile, the custom provider — built externally with a cache — creates cache-enabled connections, creating a mismatch.

## How it was fixed

Three small, orthogonal changes:

1. **`ConnectionProvider` interface** — added `default Cache getCache()` returning `null` (safe for all existing implementations that don't use cache).

2. **Four provider implementations** — each now stores and exposes its cache via `@Override getCache()`:
   - `MultiDbConnectionProvider` — already had the field, just added the getter
   - `SentineledConnectionProvider` — already had the field, just added the getter
   - `PooledConnectionProvider` — now stores the cache (was previously passing it to the pool but discarding the reference)
   - `ClusterConnectionProvider` — now stores a separate `clientSideCache` field alongside the existing `JedisClusterInfoCache cache`

3. **`AbstractClientBuilder.build()`** — after the provider is finalised, if `this.cache` is still `null`, pull it from `connectionProvider.getCache()`. This bridges the gap: a custom provider's cache now reaches `UnifiedJedis`.

## Why this approach

- **Minimal diff** — one new interface method (with a safe default), one per-provider getter, five lines in the builder.
- **No API breakage** — `default` method means all existing `ConnectionProvider` implementations compile unchanged.
- **Reuses existing patterns** — `ConnectionProvider` already has `default` methods (`getConnectionMap`, `getPrimaryNodesConnectionMap`); this follows the same pattern. The builder already has type-specific knowledge of providers; the `getCache()` bridge is in that same spirit.
- **Covers the future** — any `ConnectionProvider` implementation that holds a cache can override `getCache()` and the builder will pick it up automatically.

## How to test locally

```bash
# Unit tests (no Redis needed):
mvn -Dtest=CustomProviderCacheTest test

# Integration tests (requires Docker):
make start version=8.6
mvn -Dtest=MultiDbCSCTest test
make stop

# Existing MultiDbCacheTest integration tests:
make start version=8.6
mvn -Dtest=MultiDbCacheTest test
make stop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API (default getCache()) and builder wiring only; no auth or connection semantics change beyond exposing the existing cache reference.
> 
> **Overview**
> Fixes **cache instance divergence** when clients are built with a **custom `ConnectionProvider`** that already enables client-side caching: connections use CSC, but **`getCache()` returned `null`**.
> 
> **`ConnectionProvider`** gains a default **`getCache()`** (null when unused). Built-in providers (**`PooledConnectionProvider`**, **`ClusterConnectionProvider`**, **`MultiDbConnectionProvider`**, **`SentineledConnectionProvider`**) override it; **`PooledConnectionProvider`** now keeps the cache reference (and can read it from **`ConnectionFactory`**). **`ConnectionFactory`** exposes **`getCache()`** for the cache wired at build time.
> 
> **`AbstractClientBuilder.build()`** copies **`connectionProvider.getCache()`** into the builder’s cache when no explicit **`.cache()`** / **`.cacheConfig()`** was set, so **`UnifiedJedis.getCache()`** matches the provider’s cache.
> 
> Adds **`CustomProviderCacheTest`** and asserts **`getCache()`** in **`MultiDbCSCTest`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc7b5c8c9f95281b6b1ae3a2f3279494d8cb25c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->