### PR TITLE
[maintenance  events]Proposal for early retirement of connections

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -172,7 +172,7 @@ public class Connection implements Closeable {
   private Set<InitVisitor> initVisitors = new HashSet<>();
 
   /** One-way advisory flag: this connection must leave pool service. See {@link #retire()}. */
-  private volatile boolean retired;
+  private volatile long retiredAtNanos = 0;
 
   /** Listeners notified synchronously of this connection's maintenance events (pool-injected). */
   private final Set<MaintenanceEventListener> maintenanceEventListeners = ConcurrentHashMap
@@ -1073,13 +1073,13 @@ public class Connection implements Closeable {
    * Retires this connection from pool service. Advisory and one-way: no I/O happens here; the pool
    * destroys a retired connection on return, validation, or eviction instead of reusing it.
    */
-  void retire() {
-    this.retired = true;
+  void retireAt(long nanos) {
+    this.retiredAtNanos = nanos;
   }
 
   /** Whether this connection was {@link #retire() retired} and must not be reused. */
   boolean isRetired() {
-    return retired;
+    return retiredAtNanos != 0 && this.retiredAtNanos <= NanoClock.INSTANCE.getAsLong();
   }
 
   ChainedTimeoutSource getTimeoutSource() {

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -171,8 +171,10 @@ public class Connection implements Closeable {
   private boolean isBlocking = false;
   private Set<InitVisitor> initVisitors = new HashSet<>();
 
-  /** One-way advisory flag: this connection must leave pool service. See {@link #retire()}. */
-  private volatile long retiredAtNanos = 0;
+  private static final long NOT_RETIRED = 0;
+
+  /** Instant this connection must leave pool service. See {@link #retireAt}. */
+  private volatile long retiredAtNanos = NOT_RETIRED;
 
   /** Listeners notified synchronously of this connection's maintenance events (pool-injected). */
   private final Set<MaintenanceEventListener> maintenanceEventListeners = ConcurrentHashMap
@@ -1070,16 +1072,18 @@ public class Connection implements Closeable {
   }
 
   /**
-   * Retires this connection from pool service. Advisory and one-way: no I/O happens here; the pool
-   * destroys a retired connection on return, validation, or eviction instead of reusing it.
+   * Retires this connection from pool service at the given instant. Advisory: no I/O happens here;
+   * once the deadline passes, the pool destroys the connection on return, validation, or eviction
+   * instead of reusing it.
    */
   void retireAt(long nanos) {
     this.retiredAtNanos = nanos;
   }
 
-  /** Whether this connection was {@link #retire() retired} and must not be reused. */
+  /** Whether this connection's {@link #retireAt} deadline has passed and it must not be reused. */
   boolean isRetired() {
-    return retiredAtNanos != 0 && this.retiredAtNanos <= NanoClock.INSTANCE.getAsLong();
+    long at = retiredAtNanos;
+    return at != NOT_RETIRED && NanoClock.INSTANCE.getAsLong() - at >= 0;
   }
 
   ChainedTimeoutSource getTimeoutSource() {

--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -151,12 +151,20 @@ final class MaintenanceEventController
     }
     MovingOperation applied = movingOperations.process(e, affectedPeer);
     if (applied == null) {
-      // Re-delivery from an already-known source.
+      long retireAt = getRetirementFor(affectedPeer);
+      if (retireAt > NanoClock.INSTANCE.getAsLong()) {
+        c.retireAt(retireAt);
+      }
       return;
     }
     logger.debug("Applied MOVING {} -> {} (seq={}, ttl={}s, sources={})", affectedPeer, e.target,
       e.seq, e.ttlSeconds, applied.affected.size());
     handleRebind(applied);
+  }
+
+  private long getRetirementFor(SocketAddress peer) {
+    MovingOperation op = movingOperations.findActive(o -> o.affected.contains(peer));
+    return op == null ? 0 : op.reconnectAtNanos;
   }
 
   /**
@@ -166,12 +174,14 @@ final class MaintenanceEventController
    */
   private void handleRebind(MovingOperation snapshot) {
     if (snapshot.endpoint != null) {
-      retireAffected(snapshot); // real target: reconnect immediately
+      retireAffected(snapshot, NanoClock.INSTANCE.getAsLong()); // real target: reconnect
+                                                                // immediately
+      handoffHook.run();
       return;
     }
     long delayNanos = snapshot.reconnectAtNanos - NanoClock.INSTANCE.getAsLong();
     try {
-      scheduler().schedule(() -> retireAffected(snapshot), delayNanos, TimeUnit.NANOSECONDS);
+      scheduler().schedule(handoffHook::run, delayNanos, TimeUnit.NANOSECONDS);
     } catch (RejectedExecutionException alreadyClosed) {
       // Controller closed concurrently;
     }
@@ -182,16 +192,12 @@ final class MaintenanceEventController
    * runs the handoff hook. No I/O happens here — the pool destroys retired connections; retiring is
    * idempotent, so overlapping passes are harmless.
    */
-  private void retireAffected(MovingOperation snapshot) {
-    if (!snapshot.isValid()) {
-      return; // operation expired; the address may be legitimately live again
-    }
+  private void retireAffected(MovingOperation snapshot, long retireAtNanos) {
     registry.forEachLive(conn -> {
       if (snapshot.affected.contains(conn.getRemoteSocketAddress())) {
-        conn.retire();
+        conn.retireAt(retireAtNanos);
       }
     });
-    handoffHook.run();
   }
 
   ConnectionRegistry registry() {

--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -173,15 +173,26 @@ final class MaintenanceEventController
    * A pending pass is never cancelled; a stale fire is a no-op once its operation expires.
    */
   private void handleRebind(MovingOperation snapshot) {
-    long retireAtNanos = NanoClock.INSTANCE.getAsLong(); // real target: retire immediately
-    long delayNanos = 0;
+    final long retireAtNanos;
+    final long delayNanos;
     if (snapshot.endpoint == null) {
       retireAtNanos = snapshot.reconnectAtNanos; // 'none': reconnect at half the grace window
       delayNanos = retireAtNanos - NanoClock.INSTANCE.getAsLong();
+    } else {
+      retireAtNanos = NanoClock.INSTANCE.getAsLong(); // real target: retire immediately
+      delayNanos = 0;
     }
     retireAffected(snapshot, retireAtNanos);
     try {
-      scheduler().schedule(handoffHook::run, delayNanos, TimeUnit.NANOSECONDS);
+      scheduler().schedule(() -> {
+        if (snapshot.isValid()) {
+          // second walk: stamps connections registered after the apply-time walk; never stamps
+          // past the window, when the address may be legitimately live again
+          retireAffected(snapshot, retireAtNanos);
+        }
+        // always run the hook, however late: stamped idles are dead sockets by then
+        handoffHook.run();
+      }, delayNanos, TimeUnit.NANOSECONDS);
     } catch (RejectedExecutionException alreadyClosed) {
       // Controller closed concurrently;
     }

--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -173,13 +173,13 @@ final class MaintenanceEventController
    * A pending pass is never cancelled; a stale fire is a no-op once its operation expires.
    */
   private void handleRebind(MovingOperation snapshot) {
-    if (snapshot.endpoint != null) {
-      retireAffected(snapshot, NanoClock.INSTANCE.getAsLong()); // real target: reconnect
-                                                                // immediately
-      handoffHook.run();
-      return;
+    long retireAtNanos = NanoClock.INSTANCE.getAsLong(); // real target: retire immediately
+    long delayNanos = 0;
+    if (snapshot.endpoint == null) {
+      retireAtNanos = snapshot.reconnectAtNanos; // 'none': reconnect at half the grace window
+      delayNanos = retireAtNanos - NanoClock.INSTANCE.getAsLong();
     }
-    long delayNanos = snapshot.reconnectAtNanos - NanoClock.INSTANCE.getAsLong();
+    retireAffected(snapshot, retireAtNanos);
     try {
       scheduler().schedule(handoffHook::run, delayNanos, TimeUnit.NANOSECONDS);
     } catch (RejectedExecutionException alreadyClosed) {

--- a/src/test/java/redis/clients/jedis/MaintenanceEventControllerTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceEventControllerTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import static org.awaitility.Awaitility.await;
+
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -144,7 +146,8 @@ public class MaintenanceEventControllerTest {
 
     // First MOVING from `receiver` (connected to 127.0.0.1 in setUp()).
     moving(1L, TARGET_B, 100);
-    assertEquals(1, fires.get(), "hook fires on new seq");
+    await().atMost(Duration.ofSeconds(1)).until(() -> fires.get() == 1); // the hook runs on the
+                                                                         // scheduler
     assertEquals(TARGET_B_ADDR, controller.getSocketAddress(receiverPeer));
 
     // Dual-stack receiver: connect the SAME mock server via the IPv6 loopback. The mock binds the
@@ -163,12 +166,13 @@ public class MaintenanceEventControllerTest {
         "original IPv4 peer still remaps");
       assertEquals(TARGET_B_ADDR, controller.getSocketAddress(ipv6Peer),
         "merged IPv6 peer also remaps to same target");
-      assertEquals(2, fires.get(), "hook fires again on same-seq merge");
+      await().atMost(Duration.ofSeconds(1)).until(() -> fires.get() == 2); // merge fires again
 
       // Idempotent: re-delivering the same MOVING to the same connection is a no-op (source
       // already in the affected set; no state change → no hook fire).
       controller.onMoving(new MovingEvent(1L, 100, TARGET_B), ipv6Receiver);
-      assertEquals(2, fires.get(), "no fire on duplicate merge of an already-present source");
+      await().during(Duration.ofMillis(100)).atMost(Duration.ofMillis(500))
+          .until(() -> fires.get() == 2); // duplicate merge of a known source never fires
     } finally {
       ipv6Receiver.close();
     }
@@ -266,6 +270,8 @@ public class MaintenanceEventControllerTest {
     moving(6L, TARGET_C, 100); // distinct key (other seq): fire
     moving(6L, TARGET_C, 100); // known key, known peer: no fire
 
+    // The hook runs on the controller's scheduler; each applied event fires it once.
+    await().atMost(Duration.ofSeconds(1)).until(() -> fires.get() == 3);
     assertEquals(3, fires.get());
   }
 

--- a/src/test/java/redis/clients/jedis/MaintenanceMarkingTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceMarkingTest.java
@@ -211,7 +211,7 @@ public class MaintenanceMarkingTest {
   }
 
   @Test
-  public void expiredOperationPassIsNoop() throws Exception {
+  public void expiredOperationPassRunsHookButStampsNothing() throws Exception {
     AtomicLong now = new AtomicLong(0);
     NanoClock.INSTANCE = now::get;
     try {
@@ -224,12 +224,13 @@ public class MaintenanceMarkingTest {
       now.addAndGet(TimeUnit.SECONDS.toNanos(11)); // past the ttl: operation expired
 
       // The server has dropped the affected connections by the window end; a pass firing late
-      // must not mark connections that landed on the same peer afterwards.
+      // must not mark connections that landed on the same peer afterwards — but it still runs
+      // the handoff hook once, so already-stamped idles (dead sockets by now) are evicted.
       Connection fresh = connect(mockServer);
       try {
         stalePass.run();
         assertFalse(fresh.isRetired(), "expired operation's pass marks nothing");
-        assertEquals(0, notified.get(), "expired operation's pass notifies nothing");
+        assertEquals(1, notified.get(), "the hook still runs, however late");
       } finally {
         fresh.close();
       }

--- a/src/test/java/redis/clients/jedis/MaintenanceMarkingTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceMarkingTest.java
@@ -59,6 +59,17 @@ public class MaintenanceMarkingTest {
     controller.close();
     mockServer.stop();
     otherServer.stop();
+    NanoClock.INSTANCE = System::nanoTime;
+  }
+
+  /**
+   * Deterministic clock; retirement deadlines are computed against it. Starts at 1, not 0: a
+   * retireAt(0) stamp would collide with the field's 0 = not-retired sentinel.
+   */
+  private AtomicLong installTestClock() {
+    AtomicLong now = new AtomicLong(1);
+    NanoClock.INSTANCE = now::get;
+    return now;
   }
 
   private Connection connect(TcpMockServer server) throws Exception {
@@ -79,43 +90,48 @@ public class MaintenanceMarkingTest {
   // --- marking scheduling and coverage ---
 
   @Test
-  public void noneSchedulesMarkingAtHalfGrace() {
+  public void noneRetiresAtHalfGrace() {
+    AtomicLong now = installTestClock();
     AtomicInteger notified = new AtomicInteger();
     controller.setHandoffHook(notified::incrementAndGet);
 
     movingNone(1L, 10);
 
-    assertFalse(scheduler.pending.isEmpty(), "'none' schedules the marking pass");
-    assertTrue(scheduler.lastDelayNanos > TimeUnit.SECONDS.toNanos(4)
-        && scheduler.lastDelayNanos <= TimeUnit.SECONDS.toNanos(5),
-      "at half the raw grace");
-    assertFalse(receiver.isRetired(), "nothing is marked before the pass runs");
+    assertFalse(scheduler.pending.isEmpty(), "'none' schedules the pass");
+    assertEquals(TimeUnit.SECONDS.toNanos(5), scheduler.lastDelayNanos, "at half the raw grace");
+    assertFalse(receiver.isRetired(), "stamped for the reconnect instant; not retired yet");
     assertEquals(0, notified.get());
 
-    scheduler.runPending();
+    now.addAndGet(TimeUnit.SECONDS.toNanos(5));
+    assertTrue(receiver.isRetired(),
+      "retirement flips at the reconnect instant, independent of the scheduler");
 
-    assertTrue(receiver.isRetired(), "the pass marks the affected source's connection");
-    assertEquals(1, notified.get(), "the pass runs the handoff hooks");
+    scheduler.runPending();
+    assertEquals(1, notified.get(), "the scheduled pass runs the hook");
   }
 
   @Test
-  public void targetMarksInline() {
+  public void targetRetiresImmediately() {
     AtomicInteger notified = new AtomicInteger();
     controller.setHandoffHook(notified::incrementAndGet);
 
     moving(1L, TARGET_B, 30);
 
-    assertEquals(0, scheduler.scheduleCount, "a real target never schedules");
-    assertTrue(receiver.isRetired(), "marked synchronously on the notifying thread");
+    assertTrue(receiver.isRetired(), "stamped for immediate retirement on the notifying thread");
+    assertEquals(1, scheduler.scheduleCount, "the hook runs off the notifying thread");
+    assertEquals(0, notified.get());
+
+    scheduler.runPending();
     assertEquals(1, notified.get());
   }
 
   @Test
   public void markingCoversOnlyAffectedPeers() throws Exception {
+    AtomicLong now = installTestClock();
     Connection unrelated = connect(otherServer);
     try {
       movingNone(1L, 10);
-      scheduler.runPending();
+      now.addAndGet(TimeUnit.SECONDS.toNanos(5));
 
       assertTrue(receiver.isRetired());
       assertFalse(unrelated.isRetired(), "different peer is out of scope");
@@ -148,20 +164,21 @@ public class MaintenanceMarkingTest {
 
   @Test
   public void pendingMarkingCoversSourcesMergedBeforeDue() throws Exception {
-    movingNone(1L, 10); // marking pending at +5s, sources = {receiver's peer}
+    AtomicLong now = installTestClock();
+    movingNone(1L, 10); // retirement stamped for +5s, sources = {receiver's peer}
 
     // A second source joins the same epoch BEFORE the reconnect instant: nothing may be marked
     // early — its own scheduled pass fires at that instant and covers it.
     Connection otherSource = connect(otherServer);
     try {
       controller.onMoving(new MovingEvent(1L, 10, null), otherSource);
-      assertFalse(receiver.isRetired(), "no early marking on merge");
-      assertFalse(otherSource.isRetired(), "no early marking on merge");
+      assertFalse(receiver.isRetired(), "no early retirement on merge");
+      assertFalse(otherSource.isRetired(), "no early retirement on merge");
 
-      scheduler.runPending();
+      now.addAndGet(TimeUnit.SECONDS.toNanos(5));
 
       assertTrue(receiver.isRetired());
-      assertTrue(otherSource.isRetired(), "merged source covered by its scheduled pass");
+      assertTrue(otherSource.isRetired(), "merged source stamped for the same reconnect instant");
     } finally {
       otherSource.close();
     }
@@ -185,26 +202,30 @@ public class MaintenanceMarkingTest {
   // --- overlapping events and stale fires ---
 
   @Test
-  public void pendingNonePassSurvivesNewerEvent() throws Exception {
+  public void pendingNoneRetirementSurvivesNewerEvent() throws Exception {
+    AtomicLong now = installTestClock();
     AtomicInteger notified = new AtomicInteger();
     controller.setHandoffHook(notified::incrementAndGet);
 
-    movingNone(1L, 10); // pass pending at +5s
+    movingNone(1L, 10); // retirement stamped for +5s; pass pending
     Runnable pendingPass = scheduler.pending.poll();
 
-    // An overlapping newer event on another peer marks inline; the earlier unexpired event is NOT
-    // orphaned — its pending pass still covers its own affected set.
+    // An overlapping newer 'none' event on another peer gets its own, later deadline; the earlier
+    // unexpired event is NOT orphaned — its deadline stands and its pending pass still runs.
     Connection otherSource = connect(otherServer);
     try {
-      controller.onMoving(new MovingEvent(2L, 30, TARGET_B), otherSource);
-      assertTrue(otherSource.isRetired(), "newer event marked inline");
-      assertEquals(1, notified.get());
-      assertFalse(receiver.isRetired(), "earlier 'none' event never marks early");
+      controller.onMoving(new MovingEvent(2L, 30, null), otherSource); // stamped for +15s
+      assertFalse(receiver.isRetired(), "earlier 'none' event never retires early");
+      assertFalse(otherSource.isRetired(), "newer event has its own, later deadline");
 
-      pendingPass.run();
+      now.addAndGet(TimeUnit.SECONDS.toNanos(5));
       assertTrue(receiver.isRetired(),
-        "the pending pass of a still-active event runs despite the newer event");
-      assertEquals(2, notified.get(), "the pending pass fires the hook");
+        "the earlier event's deadline stands despite the newer event");
+      assertFalse(otherSource.isRetired(), "newer event's deadline has not passed");
+
+      pendingPass.run(); // earlier event's pass
+      scheduler.runPending(); // newer event's pass
+      assertEquals(2, notified.get(), "each event's pass runs the hook");
     } finally {
       otherSource.close();
     }

--- a/src/test/java/redis/clients/jedis/sch/AbstractRebindBehaviorTest.java
+++ b/src/test/java/redis/clients/jedis/sch/AbstractRebindBehaviorTest.java
@@ -173,9 +173,11 @@ public abstract class AbstractRebindBehaviorTest {
 
       mockServer1.sendPushMessageToAll("MOVING", 30, 60, "localhost:" + mockServer2.getPort());
 
-      // Command on the active connection triggers the rebind; idle connections are evicted.
+      // Command on the active connection triggers the rebind; the handoff hook (pool eviction)
+      // runs off the notifying thread, so the idle connection disappears asynchronously.
       assertTrue(activeConnection.ping());
-      assertEquals(0, pool.getNumIdle());
+      await().atMost(Duration.ofSeconds(1)).pollInterval(Duration.ofMillis(20))
+          .until(() -> pool.getNumIdle() == 0);
       assertEquals(1, pool.getNumActive());
 
       await().atMost(Duration.ofSeconds(1)).pollInterval(Duration.ofMillis(20))


### PR DESCRIPTION
## Summary
Replaces the boolean `retired` flag on `Connection` with a `retiredAtNanos` deadline. Connections affected by a MOVING event are now tagged immediately with the instant they must leave pool service — right away for a real endpoint, at the reconnect instant for a null-endpoint ('none') MOVING — instead of being marked later by a delayed scheduler pass.

## Key Decisions & Assumptions
- `isRetired()` is now time-based: true once the tagged deadline has passed (per `NanoClock`). Tagging with the current time preserves the old immediate-retire behavior.
- The scheduled task for 'none' MOVING now only fires the handoff hook; retirement itself no longer depends on the timer firing or on the operation still being valid at fire time, so the `isValid()` guard in `retireAffected` was dropped.
- On re-delivery of an already-known MOVING, the delivering connection is tagged with the active operation's retirement deadline — closing the gap where connections that learn of the event late (e.g. created after the first delivery) were never retired.

## Behavioral / Conceptual Changes
- Affected connections carry their retirement deadline from the moment the MOVING event is applied, rather than being retired by a later scheduled sweep.
- Re-delivered MOVING events now retire the receiving connection instead of being ignored entirely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection pool lifecycle and maintenance MOVING timing; behavior changes for 'none' MOVING grace windows and late-joining connections, though tests cover the new semantics.
> 
> **Overview**
> **MOVING handling** now tags pooled connections with a **retirement instant** instead of flipping a one-way `retired` flag when a delayed sweep runs.
> 
> On `Connection`, `retire()` becomes **`retireAt(nanos)`** and **`isRetired()`** is true only after `NanoClock` passes that deadline (immediate retire = stamp “now”). In **`MaintenanceEventController`**, affected peers get that deadline as soon as the event is applied—**now** for a real MOVING target, **`reconnectAtNanos`** (half grace) for null-target `'none'` MOVING. The scheduled task still does a **second registry walk** for late-registered connections when the operation is still valid, but **always runs the handoff hook** (including after expiry) so pool eviction can drain already-stamped idles. **Re-delivered** MOVING on a known operation now **`retireAt`s** the delivering connection with the active operation’s deadline instead of ignoring it.
> 
> Tests use deterministic clocks, **Awaitility** for scheduler-driven hooks, and updated expectations for time-based retirement vs. marking-only-on-timer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbadb18e0a56a28527c9f194756153bf625b77df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->