### PR TITLE
Fix sporadic doctest failures: stale keys and FT.AGGREGATE row-order assumptions

### DIFF
--- a/src/test/java/io/redis/examples/QueryAggExample.java
+++ b/src/test/java/io/redis/examples/QueryAggExample.java
@@ -32,6 +32,8 @@ public class QueryAggExample {
         //REMOVE_START
         // Clear any keys here before using them in tests.
         try { jedis.ftDropIndex("idx:bicycle"); } catch (JedisDataException j) {}
+        jedis.del("bicycle:0", "bicycle:1", "bicycle:2", "bicycle:3", "bicycle:4",
+            "bicycle:5", "bicycle:6", "bicycle:7", "bicycle:8", "bicycle:9");
         //REMOVE_END
 // HIDE_END
 

--- a/src/test/java/io/redis/examples/QueryAggExample.java
+++ b/src/test/java/io/redis/examples/QueryAggExample.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 // HIDE_START
 import java.util.List;
-import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 import redis.clients.jedis.RedisClient;
 import redis.clients.jedis.json.Path2;
@@ -19,7 +19,6 @@ import redis.clients.jedis.exceptions.JedisDataException;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 // HIDE_END
 
 // HIDE_START
@@ -322,35 +321,20 @@ public class QueryAggExample {
 
         // Tests for 'agg4' step.
         // REMOVE_START
+        // Neither the row order nor the order within the 'bicycles' lists is
+        // guaranteed, so sort both before comparing.
         assertEquals(3, rows4.size());
-
-        Row test4Row = rows4.get(0);
-        assertEquals("refurbished", test4Row.getString("condition"));
-
-        ArrayList<String> test4Bikes = (ArrayList<String>) test4Row.get("bicycles");
-        assertEquals(1, test4Bikes.size());
-        assertTrue(test4Bikes.contains("bicycle:9"));
-
-        test4Row = rows4.get(1);
-        assertEquals("used", test4Row.getString("condition"));
-        
-        test4Bikes = (ArrayList<String>) test4Row.get("bicycles");
-        assertEquals(4, test4Bikes.size());
-        assertTrue(test4Bikes.contains("bicycle:1"));
-        assertTrue(test4Bikes.contains("bicycle:2"));
-        assertTrue(test4Bikes.contains("bicycle:3"));
-        assertTrue(test4Bikes.contains("bicycle:4"));
-        
-        test4Row = rows4.get(2);
-        assertEquals("new", test4Row.getString("condition"));
-
-        test4Bikes = (ArrayList<String>) test4Row.get("bicycles");
-        assertEquals(5, test4Bikes.size());
-        assertTrue(test4Bikes.contains("bicycle:0"));
-        assertTrue(test4Bikes.contains("bicycle:5"));
-        assertTrue(test4Bikes.contains("bicycle:6"));
-        assertTrue(test4Bikes.contains("bicycle:7"));
-        assertTrue(test4Bikes.contains("bicycle:8"));
+        assertArrayEquals(
+            new String[] {
+                "new=[bicycle:0, bicycle:5, bicycle:6, bicycle:7, bicycle:8]",
+                "refurbished=[bicycle:9]",
+                "used=[bicycle:1, bicycle:2, bicycle:3, bicycle:4]"
+            },
+            rows4.stream()
+                    .map(r -> r.getString("condition") + "="
+                        + ((List<String>) r.get("bicycles")).stream().sorted().collect(Collectors.toList()))
+                    .sorted().toArray()
+        );
         // REMOVE_END
 
 // HIDE_START

--- a/src/test/java/io/redis/examples/QueryEmExample.java
+++ b/src/test/java/io/redis/examples/QueryEmExample.java
@@ -27,6 +27,8 @@ public class QueryEmExample {
         // Clear any keys here before using them in tests.
         try {jedis.ftDropIndex("idx:bicycle");} catch (JedisDataException j){}
         try {jedis.ftDropIndex("idx:email");} catch (JedisDataException j){}
+        jedis.del("bicycle:0", "bicycle:1", "bicycle:2", "bicycle:3", "bicycle:4",
+            "bicycle:5", "bicycle:6", "bicycle:7", "bicycle:8", "bicycle:9", "key:1");
         //REMOVE_END
 
         SchemaField[] schema = {

--- a/src/test/java/io/redis/examples/QueryFtExample.java
+++ b/src/test/java/io/redis/examples/QueryFtExample.java
@@ -25,6 +25,8 @@ public class QueryFtExample {
         //REMOVE_START
         // Clear any keys here before using them in tests.
         try {jedis.ftDropIndex("idx:bicycle");} catch (JedisDataException j){}
+        jedis.del("bicycle:0", "bicycle:1", "bicycle:2", "bicycle:3", "bicycle:4",
+            "bicycle:5", "bicycle:6", "bicycle:7", "bicycle:8", "bicycle:9");
         //REMOVE_END
 // HIDE_END
 

--- a/src/test/java/io/redis/examples/QueryGeoExample.java
+++ b/src/test/java/io/redis/examples/QueryGeoExample.java
@@ -30,6 +30,8 @@ public class QueryGeoExample {
         //REMOVE_START
         // Clear any keys here before using them in tests.
         try { jedis.ftDropIndex("idx:bicycle"); } catch (JedisDataException j) {}
+        jedis.del("bicycle:0", "bicycle:1", "bicycle:2", "bicycle:3", "bicycle:4",
+            "bicycle:5", "bicycle:6", "bicycle:7", "bicycle:8", "bicycle:9");
         //REMOVE_END
 // HIDE_END
 

--- a/src/test/java/io/redis/examples/QueryRangeExample.java
+++ b/src/test/java/io/redis/examples/QueryRangeExample.java
@@ -32,6 +32,8 @@ public class QueryRangeExample {
         //REMOVE_START
         // Clear any keys here before using them in tests.
         try { jedis.ftDropIndex("idx:bicycle"); } catch (JedisDataException j) {}
+        jedis.del("bicycle:0", "bicycle:1", "bicycle:2", "bicycle:3", "bicycle:4",
+            "bicycle:5", "bicycle:6", "bicycle:7", "bicycle:8", "bicycle:9");
         //REMOVE_END
         
         SchemaField[] schema = {

--- a/src/test/java/io/redis/examples/SearchQuickstartExample.java
+++ b/src/test/java/io/redis/examples/SearchQuickstartExample.java
@@ -44,6 +44,8 @@ public class SearchQuickstartExample {
     } catch (JedisDataException e) {
       System.out.println("Can't connect to Redis: " + e.getMessage());
     }
+    jedis.del("bicycle:0", "bicycle:1", "bicycle:2", "bicycle:3", "bicycle:4",
+        "bicycle:5", "bicycle:6", "bicycle:7", "bicycle:8", "bicycle:9");
     // REMOVE_END
 
     // STEP_START create_index


### PR DESCRIPTION
## What
Fixes sporadic `doctests` CI failures in the search examples.

## Why
`FT.AGGREGATE ... GROUPBY` row order varies per Redis process. `QueryAggExample` asserts the rows positionally, so every CI run is a coin flip (e.g. [failing run](https://github.com/redis/jedis/actions/runs/30607720027/job/91086346593) vs [passing run](https://github.com/redis/jedis/actions/runs/30614378615/job/91104080166) on the same image digest).

Additionally, the search examples drop `idx:bicycle` but leave the `bicycle:0..9` documents behind, so `FT.CREATE`'s background scan indexes stale documents and the index build order depends on which examples ran earlier.

## Changes
- `QueryAggExample`: compare sorted group/member representations in the `agg4` assertions instead of assuming row order; element order within the `TOLIST` reducer result is not guaranteed either
- Clear leftover keys before index creation in `QueryAggExample`, `QueryEmExample`, `QueryFtExample`, `QueryGeoExample`, `QueryRangeExample`, `SearchQuickstartExample` (test-only `REMOVE_START` blocks; published docs unaffected)

Verified locally against 8.10.0 with a fresh Redis process per run: 5/5 passes across 4 distinct server-side group orderings, plus full-suite runs (37 tests) on 8.8.1 and 8.10.0 with a dirty DB carried between passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only harness changes in example classes; no library or public API behavior changes.
> 
> **Overview**
> Stabilizes sporadic **doctests** CI failures in the Redis search example tests after Redis **8.10** made **`FT.AGGREGATE` `GROUPBY`** row order (and **`TOLIST`** member order) non-deterministic.
> 
> In **`QueryAggExample`**, the **`agg4`** assertions no longer assume fixed row/index positions; they build sorted `condition=bicycles` strings and compare with **`assertArrayEquals`**. Test-only setup now **`DEL`s** `bicycle:0`–`bicycle:9` before **`FT.CREATE`**, not only **`FT.DROPINDEX`**, so leftover JSON keys from other examples are not re-indexed during background scans.
> 
> The same **`jedis.del(...)`** cleanup is added in **`QueryEmExample`** (plus **`key:1`**), **`QueryFtExample`**, **`QueryGeoExample`**, **`QueryRangeExample`**, and **`SearchQuickstartExample`** inside **`REMOVE_START`** blocks (published doc snippets unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a846c4e88d4d8f4002272daf4316554b102234d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->