### PR TITLE
Add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ We'd love your contributions!
 
 Bug reports are always welcome! [You can open a bug report on GitHub](https://github.com/redis/jedis/issues/new).
 
+To report a security vulnerability, please follow our [Security Policy](https://github.com/redis/jedis/blob/master/SECURITY.md).
+
 You can also contribute documentation -- or anything to improve Jedis. Please see
 [contribution guideline](https://github.com/redis/jedis/blob/master/.github/CONTRIBUTING.md) for more details.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability, to ensure proper review and assessment, we kindly ask
+vulnerability reports be submitted through the
+[Redis Vulnerability Disclosure Program](https://redis.io/redis-responsible-vulnerability-disclosure/).
+Alternatively reach out via email to security@redis.com.


### PR DESCRIPTION
Adds a `SECURITY.md` directing vulnerability reports to the [Redis Vulnerability Disclosure Program](https://redis.io/redis-responsible-vulnerability-disclosure/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, auth, or dependency changes.
> 
> **Overview**
> Adds a **Security Policy** for the repo so security issues are routed separately from ordinary GitHub bug reports.
> 
> New `SECURITY.md` tells reporters to use the [Redis Vulnerability Disclosure Program](https://redis.io/redis-responsible-vulnerability-disclosure/) or email **security@redis.com**. The **Contributing** section in `README.md` now points security findings at that policy instead of the general issue tracker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5820e5b9a48da5c69dbfc5149af1afd0756a5f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->